### PR TITLE
投稿画面の体裁が崩れる問題を修正 (#2)

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -335,7 +335,20 @@ namespace XTimelineViewer
             };
 
             webView.Source = new Uri("https://x.com/compose/post");
-            await dlg.ShowAsync();
+
+            // WebView2 の Win32 HWND は XAML Popup より常に前面に描画されるため、
+            // ダイアログ表示中はタイムライン WebView2 を非表示にして Z-order 問題を回避する
+            foreach (var wv in _webViews)
+                wv.Visibility = Visibility.Collapsed;
+            try
+            {
+                await dlg.ShowAsync();
+            }
+            finally
+            {
+                foreach (var wv in _webViews)
+                    wv.Visibility = Visibility.Visible;
+            }
         }
 
         // ── Keyboard shortcuts ────────────────────────────────────────────────
@@ -621,6 +634,11 @@ namespace XTimelineViewer
                 _ = SaveTimelinesAsync();
                 dragging.Opacity = 1.0;
                 _draggingPane = null;
+
+                // 視覚ツリーへの再挿入後、WebView2 の Win32 HWND を再アンカーさせる
+                dragging.Visibility = Visibility.Collapsed;
+                dragging.UpdateLayout();
+                dragging.Visibility = Visibility.Visible;
             };
             pane.DragLeave += (s, args) => pane.Opacity = 1.0;
             headerGrid.DragStarting += (s, args) => pane.Opacity = 0.5;


### PR DESCRIPTION
## 概要

- ドラッグ＆ドロップでタイムラインを入れ替えた後、投稿ダイアログの体裁が崩れる問題を修正

## 原因

WebView2 の Win32 HWND は XAML の `ContentDialog`（Popup）より常に前面に描画される。  
ドラッグ＆ドロップ時に `TimelinePanel.Children.RemoveAt` → `Insert` でペインを視覚ツリーへ再挿入すると、HWND の位置がずれたまま残る。その状態で投稿ダイアログを開くと、タイムラインの WebView2 がダイアログに被さって「崩れて」見えていた。

## 修正内容

- **ドロップ完了後** に移動したペインを `Collapsed → UpdateLayout() → Visible` して HWND を再アンカー
- **`OpenPostDialogAsync`** で `dlg.ShowAsync()` の前後にタイムライン WebView2 を `Collapsed` にし、Z-order の衝突を回避

## テスト手順

1. タイムラインが 2 つ以上ある状態でドラッグ＆ドロップで順序を入れ替える
2. 投稿ボタンを押して投稿ダイアログを開く
3. 投稿画面が正常に表示されることを確認

Closes #2