### PR TITLE
DPIスケーリングの問題を修正

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -2,6 +2,7 @@ using Microsoft.UI.Xaml;
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 
 namespace XTimelineViewer
@@ -10,8 +11,13 @@ namespace XTimelineViewer
     {
         private Window? _window;
 
+        [DllImport("user32.dll")]
+        private static extern bool SetProcessDpiAwarenessContext(IntPtr dpiContext);
+        private static readonly IntPtr DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 = new IntPtr(-4);
+
         public App()
         {
+            SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
             this.InitializeComponent();
         }
 


### PR DESCRIPTION
DPIスケーリングが100%以外に設定されている環境で、以下の問題が発生していました。

- マウスホイールのスクロールが意図しないカラムに反映される
- マウスホイールが全く反応しない

125%・150%・200%のスケーリング設定で確認済みです。マルチモニター環境でも同様に発生します。

`App.xaml.cs` で `SetProcessDpiAwarenessContext` を使いDPI認識モードを明示的に `PerMonitorV2` に設定することで解決しました。