### PR TITLE
refactor: HideHeader を HideSidebar に改名

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -19,7 +19,7 @@ namespace XTimelineViewer
     {
         public string Url            { get; set; } = "";
         public double Width          { get; set; } = 350;
-        public bool   HideHeader     { get; set; } = false;
+        public bool   HideSidebar    { get; set; } = false;
         public bool   HideCompose    { get; set; } = true;
         public bool   HideListHeader { get; set; } = false;
     }
@@ -986,9 +986,9 @@ namespace XTimelineViewer
                     Width                   = 160
                 };
 
-                var hideHeaderToggle = new ToggleSwitch
+                var hideSidebarToggle = new ToggleSwitch
                 {
-                    IsOn       = cfg.HideHeader,
+                    IsOn       = cfg.HideSidebar,
                     OnContent  = R.Get("Toggle_Hide"),
                     OffContent = R.Get("Toggle_Show")
                 };
@@ -1020,10 +1020,10 @@ namespace XTimelineViewer
                 panel.Children.Add(widthBox);
                 panel.Children.Add(new TextBlock
                 {
-                    Text   = R.Get("Timeline_Header"),
+                    Text   = R.Get("Timeline_Sidebar"),
                     Margin = new Thickness(0, 8, 0, 0)
                 });
-                panel.Children.Add(hideHeaderToggle);
+                panel.Children.Add(hideSidebarToggle);
                 panel.Children.Add(new TextBlock
                 {
                     Text   = R.Get("Timeline_Compose"),
@@ -1048,9 +1048,9 @@ namespace XTimelineViewer
                     cfg.Width  = Math.Clamp(widthBox.Value, 100, 2000);
                     pane.Width = cfg.Width;
 
-                    cfg.HideHeader = hideHeaderToggle.IsOn;
+                    cfg.HideSidebar = hideSidebarToggle.IsOn;
                     if (webView.CoreWebView2 is not null)
-                        await ApplyHideHeaderAsync(webView, cfg.HideHeader);
+                        await ApplyHideSidebarAsync(webView, cfg.HideSidebar);
 
                     cfg.HideCompose = hideComposeToggle.IsOn;
                     if (webView.CoreWebView2 is not null)
@@ -1148,9 +1148,9 @@ namespace XTimelineViewer
             await webView.CoreWebView2.ExecuteScriptAsync(BuildHideListHeaderJs(hide));
         }
 
-        private static string BuildHideHeaderJs(bool hide) => $$"""
+        private static string BuildHideSidebarJs(bool hide) => $$"""
             (function(hide){
-                var id='xtv-hide-header';
+                var id='xtv-hide-sidebar';
                 var s=document.getElementById(id);
                 if(hide){
                     if(!s){s=document.createElement('style');s.id=id;
@@ -1162,10 +1162,10 @@ namespace XTimelineViewer
             })({{(hide ? "true" : "false")}});
             """;
 
-        private static async Task ApplyHideHeaderAsync(
+        private static async Task ApplyHideSidebarAsync(
             Microsoft.UI.Xaml.Controls.WebView2 webView, bool hide)
         {
-            await webView.CoreWebView2.ExecuteScriptAsync(BuildHideHeaderJs(hide));
+            await webView.CoreWebView2.ExecuteScriptAsync(BuildHideSidebarJs(hide));
         }
 
         private static async Task ApplyAutoShowNewPostsAsync(WebView2 webView, string cfgUrl)
@@ -1435,7 +1435,7 @@ namespace XTimelineViewer
             {
                 if (args.IsSuccess)
                 {
-                    await ApplyHideHeaderAsync(webView, cfg.HideHeader);
+                    await ApplyHideSidebarAsync(webView, cfg.HideSidebar);
                     await ApplyHideComposeAsync(webView, EffectiveHideCompose(cfg, webView.CoreWebView2.Source));
                     await ApplyHideListHeaderAsync(webView, cfg.HideListHeader);
 

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -53,7 +53,7 @@
   <!-- Timeline pane settings dialog -->
   <data name="Timeline_Settings_Title" xml:space="preserve"><value>Settings</value></data>
   <data name="Timeline_Width" xml:space="preserve"><value>Timeline Width (px)</value></data>
-  <data name="Timeline_Header" xml:space="preserve"><value>X Header Element</value></data>
+  <data name="Timeline_Sidebar" xml:space="preserve"><value>X Sidebar</value></data>
   <data name="Timeline_Compose" xml:space="preserve"><value>Compose Area</value></data>
   <data name="Timeline_ListHeader" xml:space="preserve"><value>Notifications / Search / Bookmarks / List Header</value></data>
   <data name="Pane_Settings_Tooltip" xml:space="preserve"><value>Settings</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -53,7 +53,7 @@
   <!-- Timeline pane settings dialog -->
   <data name="Timeline_Settings_Title" xml:space="preserve"><value>設定</value></data>
   <data name="Timeline_Width" xml:space="preserve"><value>タイムラインの幅（px）</value></data>
-  <data name="Timeline_Header" xml:space="preserve"><value>X の header 要素</value></data>
+  <data name="Timeline_Sidebar" xml:space="preserve"><value>X のサイドバー</value></data>
   <data name="Timeline_Compose" xml:space="preserve"><value>投稿画面</value></data>
   <data name="Timeline_ListHeader" xml:space="preserve"><value>通知・検索・ブックマーク・リストのヘッダー</value></data>
   <data name="Pane_Settings_Tooltip" xml:space="preserve"><value>設定</value></data>


### PR DESCRIPTION
Closes #33

## 概要

`HideHeader` と `HideListHeader` の名前の紛らわしさを解消するため、サイドバー非表示オプションを `HideSidebar` に改名しました。

## 変更内容

| 変更前 | 変更後 |
|--------|--------|
| `TimelineConfig.HideHeader` | `TimelineConfig.HideSidebar` |
| `hideHeaderToggle` | `hideSidebarToggle` |
| `BuildHideHeaderJs` | `BuildHideSidebarJs` |
| `ApplyHideHeaderAsync` | `ApplyHideSidebarAsync` |
| style id: `xtv-hide-header` | `xtv-hide-sidebar` |
| リソースキー: `Timeline_Header` | `Timeline_Sidebar` |
| en-US: "X Header Element" | "X Sidebar" |
| ja-JP: "X の header 要素" | "X のサイドバー" |

## 注意

既存の `timelines.json` に保存された `"HideHeader": true` は読み込まれず、`false`（デフォルト）にリセットされます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)