### PR TITLE
fix: プロフィールページでヘッダー非表示トグルを有効化

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1166,10 +1166,12 @@ namespace XTimelineViewer
                         css.push('#react-root main section>div>div>div:nth-child(1){display:none!important}');
                         css.push('[data-testid="emptyState"]{display:none!important}');
                     }
-                    // プロフィール: ユーザー名＋ポスト数を含むヘッダーブロックを非表示
+                    // プロフィール: ナビバー＋プロフィール情報カード（バナー・アバター・自己紹介・フォロー数）を非表示
                     if(/^\/[A-Za-z0-9_]+$/.test(path) &&
-                       !/^\/(home|notifications|search|explore|bookmarks|messages|i)/.test(path))
+                       !/^\/(home|notifications|search|explore|bookmarks|messages|i)/.test(path)){
                         css.push('div:has(>div>div>div>div>div>button[data-testid="app-bar-back"]){display:none!important}');
+                        css.push('[data-testid="cellInnerDiv"]:has([data-testid="UserName"]){display:none!important}');
+                    }
                     if(css.length){
                         if(!s){s=document.createElement('style');s.id=id;document.head.appendChild(s);}
                         s.textContent=css.join('');

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1121,6 +1121,13 @@ namespace XTimelineViewer
             return ""; // Globe
         }
 
+        private static bool IsProfilePath(string p) =>
+            System.Text.RegularExpressions.Regex.IsMatch(p, @"^/[A-Za-z0-9_]+$") &&
+            !p.StartsWith("/home") && !p.StartsWith("/notifications") &&
+            !p.StartsWith("/search") && !p.StartsWith("/explore") &&
+            !p.StartsWith("/bookmarks") && !p.StartsWith("/messages") &&
+            !p.StartsWith("/i/");
+
         private static bool IsListHeaderApplicable(string url)
         {
             if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return false;
@@ -1130,7 +1137,8 @@ namespace XTimelineViewer
                    p.StartsWith("/explore")       ||
                    p == "/bookmarks" || p.StartsWith("/bookmarks/") ||
                    p == "/i/bookmarks" || p.StartsWith("/i/bookmarks/") ||
-                   p.StartsWith("/i/lists/");
+                   p.StartsWith("/i/lists/")      ||
+                   IsProfilePath(p);
         }
 
         private static string BuildHideListHeaderJs(bool hide) => $$"""
@@ -1158,6 +1166,10 @@ namespace XTimelineViewer
                         css.push('#react-root main section>div>div>div:nth-child(1){display:none!important}');
                         css.push('[data-testid="emptyState"]{display:none!important}');
                     }
+                    // プロフィール: ユーザー名＋ポスト数を含むヘッダーブロックを非表示
+                    if(/^\/[A-Za-z0-9_]+$/.test(path) &&
+                       !/^\/(home|notifications|search|explore|bookmarks|messages|i)/.test(path))
+                        css.push('div:has(>div>div>div>div>div>button[data-testid="app-bar-back"]){display:none!important}');
                     if(css.length){
                         if(!s){s=document.createElement('style');s.id=id;document.head.appendChild(s);}
                         s.textContent=css.join('');

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1170,7 +1170,7 @@ namespace XTimelineViewer
                     if(/^\/[A-Za-z0-9_]+$/.test(path) &&
                        !/^\/(home|notifications|search|explore|bookmarks|messages|i)/.test(path)){
                         css.push('div:has(>div>div>div>div>div>button[data-testid="app-bar-back"]){display:none!important}');
-                        css.push('[data-testid="cellInnerDiv"]:has([data-testid="UserName"]){display:none!important}');
+                        css.push('div:has(>a[href$="/header_photo"]){display:none!important}');
                     }
                     if(css.length){
                         if(!s){s=document.createElement('style');s.id=id;document.head.appendChild(s);}


### PR DESCRIPTION
Closes #26

## 問題

`/@username` 形式のプロフィールページで「通知・検索・ブックマーク・リストのヘッダー」トグルがグレーアウトされており操作できなかった。

## 原因

1. `IsListHeaderApplicable()` にプロフィール URL パターンが含まれていなかった → トグルが `IsEnabled = false`
2. `BuildHideListHeaderJs()` にプロフィールページ用の CSS ルールがなかった

## 変更内容

- `IsProfilePath(string p)` ヘルパーを追加
  - `^/[A-Za-z0-9_]+$` にマッチする単一パスセグメント
  - `/home`・`/notifications`・`/search` 等のシステムパスを除外
- `IsListHeaderApplicable()` に `IsProfilePath()` を追加してトグルを有効化
- `BuildHideListHeaderJs()` にプロフィールページ用 CSS ルールを追加
  - 他ページと同じ `app-bar-back` 深さ固定セレクタを使用

## 動作確認

- [ ] `x.com/username` タイムラインでトグルがグレーアウトされないことを確認
- [ ] トグルをオンにしてヘッダー（ユーザー名＋ポスト数）が消えることを確認
- [ ] `x.com/home` ではトグルが引き続きグレーアウトであることを確認

> セレクタの DOM 深さが実際と異なる場合はヘッダーの HTML をご提供ください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)