### PR TITLE
設定ダイアログにバージョン情報と Issue 報告リンクを追加 (#10)

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -228,7 +228,7 @@ namespace XTimelineViewer
             {
                 edgeVersion = _webViewEnv?.BrowserVersionString ?? "不明";
             }
-            var versionInfoText = $"XTimelineViewer v{version}\n{edgeChannel} {edgeVersion}";
+            var versionInfoText = $"XTimelineViewer v{version}\r\n{edgeChannel} {edgeVersion}";
 
             // ヘルパー：左ラベル＋右コントロールの行を作る
             static Grid MakeRow(string label, FrameworkElement control, Thickness? margin = null)

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -266,16 +266,28 @@ namespace XTimelineViewer
                 FontWeight = Microsoft.UI.Text.FontWeights.SemiBold
             });
 
-            var versionInfoBox = new TextBox
+            var monoFont   = new FontFamily("Cascadia Mono, Consolas, Courier New");
+            var versionInfoBox = new StackPanel
             {
-                Text            = versionInfoText,
-                IsReadOnly      = true,
-                AcceptsReturn   = true,
-                FontFamily      = new FontFamily("Cascadia Mono, Consolas, Courier New"),
-                FontSize        = 11,
-                Margin          = new Thickness(0, 6, 0, 0),
-                BorderThickness = new Thickness(1),
-                CornerRadius    = new CornerRadius(4),
+                Margin  = new Thickness(0, 6, 0, 0),
+                Spacing = 2,
+                Children =
+                {
+                    new TextBlock
+                    {
+                        Text                   = $"XTimelineViewer v{version}",
+                        FontFamily             = monoFont,
+                        FontSize               = 11,
+                        IsTextSelectionEnabled = true,
+                    },
+                    new TextBlock
+                    {
+                        Text                   = $"{edgeChannel} {edgeVersion}",
+                        FontFamily             = monoFont,
+                        FontSize               = 11,
+                        IsTextSelectionEnabled = true,
+                    },
+                }
             };
 
             var copyBtn = new Button

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -217,6 +217,19 @@ namespace XTimelineViewer
             var version = System.Reflection.Assembly.GetExecutingAssembly()
                               .GetName().Version?.ToString(3) ?? "不明";
 
+            var edgeChannel = FindEdgeDevVersionFolder() is not null ? "Edge Dev" : "WebView2 ランタイム";
+            string edgeVersion;
+            try
+            {
+                edgeVersion = CoreWebView2Environment.GetAvailableBrowserVersionString(
+                    FindEdgeDevVersionFolder() ?? "");
+            }
+            catch
+            {
+                edgeVersion = _webViewEnv?.BrowserVersionString ?? "不明";
+            }
+            var versionInfoText = $"XTimelineViewer v{version}\n{edgeChannel} {edgeVersion}";
+
             // ヘルパー：左ラベル＋右コントロールの行を作る
             static Grid MakeRow(string label, FrameworkElement control, Thickness? margin = null)
             {
@@ -249,10 +262,67 @@ namespace XTimelineViewer
             panel.Children.Add(new NavigationViewItemSeparator { Margin = new Thickness(0, 12, 0, 8) });
             panel.Children.Add(new TextBlock
             {
-                Text                = $"XTimelineViewer v{version}",
-                Opacity             = 0.6,
-                HorizontalAlignment = HorizontalAlignment.Center
+                Text       = "バージョン情報",
+                FontWeight = Microsoft.UI.Text.FontWeights.SemiBold
             });
+
+            var versionInfoBox = new TextBox
+            {
+                Text            = versionInfoText,
+                IsReadOnly      = true,
+                AcceptsReturn   = true,
+                FontFamily      = new FontFamily("Cascadia Mono, Consolas, Courier New"),
+                FontSize        = 11,
+                Margin          = new Thickness(0, 6, 0, 0),
+                BorderThickness = new Thickness(1),
+                CornerRadius    = new CornerRadius(4),
+            };
+
+            var copyBtn = new Button
+            {
+                Content = new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    Spacing     = 6,
+                    Children    =
+                    {
+                        new FontIcon
+                        {
+                            Glyph      = "",
+                            FontFamily = new FontFamily("Segoe Fluent Icons"),
+                            FontSize   = 14
+                        },
+                        new TextBlock { Text = "コピー" }
+                    }
+                },
+                Margin = new Thickness(0, 8, 8, 0)
+            };
+            copyBtn.Click += (_, _) =>
+            {
+                var dp = new DataPackage();
+                dp.SetText(versionInfoText);
+                Clipboard.SetContent(dp);
+            };
+
+            var issueBody = Uri.EscapeDataString(
+                $"- アプリバージョン：v{version}\n" +
+                $"- 内部の Edge バージョン：{edgeChannel} {edgeVersion}\n" +
+                $"- 具体的な症状：\n");
+            var issueUrl = $"https://github.com/daruyanagi/XTimelineViewer/issues/new?labels=bug&title=&body={issueBody}";
+
+            var issueBtn = new HyperlinkButton
+            {
+                Content    = "Issue を報告",
+                Margin     = new Thickness(0, 8, 0, 0),
+                NavigateUri = new Uri(issueUrl),
+            };
+
+            var actionsPanel = new StackPanel { Orientation = Orientation.Horizontal };
+            actionsPanel.Children.Add(copyBtn);
+            actionsPanel.Children.Add(issueBtn);
+
+            panel.Children.Add(versionInfoBox);
+            panel.Children.Add(actionsPanel);
 
             var dlg = new ContentDialog
             {


### PR DESCRIPTION
## 概要

設定ダイアログの「バージョン情報」セクションを拡充。

## 変更内容

- アプリバージョンに加えて **Edge チャネル・バージョン** を表示（`CoreWebView2Environment.GetAvailableBrowserVersionString` で取得）
- **[コピー] ボタン** でバージョン情報をクリップボードへ一括コピー
- **[Issue を報告]** ボタンでアプリ・Edge バージョンが本文に埋め込まれた GitHub issue 作成ページを既定ブラウザーで開く

## Issue 報告 URL の body

```
- アプリバージョン：v1.1.0
- 内部の Edge バージョン：Edge Dev 132.0.2957.140
- 具体的な症状：
```

Closes #10