### PR TITLE
feat: タイムライン設定にページヘッダー非表示トグルを追加

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -17,10 +17,11 @@ namespace XTimelineViewer
 {
     internal class TimelineConfig
     {
-        public string Url        { get; set; } = "";
-        public double Width      { get; set; } = 350;
-        public bool   HideHeader  { get; set; } = false;
-        public bool   HideCompose { get; set; } = true;
+        public string Url            { get; set; } = "";
+        public double Width          { get; set; } = 350;
+        public bool   HideHeader     { get; set; } = false;
+        public bool   HideCompose    { get; set; } = true;
+        public bool   HideListHeader { get; set; } = false;
     }
 
     internal class AppSettings
@@ -999,6 +1000,21 @@ namespace XTimelineViewer
                     OffContent = R.Get("Toggle_Show")
                 };
 
+                var listHeaderApplicable = IsListHeaderApplicable(cfg.Url);
+                var hideListHeaderToggle = new ToggleSwitch
+                {
+                    IsOn       = cfg.HideListHeader,
+                    IsEnabled  = listHeaderApplicable,
+                    OnContent  = R.Get("Toggle_Hide"),
+                    OffContent = R.Get("Toggle_Show")
+                };
+                var hideListHeaderLabel = new TextBlock
+                {
+                    Text    = R.Get("Timeline_ListHeader"),
+                    Margin  = new Thickness(0, 8, 0, 0),
+                    Opacity = listHeaderApplicable ? 1.0 : 0.4
+                };
+
                 var panel = new StackPanel { Spacing = 8 };
                 panel.Children.Add(new TextBlock { Text = R.Get("Timeline_Width") });
                 panel.Children.Add(widthBox);
@@ -1014,6 +1030,8 @@ namespace XTimelineViewer
                     Margin = new Thickness(0, 8, 0, 0)
                 });
                 panel.Children.Add(hideComposeToggle);
+                panel.Children.Add(hideListHeaderLabel);
+                panel.Children.Add(hideListHeaderToggle);
 
                 var dlg = new ContentDialog
                 {
@@ -1037,6 +1055,10 @@ namespace XTimelineViewer
                     cfg.HideCompose = hideComposeToggle.IsOn;
                     if (webView.CoreWebView2 is not null)
                         await ApplyHideComposeAsync(webView, cfg.HideCompose);
+
+                    cfg.HideListHeader = hideListHeaderToggle.IsOn;
+                    if (webView.CoreWebView2 is not null)
+                        await ApplyHideListHeaderAsync(webView, cfg.HideListHeader);
 
                     await SaveTimelinesAsync();
                 }
@@ -1070,6 +1092,61 @@ namespace XTimelineViewer
         }
 
         // ── WebView2 init ─────────────────────────────────────────────────────
+
+        private static bool IsListHeaderApplicable(string url)
+        {
+            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return false;
+            var p = uri.AbsolutePath;
+            return p.StartsWith("/notifications") ||
+                   p.StartsWith("/search")        ||
+                   p.StartsWith("/explore")       ||
+                   p == "/bookmarks" || p.StartsWith("/bookmarks/") ||
+                   p == "/i/bookmarks" || p.StartsWith("/i/bookmarks/") ||
+                   p.StartsWith("/i/lists/");
+        }
+
+        private static string BuildHideListHeaderJs(bool hide) => $$"""
+            (function(hide){
+                var id='xtv-hide-list-header';
+                var s=document.getElementById(id);
+                if(hide){
+                    var path=window.location.pathname;
+                    var css=[];
+                    // 通知: 「通知」タイトル＋設定ギアを含むヘッダーブロックを非表示
+                    // 直接子セレクタで深さを固定し、全祖先にマッチしないよう限定する
+                    if(/^\/notifications/.test(path))
+                        css.push('div:has(>div>div>div>div>div>a[data-testid="settingsAppBar"]){display:none!important}');
+                    // 検索: 検索ボックス＋戻るボタンを含むヘッダーブロックを非表示
+                    if(/^\/(search|explore)/.test(path))
+                        css.push('div:has(>div>div>div>div>div>button[data-testid="app-bar-back"]){display:none!important}');
+                    // リスト: 上部ナビバー＋リスト情報カード（バナー・作成者・メンバー数）を非表示
+                    if(/^\/i\/lists\//.test(path)){
+                        css.push('div:has(>div>div>div>div>div>button[data-testid="app-bar-back"]){display:none!important}');
+                        css.push('[data-testid="cellInnerDiv"]:has(a[href*="/i/lists/"][href$="/members"]){display:none!important}');
+                    }
+                    // ブックマーク: 上部ナビバー＋nth-child(1)ブロック＋空フォルダの説明文を非表示
+                    if(/^\/(i\/bookmarks|bookmarks)/.test(path)){
+                        css.push('div:has(>div>div>div>div>div>button[data-testid="app-bar-back"]){display:none!important}');
+                        css.push('#react-root main section>div>div>div:nth-child(1){display:none!important}');
+                        css.push('[data-testid="emptyState"]{display:none!important}');
+                    }
+                    if(css.length){
+                        if(!s){s=document.createElement('style');s.id=id;document.head.appendChild(s);}
+                        s.textContent=css.join('');
+                    }else{
+                        if(s)s.remove();
+                    }
+                }else{
+                    if(s)s.remove();
+                }
+            })({{(hide ? "true" : "false")}});
+            """;
+
+        private static async Task ApplyHideListHeaderAsync(
+            Microsoft.UI.Xaml.Controls.WebView2 webView, bool hide)
+        {
+            await webView.CoreWebView2.ExecuteScriptAsync(BuildHideListHeaderJs(hide));
+        }
 
         private static string BuildHideHeaderJs(bool hide) => $$"""
             (function(hide){
@@ -1360,6 +1437,7 @@ namespace XTimelineViewer
                 {
                     await ApplyHideHeaderAsync(webView, cfg.HideHeader);
                     await ApplyHideComposeAsync(webView, EffectiveHideCompose(cfg, webView.CoreWebView2.Source));
+                    await ApplyHideListHeaderAsync(webView, cfg.HideListHeader);
 
                     // TweetInterceptScript のフラグを設定と同期する
                     var flag = _appSettings.OpenTweetInBrowser ? "true" : "false";
@@ -1379,6 +1457,8 @@ namespace XTimelineViewer
             {
                 if (cfg.HideCompose)
                     await ApplyHideComposeAsync(webView, EffectiveHideCompose(cfg, webView.CoreWebView2.Source));
+                if (cfg.HideListHeader)
+                    await ApplyHideListHeaderAsync(webView, cfg.HideListHeader);
             };
 
             webView.Source = new Uri(cfg.Url);

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -55,6 +55,7 @@
   <data name="Timeline_Width" xml:space="preserve"><value>Timeline Width (px)</value></data>
   <data name="Timeline_Header" xml:space="preserve"><value>X Header Element</value></data>
   <data name="Timeline_Compose" xml:space="preserve"><value>Compose Area</value></data>
+  <data name="Timeline_ListHeader" xml:space="preserve"><value>Notifications / Search / Bookmarks / List Header</value></data>
   <data name="Pane_Settings_Tooltip" xml:space="preserve"><value>Settings</value></data>
   <data name="Pane_Close_Tooltip" xml:space="preserve"><value>Close</value></data>
   <data name="DragCaption" xml:space="preserve"><value>Add Timeline</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -55,6 +55,7 @@
   <data name="Timeline_Width" xml:space="preserve"><value>タイムラインの幅（px）</value></data>
   <data name="Timeline_Header" xml:space="preserve"><value>X の header 要素</value></data>
   <data name="Timeline_Compose" xml:space="preserve"><value>投稿画面</value></data>
+  <data name="Timeline_ListHeader" xml:space="preserve"><value>通知・検索・ブックマーク・リストのヘッダー</value></data>
   <data name="Pane_Settings_Tooltip" xml:space="preserve"><value>設定</value></data>
   <data name="Pane_Close_Tooltip" xml:space="preserve"><value>閉じる</value></data>
   <data name="DragCaption" xml:space="preserve"><value>タイムラインを追加</value></data>


### PR DESCRIPTION
Closes #26

## 概要

通知・検索・ブックマーク・リストページのヘッダーを、タイムラインごとに非表示にできるトグルスイッチを設定ダイアログに追加しました。

<img width="1152" height="864" alt="スクリーンショット 2026-05-16 130331" src="https://github.com/user-attachments/assets/3d7121c2-9cc8-4dd8-b4ad-4d17794bb5ca" />

## 変更内容

- `TimelineConfig` に `HideListHeader` プロパティを追加（JSON シリアライズ対応、既存データは `false` にフォールバック）
- 設定ダイアログに「通知・検索・ブックマーク・リストのヘッダー」トグルを追加
- `BuildHideListHeaderJs`: `window.location.pathname` で URL を判定し、ページごとに適切な CSS を動的注入
  - 通知 (`/notifications`): `data-testid="settingsAppBar"` を含むナビバー
  - 検索・探索 (`/search`, `/explore`): `data-testid="app-bar-back"` を含むナビバー
  - ブックマーク (`/bookmarks`, `/i/bookmarks`): ナビバー・リスト先頭ブロック・空フォルダ説明文 (`emptyState`)
  - リスト (`/i/lists/*`): ナビバー・リスト情報カード（バナー・作成者・メンバー数）
- SPA 対応: `NavigationCompleted` と `SourceChanged` の両方で CSS を再適用
- ホームタイムラインなど非対象 URL では、トグルとラベルをグレーアウト表示 (`IsEnabled = false` / `Opacity = 0.4`)

## 動作確認

- [x] 通知タイムラインでトグルをオン → 「通知」タイトル＋設定ギアが消える
- [x] 検索タイムラインでトグルをオン → 検索ボックス＋戻るボタンエリアが消える
- [x] ブックマークタイムラインでトグルをオン → ナビバー＋空フォルダ説明文が消える
- [x] リストタイムラインでトグルをオン → ナビバー＋リスト情報カードが消える
- [x] ホームタイムラインではトグルがグレーアウト
- [x] アプリ再起動後も設定が保持される (`timelines.json` の `HideListHeader` フィールド)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

スイッチオフ

<img width="1152" height="864" alt="スクリーンショット 2026-05-16 130340" src="https://github.com/user-attachments/assets/22e498f2-50a5-41f4-b5f2-709d233be993" />

スイッチオン


<img width="1152" height="864" alt="スクリーンショット 2026-05-16 130325" src="https://github.com/user-attachments/assets/ae2a1f73-06c6-41f3-8f06-adaf35d754d3" />
