### PR TITLE
feat: タイムラインの閉じるボタンを設定ダイアログに移動 (#45)

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -882,15 +882,7 @@ namespace XTimelineViewer
             };
             ToolTipService.SetToolTip(settingsBtn, R.Get("Pane_Settings_Tooltip"));
 
-            var closeBtn = new Button
-            {
-                Content = "✕", Width = 28, Height = 26,
-                Padding = new Thickness(0), FontSize = 11
-            };
-            ToolTipService.SetToolTip(closeBtn, R.Get("Pane_Close_Tooltip"));
-
             buttonPanel.Children.Add(settingsBtn);
-            buttonPanel.Children.Add(closeBtn);
 
             headerGrid.Children.Add(typeIcon);
             headerGrid.Children.Add(urlLabel);
@@ -1019,6 +1011,14 @@ namespace XTimelineViewer
                     Opacity = listHeaderApplicable ? 1.0 : 0.4
                 };
 
+                var deleteBtn = new Button
+                {
+                    Content             = R.Get("Pane_Delete"),
+                    HorizontalAlignment = HorizontalAlignment.Stretch,
+                    Margin              = new Thickness(0, 16, 0, 0),
+                    Foreground          = new SolidColorBrush(Color.FromArgb(255, 196, 43, 28)),
+                };
+
                 var panel = new StackPanel { Spacing = 8 };
                 panel.Children.Add(new TextBlock { Text = R.Get("Timeline_Width") });
                 panel.Children.Add(widthBox);
@@ -1036,6 +1036,8 @@ namespace XTimelineViewer
                 panel.Children.Add(hideComposeToggle);
                 panel.Children.Add(hideListHeaderLabel);
                 panel.Children.Add(hideListHeaderToggle);
+                panel.Children.Add(new NavigationViewItemSeparator { Margin = new Thickness(0, 8, 0, 0) });
+                panel.Children.Add(deleteBtn);
 
                 var dlg = new ContentDialog
                 {
@@ -1047,7 +1049,33 @@ namespace XTimelineViewer
                     XamlRoot          = Content.XamlRoot
                 };
 
-                if (await dlg.ShowAsync() == ContentDialogResult.Primary)
+                bool shouldDelete = false;
+                deleteBtn.Click += (_, _) => { shouldDelete = true; dlg.Hide(); };
+
+                var result = await dlg.ShowAsync();
+
+                if (shouldDelete)
+                {
+                    _configs.Remove(cfg);
+                    _webViews.Remove(webView);
+                    _webViewToPane.Remove(webView);
+                    _paneToSetFocus.Remove(pane);
+                    _headerRefreshers.Remove(refreshHeader);
+                    if (_focusedHeaderGrid == headerGrid)
+                    {
+                        _focusedHeaderGrid = null;
+                        foreach (var r in _headerRefreshers) r();
+                    }
+                    await SaveTimelinesAsync();
+
+                    TimelinePanel.Children.Remove(pane);
+                    if (TimelinePanel.Children.Count == 0)
+                    {
+                        TimelineScroll.Visibility = Visibility.Collapsed;
+                        DropHintBorder.Visibility = Visibility.Visible;
+                    }
+                }
+                else if (result == ContentDialogResult.Primary)
                 {
                     cfg.Width  = Math.Clamp(widthBox.Value, 100, 2000);
                     pane.Width = cfg.Width;
@@ -1065,30 +1093,6 @@ namespace XTimelineViewer
                         await ApplyHideListHeaderAsync(webView, cfg.HideListHeader);
 
                     await SaveTimelinesAsync();
-                }
-            };
-
-            // ── Close ─────────────────────────────────────────────────────────
-
-            closeBtn.Click += (s, e) =>
-            {
-                _configs.Remove(cfg);
-                _webViews.Remove(webView);
-                _webViewToPane.Remove(webView);
-                _paneToSetFocus.Remove(pane);
-                _headerRefreshers.Remove(refreshHeader);
-                if (_focusedHeaderGrid == headerGrid)
-                {
-                    _focusedHeaderGrid = null;
-                    foreach (var r in _headerRefreshers) r();
-                }
-                _ = SaveTimelinesAsync();
-
-                TimelinePanel.Children.Remove(pane);
-                if (TimelinePanel.Children.Count == 0)
-                {
-                    TimelineScroll.Visibility  = Visibility.Collapsed;
-                    DropHintBorder.Visibility  = Visibility.Visible;
                 }
             };
 

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -58,6 +58,7 @@
   <data name="Timeline_ListHeader" xml:space="preserve"><value>Notifications / Search / Bookmarks / List Header</value></data>
   <data name="Pane_Settings_Tooltip" xml:space="preserve"><value>Settings</value></data>
   <data name="Pane_Close_Tooltip" xml:space="preserve"><value>Close</value></data>
+  <data name="Pane_Delete" xml:space="preserve"><value>Remove This Timeline</value></data>
   <data name="DragCaption" xml:space="preserve"><value>Add Timeline</value></data>
 
   <!-- Error dialogs -->

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -58,6 +58,7 @@
   <data name="Timeline_ListHeader" xml:space="preserve"><value>通知・検索・ブックマーク・リストのヘッダー</value></data>
   <data name="Pane_Settings_Tooltip" xml:space="preserve"><value>設定</value></data>
   <data name="Pane_Close_Tooltip" xml:space="preserve"><value>閉じる</value></data>
+  <data name="Pane_Delete" xml:space="preserve"><value>このタイムラインを削除</value></data>
   <data name="DragCaption" xml:space="preserve"><value>タイムラインを追加</value></data>
 
   <!-- Error dialogs -->


### PR DESCRIPTION
## Summary

- ヘッダーの「✕」閉じるボタンを廃止
- 設定ダイアログ下部にセパレーターを挟んで赤字の「このタイムラインを削除」ボタンを追加
- 削除ボタンを押すとダイアログを閉じてからタイムラインを除去する（`shouldDelete` フラグ方式）

## Test plan

- [ ] ヘッダーに閉じるボタンがなくなっていることを確認
- [ ] 設定ダイアログ下部に赤字の削除ボタンが表示されることを確認
- [ ] 削除ボタンでタイムラインが正しく除去されることを確認
- [ ] 「適用」「キャンセル」は従来通り動作することを確認

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)