### PR TITLE
feat: 多言語対応（日本語・英語）#24

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -17,6 +17,7 @@ namespace XTimelineViewer
         protected override void OnLaunched(LaunchActivatedEventArgs args)
         {
             ApplyLanguageOverride();
+            R.Initialize();
             _window = new MainWindow();
             _window.Activate();
         }

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -1,5 +1,6 @@
 using Microsoft.UI.Xaml;
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Text.Json;
 
@@ -16,13 +17,21 @@ namespace XTimelineViewer
 
         protected override void OnLaunched(LaunchActivatedEventArgs args)
         {
-            ApplyLanguageOverride();
-            R.Initialize();
+            var lang = ReadLanguageSetting();
+
+            // Packaged (MSIX) mode: PrimaryLanguageOverride affects XAML x:Uid bindings
+            if (lang != null)
+            {
+                try { Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride = lang; }
+                catch { /* unpackaged mode — R.Initialize() handles the override via resw */ }
+            }
+
+            R.Initialize(lang);
             _window = new MainWindow();
             _window.Activate();
         }
 
-        private static void ApplyLanguageOverride()
+        private static string? ReadLanguageSetting()
         {
             try
             {
@@ -39,16 +48,22 @@ namespace XTimelineViewer
                         "XTimelineViewer", "settings.json");
                 }
 
-                if (!File.Exists(settingsPath)) return;
+                if (!File.Exists(settingsPath)) return null;
 
                 using var doc = JsonDocument.Parse(File.ReadAllText(settingsPath));
                 if (doc.RootElement.TryGetProperty("Language", out var lang) &&
                     lang.GetString() is { } langStr && langStr != "system")
                 {
-                    Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride = langStr;
+                    Debug.WriteLine($"[App] Language setting: {langStr}");
+                    return langStr;
                 }
+                return null;
             }
-            catch { }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[App] ReadLanguageSetting FAILED: {ex.Message}");
+                return null;
+            }
         }
     }
 }

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -1,4 +1,7 @@
 using Microsoft.UI.Xaml;
+using System;
+using System.IO;
+using System.Text.Json;
 
 namespace XTimelineViewer
 {
@@ -8,6 +11,7 @@ namespace XTimelineViewer
 
         public App()
         {
+            ApplyLanguageOverride();
             this.InitializeComponent();
         }
 
@@ -15,6 +19,35 @@ namespace XTimelineViewer
         {
             _window = new MainWindow();
             _window.Activate();
+        }
+
+        private static void ApplyLanguageOverride()
+        {
+            try
+            {
+                string settingsPath;
+                try
+                {
+                    settingsPath = Path.Combine(
+                        Windows.Storage.ApplicationData.Current.LocalFolder.Path, "settings.json");
+                }
+                catch
+                {
+                    settingsPath = Path.Combine(
+                        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                        "XTimelineViewer", "settings.json");
+                }
+
+                if (!File.Exists(settingsPath)) return;
+
+                using var doc = JsonDocument.Parse(File.ReadAllText(settingsPath));
+                if (doc.RootElement.TryGetProperty("Language", out var lang) &&
+                    lang.GetString() is { } langStr && langStr != "system")
+                {
+                    Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride = langStr;
+                }
+            }
+            catch { }
         }
     }
 }

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -11,12 +11,12 @@ namespace XTimelineViewer
 
         public App()
         {
-            ApplyLanguageOverride();
             this.InitializeComponent();
         }
 
         protected override void OnLaunched(LaunchActivatedEventArgs args)
         {
+            ApplyLanguageOverride();
             _window = new MainWindow();
             _window.Activate();
         }

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -29,7 +29,7 @@
                 </Button.KeyboardAccelerators>
                 <StackPanel Orientation="Horizontal" Spacing="6">
                     <FontIcon Glyph="&#xE70F;" FontFamily="Segoe Fluent Icons" FontSize="14" VerticalAlignment="Center"/>
-                    <TextBlock x:Uid="PostLabel" VerticalAlignment="Center"/>
+                    <TextBlock x:Name="PostLabel" VerticalAlignment="Center"/>
                 </StackPanel>
             </Button>
             <StackPanel x:Name="RightToolbar"
@@ -62,11 +62,11 @@
                     <TextBlock Text="🐦"
                                FontSize="52"
                                HorizontalAlignment="Center"/>
-                    <TextBlock x:Uid="DropHintTitle"
+                    <TextBlock x:Name="DropHintTitle"
                                FontSize="18"
                                FontWeight="SemiBold"
                                HorizontalAlignment="Center"/>
-                    <TextBlock x:Uid="DropHintSubtitle"
+                    <TextBlock x:Name="DropHintSubtitle"
                                FontSize="13"
                                Opacity="0.6"
                                HorizontalAlignment="Center"/>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -27,10 +27,9 @@
                 <Button.KeyboardAccelerators>
                     <KeyboardAccelerator Key="N" Modifiers="Control"/>
                 </Button.KeyboardAccelerators>
-                <ToolTipService.ToolTip>新規投稿</ToolTipService.ToolTip>
                 <StackPanel Orientation="Horizontal" Spacing="6">
                     <FontIcon Glyph="&#xE70F;" FontFamily="Segoe Fluent Icons" FontSize="14" VerticalAlignment="Center"/>
-                    <TextBlock Text="投稿" VerticalAlignment="Center"/>
+                    <TextBlock x:Uid="PostLabel" VerticalAlignment="Center"/>
                 </StackPanel>
             </Button>
             <StackPanel x:Name="RightToolbar"
@@ -38,9 +37,8 @@
                         Spacing="4"
                         HorizontalAlignment="Right"
                         VerticalAlignment="Center">
-                <Button Width="32" Height="32" Padding="0" FontSize="14"
+                <Button x:Name="AppSettingsBtn" Width="32" Height="32" Padding="0" FontSize="14"
                         Click="AppSettingsBtn_Click">
-                    <ToolTipService.ToolTip>アプリ設定</ToolTipService.ToolTip>
                     <FontIcon Glyph="&#xE713;" FontFamily="Segoe Fluent Icons" FontSize="14"/>
                 </Button>
             </StackPanel>
@@ -64,11 +62,11 @@
                     <TextBlock Text="🐦"
                                FontSize="52"
                                HorizontalAlignment="Center"/>
-                    <TextBlock Text="X の URL ショートカットをドロップ"
+                    <TextBlock x:Uid="DropHintTitle"
                                FontSize="18"
                                FontWeight="SemiBold"
                                HorizontalAlignment="Center"/>
-                    <TextBlock Text="タイムラインが横並びで追加されます"
+                    <TextBlock x:Uid="DropHintSubtitle"
                                FontSize="13"
                                Opacity="0.6"
                                HorizontalAlignment="Center"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -264,6 +264,9 @@ namespace XTimelineViewer
             var iconPath = Path.Combine(AppContext.BaseDirectory, "Assets", "AppIcon.ico");
             if (File.Exists(iconPath)) AppWindow.SetIcon(iconPath);
             Title = $"XTimelineViewer — {SaveFilePath}";
+            PostLabel.Text       = R.Get("PostLabel.Text");
+            DropHintTitle.Text   = R.Get("DropHintTitle.Text");
+            DropHintSubtitle.Text = R.Get("DropHintSubtitle.Text");
             ToolTipService.SetToolTip(PostBtn, R.Get("PostBtn_Tooltip"));
             ToolTipService.SetToolTip(AppSettingsBtn, R.Get("AppSettingsBtn_Tooltip"));
             Closed += async (s, e) => await SaveTimelinesAsync();
@@ -349,17 +352,6 @@ namespace XTimelineViewer
                 MinWidth      = 140
             };
 
-            var separateEnvToggle = new ToggleSwitch
-            {
-                IsOn              = false,
-                IsEnabled         = false, // 廃止予定 (#17)
-                OnContent         = R.Get("Toggle_On"),
-                OffContent        = R.Get("Toggle_Off"),
-                Margin              = new Thickness(12, 0, 0, 0),
-                VerticalAlignment   = VerticalAlignment.Center,
-                HorizontalAlignment = HorizontalAlignment.Right
-            };
-
             var openFolderBtn = new Button { Content = R.Get("Button_OpenFolder") };
             openFolderBtn.Click += async (_, _) =>
             {
@@ -414,6 +406,16 @@ namespace XTimelineViewer
                 Text       = R.Get("Section_Experimental"),
                 FontWeight = Microsoft.UI.Text.FontWeights.SemiBold
             });
+            var separateEnvToggle = new ToggleSwitch
+            {
+                IsOn              = false,
+                IsEnabled         = false, // 廃止予定 (#17)
+                OnContent         = R.Get("Toggle_On"),
+                OffContent        = R.Get("Toggle_Off"),
+                Margin              = new Thickness(12, 0, 0, 0),
+                VerticalAlignment   = VerticalAlignment.Center,
+                HorizontalAlignment = HorizontalAlignment.Right
+            };
             panel.Children.Add(MakeRow(R.Get("Settings_SeparateCompose"), separateEnvToggle));
 
             var openPostToggle = new ToggleSwitch

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -26,10 +26,11 @@ namespace XTimelineViewer
     internal class AppSettings
     {
         public bool   SeparateComposeEnv    { get; set; } = false;
-        public bool   OpenComposerInBrowser     { get; set; } = false;
+        public bool   OpenComposerInBrowser { get; set; } = false;
         public bool   OpenTweetInBrowser    { get; set; } = false;
         public string Theme                 { get; set; } = "Default"; // "Light" | "Dark" | "Default"
-        public int    AutoActivateMinutes   { get; set; } = 0;         // 0 = 無効
+        public int    AutoActivateMinutes   { get; set; } = 0;
+        public string Language              { get; set; } = "system";  // "system" | "ja-JP" | "en-US"
     }
 
     public sealed partial class MainWindow : Window
@@ -263,6 +264,8 @@ namespace XTimelineViewer
             var iconPath = Path.Combine(AppContext.BaseDirectory, "Assets", "AppIcon.ico");
             if (File.Exists(iconPath)) AppWindow.SetIcon(iconPath);
             Title = $"XTimelineViewer — {SaveFilePath}";
+            ToolTipService.SetToolTip(PostBtn, R.Get("PostBtn_Tooltip"));
+            ToolTipService.SetToolTip(AppSettingsBtn, R.Get("AppSettingsBtn_Tooltip"));
             Closed += async (s, e) => await SaveTimelinesAsync();
             ((FrameworkElement)Content).ActualThemeChanged += (s, e) => ApplyThemeToWebViews();
             LoadSettings();
@@ -332,8 +335,17 @@ namespace XTimelineViewer
         {
             var themeCombo = new ComboBox
             {
-                ItemsSource   = new List<string> { "システム", "ライト", "ダーク" },
+                ItemsSource   = new List<string> { R.Get("Theme_System"), R.Get("Theme_Light"), R.Get("Theme_Dark") },
                 SelectedIndex = _appSettings.Theme switch { "Light" => 1, "Dark" => 2, _ => 0 },
+                MinWidth      = 140
+            };
+
+            var langValues = new[] { "system", "ja-JP", "en-US" };
+            var langIdx    = Array.IndexOf(langValues, _appSettings.Language);
+            var langCombo  = new ComboBox
+            {
+                ItemsSource   = new List<string> { R.Get("Language_System"), R.Get("Language_JA"), R.Get("Language_EN") },
+                SelectedIndex = langIdx < 0 ? 0 : langIdx,
                 MinWidth      = 140
             };
 
@@ -341,14 +353,14 @@ namespace XTimelineViewer
             {
                 IsOn              = false,
                 IsEnabled         = false, // 廃止予定 (#17)
-                OnContent         = "有効",
-                OffContent        = "無効",
+                OnContent         = R.Get("Toggle_On"),
+                OffContent        = R.Get("Toggle_Off"),
                 Margin              = new Thickness(12, 0, 0, 0),
                 VerticalAlignment   = VerticalAlignment.Center,
                 HorizontalAlignment = HorizontalAlignment.Right
             };
 
-            var openFolderBtn = new Button { Content = "フォルダーを開く" };
+            var openFolderBtn = new Button { Content = R.Get("Button_OpenFolder") };
             openFolderBtn.Click += async (_, _) =>
             {
                 var folder = Path.GetDirectoryName(SettingsFilePath)!;
@@ -357,9 +369,11 @@ namespace XTimelineViewer
             };
 
             var version = System.Reflection.Assembly.GetExecutingAssembly()
-                              .GetName().Version?.ToString(3) ?? "不明";
+                              .GetName().Version?.ToString(3) ?? R.Get("Version_Unknown");
 
-            var edgeChannel = FindEdgeDevVersionFolder() is not null ? "Edge Dev" : "WebView2 ランタイム";
+            var edgeChannel = FindEdgeDevVersionFolder() is not null
+                ? R.Get("EdgeChannel_Dev")
+                : R.Get("EdgeChannel_Runtime");
             string edgeVersion;
             try
             {
@@ -368,11 +382,10 @@ namespace XTimelineViewer
             }
             catch
             {
-                edgeVersion = _webViewEnv?.BrowserVersionString ?? "不明";
+                edgeVersion = _webViewEnv?.BrowserVersionString ?? R.Get("Version_Unknown");
             }
             var versionInfoText = $"XTimelineViewer v{version}\r\n{edgeChannel} {edgeVersion}";
 
-            // ヘルパー：左ラベル＋右コントロールの行を作る
             static Grid MakeRow(string label, FrameworkElement control, Thickness? margin = null)
             {
                 var g = new Grid { Margin = margin ?? new Thickness(0, 6, 0, 0) };
@@ -392,37 +405,38 @@ namespace XTimelineViewer
             }
 
             var panel = new StackPanel { MinWidth = 400 };
-            panel.Children.Add(MakeRow("テーマ", themeCombo, new Thickness(0)));
-            panel.Children.Add(MakeRow("設定ファイルのエクスポート", openFolderBtn));
+            panel.Children.Add(MakeRow(R.Get("Settings_Theme"), themeCombo, new Thickness(0)));
+            panel.Children.Add(MakeRow(R.Get("Settings_Language"), langCombo));
+            panel.Children.Add(MakeRow(R.Get("Settings_ExportFolder"), openFolderBtn));
             panel.Children.Add(new NavigationViewItemSeparator { Margin = new Thickness(0, 12, 0, 8) });
             panel.Children.Add(new TextBlock
             {
-                Text       = "試験機能",
+                Text       = R.Get("Section_Experimental"),
                 FontWeight = Microsoft.UI.Text.FontWeights.SemiBold
             });
-            panel.Children.Add(MakeRow("投稿画面を別プロファイルで開く（廃止予定）", separateEnvToggle));
+            panel.Children.Add(MakeRow(R.Get("Settings_SeparateCompose"), separateEnvToggle));
 
             var openPostToggle = new ToggleSwitch
             {
                 IsOn                = _appSettings.OpenComposerInBrowser,
-                OnContent           = "有効",
-                OffContent          = "無効",
+                OnContent           = R.Get("Toggle_On"),
+                OffContent          = R.Get("Toggle_Off"),
                 Margin              = new Thickness(12, 0, 0, 0),
                 VerticalAlignment   = VerticalAlignment.Center,
                 HorizontalAlignment = HorizontalAlignment.Right
             };
-            panel.Children.Add(MakeRow("新規投稿を外部ブラウザーで開く", openPostToggle));
+            panel.Children.Add(MakeRow(R.Get("Settings_OpenComposerInBrowser"), openPostToggle));
 
             var openTweetToggle = new ToggleSwitch
             {
                 IsOn                = _appSettings.OpenTweetInBrowser,
-                OnContent           = "有効",
-                OffContent          = "無効",
+                OnContent           = R.Get("Toggle_On"),
+                OffContent          = R.Get("Toggle_Off"),
                 Margin              = new Thickness(12, 0, 0, 0),
                 VerticalAlignment   = VerticalAlignment.Center,
                 HorizontalAlignment = HorizontalAlignment.Right
             };
-            panel.Children.Add(MakeRow("ツイートを外部ブラウザーで開く", openTweetToggle));
+            panel.Children.Add(MakeRow(R.Get("Settings_OpenTweetInBrowser"), openTweetToggle));
 
             var autoActivateBox = new NumberBox
             {
@@ -434,11 +448,11 @@ namespace XTimelineViewer
                 SpinButtonPlacementMode = NumberBoxSpinButtonPlacementMode.Inline,
                 Width                   = 160,
             };
-            panel.Children.Add(MakeRow("ホームタイムラインを定期的にアクティブ化（分、0 で無効）", autoActivateBox));
+            panel.Children.Add(MakeRow(R.Get("Settings_AutoActivate"), autoActivateBox));
             panel.Children.Add(new NavigationViewItemSeparator { Margin = new Thickness(0, 12, 0, 8) });
             panel.Children.Add(new TextBlock
             {
-                Text       = "バージョン情報",
+                Text       = R.Get("Section_About"),
                 FontWeight = Microsoft.UI.Text.FontWeights.SemiBold
             });
 
@@ -480,7 +494,7 @@ namespace XTimelineViewer
                             FontFamily = new FontFamily("Segoe Fluent Icons"),
                             FontSize   = 14
                         },
-                        new TextBlock { Text = "コピー" }
+                        new TextBlock { Text = R.Get("Button_Copy") }
                     }
                 },
                 Margin = new Thickness(0, 8, 8, 0)
@@ -493,15 +507,15 @@ namespace XTimelineViewer
             };
 
             var issueBody = Uri.EscapeDataString(
-                $"- アプリバージョン：v{version}\n" +
-                $"- 内部の Edge バージョン：{edgeChannel} {edgeVersion}\n" +
-                $"- 具体的な症状：\n");
+                $"- {R.Get("IssueLabel_AppVersion")}: v{version}\n" +
+                $"- {R.Get("IssueLabel_EdgeVersion")}: {edgeChannel} {edgeVersion}\n" +
+                $"- {R.Get("IssueLabel_Symptoms")}:\n");
             var issueUrl = $"https://github.com/daruyanagi/XTimelineViewer/issues/new?labels=bug&title=&body={issueBody}";
 
             var issueBtn = new HyperlinkButton
             {
-                Content    = "Issue を報告",
-                Margin     = new Thickness(0, 8, 0, 0),
+                Content     = R.Get("Button_ReportIssue"),
+                Margin      = new Thickness(0, 8, 0, 0),
                 NavigateUri = new Uri(issueUrl),
             };
 
@@ -514,10 +528,10 @@ namespace XTimelineViewer
 
             var dlg = new ContentDialog
             {
-                Title             = "アプリ設定",
+                Title             = R.Get("AppSettings_Title"),
                 Content           = panel,
-                PrimaryButtonText = "保存",
-                CloseButtonText   = "キャンセル",
+                PrimaryButtonText = R.Get("Button_Save"),
+                CloseButtonText   = R.Get("Button_Cancel"),
                 DefaultButton     = ContentDialogButton.Primary,
                 XamlRoot          = Content.XamlRoot,
                 RequestedTheme    = ((FrameworkElement)Content).ActualTheme
@@ -526,19 +540,35 @@ namespace XTimelineViewer
             if (await dlg.ShowAsync() == ContentDialogResult.Primary)
             {
                 _appSettings.Theme = themeCombo.SelectedIndex switch { 1 => "Light", 2 => "Dark", _ => "Default" };
-                _appSettings.OpenComposerInBrowser   = openPostToggle.IsOn;
-                _appSettings.OpenTweetInBrowser  = openTweetToggle.IsOn;
-                _appSettings.AutoActivateMinutes = (int)Math.Clamp(autoActivateBox.Value, 0, 60);
+                _appSettings.OpenComposerInBrowser = openPostToggle.IsOn;
+                _appSettings.OpenTweetInBrowser    = openTweetToggle.IsOn;
+                _appSettings.AutoActivateMinutes   = (int)Math.Clamp(autoActivateBox.Value, 0, 60);
+
+                var newLang    = langValues[Math.Max(0, Math.Min(langCombo.SelectedIndex, langValues.Length - 1))];
+                var langChanged = newLang != _appSettings.Language;
+                _appSettings.Language = newLang;
+
                 SaveSettings();
                 ApplySavedTheme();
 
-                // 設定変更を即時反映する
                 var flag = _appSettings.OpenTweetInBrowser ? "true" : "false";
                 foreach (var wv in _webViews)
                     if (wv.CoreWebView2 is not null)
                         await wv.CoreWebView2.ExecuteScriptAsync(
                             $"window._xtvOpenTweetInBrowser = {flag};");
                 ApplyAutoActivateTimer();
+
+                if (langChanged)
+                {
+                    var notifDlg = new ContentDialog
+                    {
+                        Content         = R.Get("RestartRequired"),
+                        CloseButtonText = R.Get("Button_Close"),
+                        XamlRoot        = Content.XamlRoot,
+                        RequestedTheme  = ((FrameworkElement)Content).ActualTheme
+                    };
+                    await notifDlg.ShowAsync();
+                }
             }
         }
 
@@ -558,10 +588,10 @@ namespace XTimelineViewer
 
             var dlg = new ContentDialog
             {
-                Content          = webView,
-                CloseButtonText  = "閉じる",
-                XamlRoot         = Content.XamlRoot,
-                RequestedTheme   = ((FrameworkElement)Content).ActualTheme
+                Content         = webView,
+                CloseButtonText = R.Get("Button_Close"),
+                XamlRoot        = Content.XamlRoot,
+                RequestedTheme  = ((FrameworkElement)Content).ActualTheme
             };
 
             var env = _appSettings.SeparateComposeEnv
@@ -715,7 +745,7 @@ namespace XTimelineViewer
             if (e.DataView.Contains(StandardDataFormats.StorageItems))
             {
                 e.AcceptedOperation          = DataPackageOperation.Link;
-                e.DragUIOverride.Caption     = "タイムラインを追加";
+                e.DragUIOverride.Caption     = R.Get("DragCaption");
                 e.DragUIOverride.IsGlyphVisible = true;
             }
             else
@@ -844,14 +874,14 @@ namespace XTimelineViewer
                 Width = 28, Height = 26,
                 Padding = new Thickness(0)
             };
-            ToolTipService.SetToolTip(settingsBtn, "設定");
+            ToolTipService.SetToolTip(settingsBtn, R.Get("Pane_Settings_Tooltip"));
 
             var closeBtn = new Button
             {
                 Content = "✕", Width = 28, Height = 26,
                 Padding = new Thickness(0), FontSize = 11
             };
-            ToolTipService.SetToolTip(closeBtn, "閉じる");
+            ToolTipService.SetToolTip(closeBtn, R.Get("Pane_Close_Tooltip"));
 
             buttonPanel.Children.Add(settingsBtn);
             buttonPanel.Children.Add(closeBtn);
@@ -956,39 +986,39 @@ namespace XTimelineViewer
                 var hideHeaderToggle = new ToggleSwitch
                 {
                     IsOn       = cfg.HideHeader,
-                    OnContent  = "非表示",
-                    OffContent = "表示"
+                    OnContent  = R.Get("Toggle_Hide"),
+                    OffContent = R.Get("Toggle_Show")
                 };
 
                 var hideComposeToggle = new ToggleSwitch
                 {
                     IsOn       = cfg.HideCompose,
-                    OnContent  = "非表示",
-                    OffContent = "表示"
+                    OnContent  = R.Get("Toggle_Hide"),
+                    OffContent = R.Get("Toggle_Show")
                 };
 
                 var panel = new StackPanel { Spacing = 8 };
-                panel.Children.Add(new TextBlock { Text = "タイムラインの幅（px）" });
+                panel.Children.Add(new TextBlock { Text = R.Get("Timeline_Width") });
                 panel.Children.Add(widthBox);
                 panel.Children.Add(new TextBlock
                 {
-                    Text   = "X の header 要素",
+                    Text   = R.Get("Timeline_Header"),
                     Margin = new Thickness(0, 8, 0, 0)
                 });
                 panel.Children.Add(hideHeaderToggle);
                 panel.Children.Add(new TextBlock
                 {
-                    Text   = "投稿画面",
+                    Text   = R.Get("Timeline_Compose"),
                     Margin = new Thickness(0, 8, 0, 0)
                 });
                 panel.Children.Add(hideComposeToggle);
 
                 var dlg = new ContentDialog
                 {
-                    Title             = "設定",
+                    Title             = R.Get("Timeline_Settings_Title"),
                     Content           = panel,
-                    PrimaryButtonText = "適用",
-                    CloseButtonText   = "キャンセル",
+                    PrimaryButtonText = R.Get("Button_Apply"),
+                    CloseButtonText   = R.Get("Button_Cancel"),
                     DefaultButton     = ContentDialogButton.Primary,
                     XamlRoot          = Content.XamlRoot
                 };
@@ -1137,7 +1167,7 @@ namespace XTimelineViewer
             {
                 var dlg = new ContentDialog
                 {
-                    Title           = "拡張機能の読み込みに失敗しました",
+                    Title           = R.Get("ExtLoadError_Title"),
                     Content         = new ScrollViewer
                     {
                         MaxHeight = 300,
@@ -1151,7 +1181,7 @@ namespace XTimelineViewer
                             TextWrapping = TextWrapping.Wrap
                         }
                     },
-                    CloseButtonText = "閉じる",
+                    CloseButtonText = R.Get("Button_Close"),
                     XamlRoot        = Content.XamlRoot
                 };
                 await dlg.ShowAsync();
@@ -1205,7 +1235,7 @@ namespace XTimelineViewer
                 Height  = 32,
                 Padding = new Thickness(0),
             };
-            ToolTipService.SetToolTip(btn, $"{name} の設定");
+            ToolTipService.SetToolTip(btn, string.Format(R.Get("ExtSettings_Format"), name));
 
             var optPageUrl = $"chrome-extension://{ext.Id}/{optPage}";
             btn.Click += async (_, _) =>
@@ -1213,9 +1243,9 @@ namespace XTimelineViewer
                 var optWebView = new WebView2 { Width = 480, MinHeight = 200 };
                 var dlg = new ContentDialog
                 {
-                    Title           = $"{name} の設定",
+                    Title           = string.Format(R.Get("ExtSettings_Format"), name),
                     Content         = optWebView,
-                    CloseButtonText = "閉じる",
+                    CloseButtonText = R.Get("Button_Close"),
                     XamlRoot        = Content.XamlRoot
                 };
                 var env = await GetOrCreateEnvAsync();
@@ -1265,7 +1295,7 @@ namespace XTimelineViewer
                 {
                     var dlg = new ContentDialog
                     {
-                        Title           = "WebView2 の初期化に失敗しました",
+                        Title           = R.Get("WebViewInitError_Title"),
                         Content         = new ScrollViewer
                         {
                             MaxHeight = 300,
@@ -1278,7 +1308,7 @@ namespace XTimelineViewer
                                 TextWrapping = TextWrapping.Wrap
                             }
                         },
-                        CloseButtonText = "閉じる",
+                        CloseButtonText = R.Get("Button_Close"),
                         XamlRoot        = Content.XamlRoot
                     };
                     await dlg.ShowAsync();

--- a/Package.appxmanifest
+++ b/Package.appxmanifest
@@ -26,6 +26,7 @@
 
   <Resources>
     <Resource Language="ja-JP" />
+    <Resource Language="en-US" />
   </Resources>
 
   <Applications>

--- a/R.cs
+++ b/R.cs
@@ -1,26 +1,85 @@
 using Microsoft.Windows.ApplicationModel.Resources;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Xml.Linq;
 
 namespace XTimelineViewer
 {
     internal static class R
     {
         private static ResourceMap? _map;
+        private static Dictionary<string, string>? _overrideDict;
         private static bool _initialized;
 
-        internal static void Initialize()
+        internal static void Initialize(string? languageOverride = null)
         {
             if (_initialized) return;
             _initialized = true;
-            try { _map = new ResourceManager().MainResourceMap.GetSubtree("Resources"); }
-            catch { }
+            Debug.WriteLine("[R] Initialize() start");
+
+            try
+            {
+                _map = new ResourceManager().MainResourceMap.GetSubtree("Resources");
+                Debug.WriteLine("[R] ResourceMap acquired");
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[R] ResourceMap FAILED: {ex.GetType().Name}: {ex.Message}");
+            }
+
+            if (languageOverride != null)
+            {
+                var reswPath = Path.Combine(
+                    AppContext.BaseDirectory, "Strings", languageOverride, "Resources.resw");
+                Debug.WriteLine($"[R] Looking for resw: {reswPath}");
+                if (File.Exists(reswPath))
+                {
+                    _overrideDict = ParseResw(reswPath);
+                    Debug.WriteLine($"[R] Loaded {_overrideDict.Count} strings from {languageOverride}");
+                }
+                else
+                {
+                    Debug.WriteLine($"[R] resw not found: {reswPath}");
+                }
+            }
+        }
+
+        private static Dictionary<string, string> ParseResw(string path)
+        {
+            var dict = new Dictionary<string, string>();
+            try
+            {
+                foreach (var data in XDocument.Load(path).Descendants("data"))
+                {
+                    var name  = data.Attribute("name")?.Value;
+                    var value = data.Element("value")?.Value;
+                    if (name != null && value != null)
+                        dict[name] = value;
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[R] ParseResw FAILED: {ex.Message}");
+            }
+            return dict;
         }
 
         public static string Get(string key)
         {
             if (!_initialized) Initialize();
+
+            if (_overrideDict != null && _overrideDict.TryGetValue(key, out var overrideVal))
+                return overrideVal;
+
             if (_map is null) return string.Empty;
             try { return _map.GetValue(key)?.ValueAsString ?? string.Empty; }
-            catch { return string.Empty; }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[R] Get({key}) FAILED: {ex.GetType().Name}: {ex.Message}");
+                return string.Empty;
+            }
         }
     }
 }

--- a/R.cs
+++ b/R.cs
@@ -4,7 +4,23 @@ namespace XTimelineViewer
 {
     internal static class R
     {
-        private static readonly ResourceLoader _loader = new();
-        public static string Get(string key) => _loader.GetString(key);
+        private static ResourceMap? _map;
+        private static bool _initialized;
+
+        internal static void Initialize()
+        {
+            if (_initialized) return;
+            _initialized = true;
+            try { _map = new ResourceManager().MainResourceMap.GetSubtree("Resources"); }
+            catch { }
+        }
+
+        public static string Get(string key)
+        {
+            if (!_initialized) Initialize();
+            if (_map is null) return string.Empty;
+            try { return _map.GetValue(key)?.ValueAsString ?? string.Empty; }
+            catch { return string.Empty; }
+        }
     }
 }

--- a/R.cs
+++ b/R.cs
@@ -1,0 +1,10 @@
+using Microsoft.Windows.ApplicationModel.Resources;
+
+namespace XTimelineViewer
+{
+    internal static class R
+    {
+        private static readonly ResourceLoader _loader = new();
+        public static string Get(string key) => _loader.GetString(key);
+    }
+}

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+
+  <!-- XAML x:Uid bindings -->
+  <data name="PostLabel.Text" xml:space="preserve"><value>Post</value></data>
+  <data name="DropHintTitle.Text" xml:space="preserve"><value>Drop an X URL Shortcut</value></data>
+  <data name="DropHintSubtitle.Text" xml:space="preserve"><value>Timelines will be added side by side</value></data>
+
+  <!-- Toolbar tooltips -->
+  <data name="PostBtn_Tooltip" xml:space="preserve"><value>New Post</value></data>
+  <data name="AppSettingsBtn_Tooltip" xml:space="preserve"><value>App Settings</value></data>
+
+  <!-- Theme selector items -->
+  <data name="Theme_System" xml:space="preserve"><value>System</value></data>
+  <data name="Theme_Light" xml:space="preserve"><value>Light</value></data>
+  <data name="Theme_Dark" xml:space="preserve"><value>Dark</value></data>
+
+  <!-- ToggleSwitch on/off labels -->
+  <data name="Toggle_On" xml:space="preserve"><value>On</value></data>
+  <data name="Toggle_Off" xml:space="preserve"><value>Off</value></data>
+  <data name="Toggle_Hide" xml:space="preserve"><value>Hidden</value></data>
+  <data name="Toggle_Show" xml:space="preserve"><value>Visible</value></data>
+
+  <!-- App settings dialog -->
+  <data name="AppSettings_Title" xml:space="preserve"><value>App Settings</value></data>
+  <data name="Settings_Theme" xml:space="preserve"><value>Theme</value></data>
+  <data name="Settings_Language" xml:space="preserve"><value>Language</value></data>
+  <data name="Settings_ExportFolder" xml:space="preserve"><value>Export Settings</value></data>
+  <data name="Section_Experimental" xml:space="preserve"><value>Experimental Features</value></data>
+  <data name="Section_About" xml:space="preserve"><value>About</value></data>
+  <data name="Settings_SeparateCompose" xml:space="preserve"><value>Open Composer in Separate Profile (Deprecated)</value></data>
+  <data name="Settings_OpenComposerInBrowser" xml:space="preserve"><value>Open Composer in External Browser</value></data>
+  <data name="Settings_OpenTweetInBrowser" xml:space="preserve"><value>Open Tweets in External Browser</value></data>
+  <data name="Settings_AutoActivate" xml:space="preserve"><value>Auto-activate Home Timeline (min, 0 to disable)</value></data>
+
+  <!-- Language selector items -->
+  <data name="Language_System" xml:space="preserve"><value>System Language</value></data>
+  <data name="Language_JA" xml:space="preserve"><value>日本語</value></data>
+  <data name="Language_EN" xml:space="preserve"><value>English</value></data>
+  <data name="RestartRequired" xml:space="preserve"><value>Language changed. The change will take effect on the next launch.</value></data>
+
+  <!-- Common buttons -->
+  <data name="Button_Save" xml:space="preserve"><value>Save</value></data>
+  <data name="Button_Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="Button_Close" xml:space="preserve"><value>Close</value></data>
+  <data name="Button_Apply" xml:space="preserve"><value>Apply</value></data>
+  <data name="Button_Copy" xml:space="preserve"><value>Copy</value></data>
+  <data name="Button_ReportIssue" xml:space="preserve"><value>Report Issue</value></data>
+  <data name="Button_OpenFolder" xml:space="preserve"><value>Open Folder</value></data>
+
+  <!-- Timeline pane settings dialog -->
+  <data name="Timeline_Settings_Title" xml:space="preserve"><value>Settings</value></data>
+  <data name="Timeline_Width" xml:space="preserve"><value>Timeline Width (px)</value></data>
+  <data name="Timeline_Header" xml:space="preserve"><value>X Header Element</value></data>
+  <data name="Timeline_Compose" xml:space="preserve"><value>Compose Area</value></data>
+  <data name="Pane_Settings_Tooltip" xml:space="preserve"><value>Settings</value></data>
+  <data name="Pane_Close_Tooltip" xml:space="preserve"><value>Close</value></data>
+  <data name="DragCaption" xml:space="preserve"><value>Add Timeline</value></data>
+
+  <!-- Error dialogs -->
+  <data name="ExtLoadError_Title" xml:space="preserve"><value>Failed to Load Extensions</value></data>
+  <data name="WebViewInitError_Title" xml:space="preserve"><value>Failed to Initialize WebView2</value></data>
+
+  <!-- Version info -->
+  <data name="Version_Unknown" xml:space="preserve"><value>Unknown</value></data>
+  <data name="EdgeChannel_Runtime" xml:space="preserve"><value>WebView2 Runtime</value></data>
+  <data name="EdgeChannel_Dev" xml:space="preserve"><value>Edge Dev</value></data>
+
+  <!-- Issue report body labels -->
+  <data name="IssueLabel_AppVersion" xml:space="preserve"><value>App version</value></data>
+  <data name="IssueLabel_EdgeVersion" xml:space="preserve"><value>Edge version</value></data>
+  <data name="IssueLabel_Symptoms" xml:space="preserve"><value>Symptoms</value></data>
+
+  <!-- Extension settings -->
+  <data name="ExtSettings_Format" xml:space="preserve"><value>{0} Settings</value></data>
+</root>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+
+  <!-- XAML x:Uid bindings -->
+  <data name="PostLabel.Text" xml:space="preserve"><value>投稿</value></data>
+  <data name="DropHintTitle.Text" xml:space="preserve"><value>X の URL ショートカットをドロップ</value></data>
+  <data name="DropHintSubtitle.Text" xml:space="preserve"><value>タイムラインが横並びで追加されます</value></data>
+
+  <!-- Toolbar tooltips -->
+  <data name="PostBtn_Tooltip" xml:space="preserve"><value>新規投稿</value></data>
+  <data name="AppSettingsBtn_Tooltip" xml:space="preserve"><value>アプリ設定</value></data>
+
+  <!-- Theme selector items -->
+  <data name="Theme_System" xml:space="preserve"><value>システム</value></data>
+  <data name="Theme_Light" xml:space="preserve"><value>ライト</value></data>
+  <data name="Theme_Dark" xml:space="preserve"><value>ダーク</value></data>
+
+  <!-- ToggleSwitch on/off labels -->
+  <data name="Toggle_On" xml:space="preserve"><value>有効</value></data>
+  <data name="Toggle_Off" xml:space="preserve"><value>無効</value></data>
+  <data name="Toggle_Hide" xml:space="preserve"><value>非表示</value></data>
+  <data name="Toggle_Show" xml:space="preserve"><value>表示</value></data>
+
+  <!-- App settings dialog -->
+  <data name="AppSettings_Title" xml:space="preserve"><value>アプリ設定</value></data>
+  <data name="Settings_Theme" xml:space="preserve"><value>テーマ</value></data>
+  <data name="Settings_Language" xml:space="preserve"><value>言語</value></data>
+  <data name="Settings_ExportFolder" xml:space="preserve"><value>設定ファイルのエクスポート</value></data>
+  <data name="Section_Experimental" xml:space="preserve"><value>試験機能</value></data>
+  <data name="Section_About" xml:space="preserve"><value>バージョン情報</value></data>
+  <data name="Settings_SeparateCompose" xml:space="preserve"><value>投稿画面を別プロファイルで開く（廃止予定）</value></data>
+  <data name="Settings_OpenComposerInBrowser" xml:space="preserve"><value>新規投稿を外部ブラウザーで開く</value></data>
+  <data name="Settings_OpenTweetInBrowser" xml:space="preserve"><value>ツイートを外部ブラウザーで開く</value></data>
+  <data name="Settings_AutoActivate" xml:space="preserve"><value>ホームタイムラインを定期的にアクティブ化（分、0 で無効）</value></data>
+
+  <!-- Language selector items -->
+  <data name="Language_System" xml:space="preserve"><value>システム言語</value></data>
+  <data name="Language_JA" xml:space="preserve"><value>日本語</value></data>
+  <data name="Language_EN" xml:space="preserve"><value>English</value></data>
+  <data name="RestartRequired" xml:space="preserve"><value>言語を変更しました。次回起動時に反映されます。</value></data>
+
+  <!-- Common buttons -->
+  <data name="Button_Save" xml:space="preserve"><value>保存</value></data>
+  <data name="Button_Cancel" xml:space="preserve"><value>キャンセル</value></data>
+  <data name="Button_Close" xml:space="preserve"><value>閉じる</value></data>
+  <data name="Button_Apply" xml:space="preserve"><value>適用</value></data>
+  <data name="Button_Copy" xml:space="preserve"><value>コピー</value></data>
+  <data name="Button_ReportIssue" xml:space="preserve"><value>Issue を報告</value></data>
+  <data name="Button_OpenFolder" xml:space="preserve"><value>フォルダーを開く</value></data>
+
+  <!-- Timeline pane settings dialog -->
+  <data name="Timeline_Settings_Title" xml:space="preserve"><value>設定</value></data>
+  <data name="Timeline_Width" xml:space="preserve"><value>タイムラインの幅（px）</value></data>
+  <data name="Timeline_Header" xml:space="preserve"><value>X の header 要素</value></data>
+  <data name="Timeline_Compose" xml:space="preserve"><value>投稿画面</value></data>
+  <data name="Pane_Settings_Tooltip" xml:space="preserve"><value>設定</value></data>
+  <data name="Pane_Close_Tooltip" xml:space="preserve"><value>閉じる</value></data>
+  <data name="DragCaption" xml:space="preserve"><value>タイムラインを追加</value></data>
+
+  <!-- Error dialogs -->
+  <data name="ExtLoadError_Title" xml:space="preserve"><value>拡張機能の読み込みに失敗しました</value></data>
+  <data name="WebViewInitError_Title" xml:space="preserve"><value>WebView2 の初期化に失敗しました</value></data>
+
+  <!-- Version info -->
+  <data name="Version_Unknown" xml:space="preserve"><value>不明</value></data>
+  <data name="EdgeChannel_Runtime" xml:space="preserve"><value>WebView2 ランタイム</value></data>
+  <data name="EdgeChannel_Dev" xml:space="preserve"><value>Edge Dev</value></data>
+
+  <!-- Issue report body labels -->
+  <data name="IssueLabel_AppVersion" xml:space="preserve"><value>アプリバージョン</value></data>
+  <data name="IssueLabel_EdgeVersion" xml:space="preserve"><value>内部の Edge バージョン</value></data>
+  <data name="IssueLabel_Symptoms" xml:space="preserve"><value>具体的な症状</value></data>
+
+  <!-- Extension settings -->
+  <data name="ExtSettings_Format" xml:space="preserve"><value>{0} の設定</value></data>
+</root>

--- a/XTimelineViewer.csproj
+++ b/XTimelineViewer.csproj
@@ -31,5 +31,8 @@
     <Content Include="Assets\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Strings\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

- `Strings/ja-JP/Resources.resw` と `Strings/en-US/Resources.resw` を追加し、UI 文字列をすべてリソースファイルに移行
- 設定ダイアログに言語セレクター（システム / 日本語 / English）を追加。変更後の再起動で反映
- `R` クラスを追加し、`R.Get(key)` でリソース文字列を取得する統一インターフェースを提供

## Technical Notes

- `PrimaryLanguageOverride` は MSIX パッケージ ID が必要なため unpackaged（デバッグ）環境では使用不可
- 代わりに `Strings/{lang}/Resources.resw` を `XDocument` で直接パースする方式を採用
- MSIX パッケージとして配布した場合は `PrimaryLanguageOverride` も試みる（try-catch で安全に）
- XAML の `x:Uid` は `PrimaryLanguageOverride` に依存するため `x:Name` + コードビハインドに変更

## Test plan

- [ ] 日本語システム環境でデフォルト起動 → UI が日本語で表示される
- [ ] 設定で English を選択 → 再起動後 UI が英語で表示される
- [ ] 設定でシステム言語に戻す → 再起動後 UI が日本語に戻る
- [ ] ツールチップ・ダイアログ・エラーメッセージすべて選択言語で表示される

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)