### PR TITLE
Ctrl+N をどこからでも動作するよう修正 #19

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -24,6 +24,9 @@
                     FontSize="14"
                     Style="{StaticResource AccentButtonStyle}"
                     Click="PostBtn_Click">
+                <Button.KeyboardAccelerators>
+                    <KeyboardAccelerator Key="N" Modifiers="Control"/>
+                </Button.KeyboardAccelerators>
                 <ToolTipService.ToolTip>新規投稿</ToolTipService.ToolTip>
                 <StackPanel Orientation="Horizontal" Spacing="6">
                     <FontIcon Glyph="&#xE70F;" FontFamily="Segoe Fluent Icons" FontSize="14" VerticalAlignment="Center"/>


### PR DESCRIPTION
## 概要

ツールバーやメインウィンドウなど XAML 側にフォーカスがある状態では Ctrl+N が機能しない問題を修正します。

## 原因

Ctrl+N のショートカットは WebView2 に注入した JavaScript で処理していたため、WebView2 にフォーカスがある場合のみ動作していました。

## 修正内容

- `PostBtn` に `<KeyboardAccelerator Key="N" Modifiers="Control"/>` を追加
  - XAML 側にフォーカスがある場合は Accelerator が `PostBtn_Click` を発火
  - WebView2 にフォーカスがある場合は従来通り JS → `postMessage('newPost')` が動作
- ダイアログを閉じた後、Ctrl+N を押していた WebView2 にフォーカスを戻すよう修正

Closes #19