### PR TITLE
feat: ポインター乗せ中に定期ハードリロードを一時停止し状態をツールチップに表示

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1199,19 +1199,19 @@ namespace XTimelineViewer
         {
             if (!_hardReloadTimers.TryGetValue(wv, out var t))
             {
-                tooltip.Content = "⏹ 定期ハードリロード無効";
+                tooltip.Content = R.Get("HardReload_Disabled");
                 return;
             }
             if (!t.IsEnabled)
             {
-                tooltip.Content = "⏸ 定期ハードリロード一時停止中";
+                tooltip.Content = R.Get("HardReload_Paused");
                 return;
             }
             if (_hardReloadStartTimes.TryGetValue(wv, out var start))
             {
                 var remaining = t.Interval - (DateTimeOffset.Now - start);
                 tooltip.Content = remaining > TimeSpan.Zero
-                    ? $"🔄 定期ハードリロード有効: ⏱ 残り {(int)remaining.TotalMinutes}:{remaining.Seconds:D2}"
+                    ? string.Format(R.Get("HardReload_Active"), (int)remaining.TotalMinutes, remaining.Seconds.ToString("D2"))
                     : null;
             }
         }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1199,19 +1199,19 @@ namespace XTimelineViewer
         {
             if (!_hardReloadTimers.TryGetValue(wv, out var t))
             {
-                tooltip.Content = null;
+                tooltip.Content = "⏹ 定期ハードリロード無効";
                 return;
             }
             if (!t.IsEnabled)
             {
-                tooltip.Content = "⏸ リロード一時停止中";
+                tooltip.Content = "⏸ 定期ハードリロード一時停止中";
                 return;
             }
             if (_hardReloadStartTimes.TryGetValue(wv, out var start))
             {
                 var remaining = t.Interval - (DateTimeOffset.Now - start);
                 tooltip.Content = remaining > TimeSpan.Zero
-                    ? $"⏱ 残り {(int)remaining.TotalMinutes}:{remaining.Seconds:D2} でリロード"
+                    ? $"🔄 定期ハードリロード有効: ⏱ 残り {(int)remaining.TotalMinutes}:{remaining.Seconds:D2}"
                     : null;
             }
         }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -108,7 +108,10 @@ namespace XTimelineViewer
         private CoreWebView2Environment? _composeEnv;
         private readonly Dictionary<WebView2, Grid>            _webViewToPane  = [];
         private readonly Dictionary<Grid, Action>              _paneToSetFocus = [];
-        private readonly Dictionary<WebView2, DispatcherTimer> _hardReloadTimers = [];
+        private readonly Dictionary<WebView2, DispatcherTimer>  _hardReloadTimers    = [];
+        private readonly Dictionary<WebView2, DateTimeOffset>   _hardReloadStartTimes = [];
+        private readonly Dictionary<WebView2, Action>           _hardReloadUiUpdaters = [];
+        private DispatcherTimer? _hardReloadUiTimer;
         private DispatcherTimer? _autoActivateTimer;
 
         // キーボードショートカット処理スクリプト（各 WebView2 に注入）
@@ -858,6 +861,8 @@ namespace XTimelineViewer
                 VerticalAlignment = VerticalAlignment.Center
             };
             Grid.SetColumn(typeIcon, 0);
+            var hardReloadTooltip = new ToolTip();
+            ToolTipService.SetToolTip(typeIcon, hardReloadTooltip);
 
             var urlLabel = new TextBlock
             {
@@ -930,6 +935,11 @@ namespace XTimelineViewer
                 _focusedHeaderGrid = headerGrid;
                 foreach (var r in _headerRefreshers) r();
             };
+            webView.PointerEntered += (s, e) => PauseHardReloadTimer(webView);
+            webView.PointerExited  += (s, e) => ResumeHardReloadTimer(webView);
+
+            _hardReloadUiUpdaters[webView] = () => UpdateHardReloadTooltip(webView, hardReloadTooltip);
+            EnsureHardReloadUiTimer();
 
             // ── Drag & Drop reorder ───────────────────────────────────────────
 
@@ -1095,6 +1105,13 @@ namespace XTimelineViewer
                 if (shouldDelete)
                 {
                     StopHardReloadTimer(webView);
+                    _hardReloadUiUpdaters.Remove(webView);
+                    _hardReloadStartTimes.Remove(webView);
+                    if (_hardReloadUiUpdaters.Count == 0)
+                    {
+                        _hardReloadUiTimer?.Stop();
+                        _hardReloadUiTimer = null;
+                    }
                     _configs.Remove(cfg);
                     _webViews.Remove(webView);
                     _webViewToPane.Remove(webView);
@@ -1148,7 +1165,12 @@ namespace XTimelineViewer
             if (!cfg.HardReloadEnabled) return;
 
             var timer = new DispatcherTimer { Interval = TimeSpan.FromMinutes(cfg.HardReloadInterval) };
-            timer.Tick += (_, _) => wv.CoreWebView2?.Reload();
+            timer.Tick += (_, _) =>
+            {
+                wv.CoreWebView2?.Reload();
+                _hardReloadStartTimes[wv] = DateTimeOffset.Now;
+            };
+            _hardReloadStartTimes[wv] = DateTimeOffset.Now;
             timer.Start();
             _hardReloadTimers[wv] = timer;
         }
@@ -1156,6 +1178,53 @@ namespace XTimelineViewer
         private void StopHardReloadTimer(WebView2 wv)
         {
             if (_hardReloadTimers.Remove(wv, out var t)) t.Stop();
+            _hardReloadStartTimes.Remove(wv);
+        }
+
+        private void PauseHardReloadTimer(WebView2 wv)
+        {
+            if (_hardReloadTimers.TryGetValue(wv, out var t)) t.Stop();
+        }
+
+        private void ResumeHardReloadTimer(WebView2 wv)
+        {
+            if (_hardReloadTimers.TryGetValue(wv, out var t))
+            {
+                _hardReloadStartTimes[wv] = DateTimeOffset.Now;
+                t.Start();
+            }
+        }
+
+        private void UpdateHardReloadTooltip(WebView2 wv, ToolTip tooltip)
+        {
+            if (!_hardReloadTimers.TryGetValue(wv, out var t))
+            {
+                tooltip.Content = null;
+                return;
+            }
+            if (!t.IsEnabled)
+            {
+                tooltip.Content = "⏸ リロード一時停止中";
+                return;
+            }
+            if (_hardReloadStartTimes.TryGetValue(wv, out var start))
+            {
+                var remaining = t.Interval - (DateTimeOffset.Now - start);
+                tooltip.Content = remaining > TimeSpan.Zero
+                    ? $"⏱ 残り {(int)remaining.TotalMinutes}:{remaining.Seconds:D2} でリロード"
+                    : null;
+            }
+        }
+
+        private void EnsureHardReloadUiTimer()
+        {
+            if (_hardReloadUiTimer is not null) return;
+            _hardReloadUiTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+            _hardReloadUiTimer.Tick += (_, _) =>
+            {
+                foreach (var (wv, update) in _hardReloadUiUpdaters) update();
+            };
+            _hardReloadUiTimer.Start();
         }
 
         // ── WebView2 init ─────────────────────────────────────────────────────

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -57,6 +57,9 @@
   <data name="Timeline_Compose" xml:space="preserve"><value>Compose Area</value></data>
   <data name="Timeline_ListHeader" xml:space="preserve"><value>Notifications / Search / Bookmarks / List Header</value></data>
   <data name="Timeline_ReloadInterval" xml:space="preserve"><value>Auto-Reload Interval (min, 0 to disable)</value></data>
+  <data name="HardReload_Active" xml:space="preserve"><value>🔄 Auto-Reload On: ⏱ {0}:{1} remaining</value></data>
+  <data name="HardReload_Paused" xml:space="preserve"><value>⏸ Auto-Reload Paused</value></data>
+  <data name="HardReload_Disabled" xml:space="preserve"><value>⏹ Auto-Reload Off</value></data>
   <data name="Pane_Settings_Tooltip" xml:space="preserve"><value>Settings</value></data>
   <data name="Pane_Close_Tooltip" xml:space="preserve"><value>Close</value></data>
   <data name="Pane_Delete" xml:space="preserve"><value>Remove This Timeline</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -57,6 +57,9 @@
   <data name="Timeline_Compose" xml:space="preserve"><value>投稿画面</value></data>
   <data name="Timeline_ListHeader" xml:space="preserve"><value>通知・検索・ブックマーク・リストのヘッダー</value></data>
   <data name="Timeline_ReloadInterval" xml:space="preserve"><value>定期リロード間隔（分、0 で無効）</value></data>
+  <data name="HardReload_Active" xml:space="preserve"><value>🔄 定期ハードリロード有効: ⏱ 残り {0}:{1}</value></data>
+  <data name="HardReload_Paused" xml:space="preserve"><value>⏸ 定期ハードリロード一時停止中</value></data>
+  <data name="HardReload_Disabled" xml:space="preserve"><value>⏹ 定期ハードリロード無効</value></data>
   <data name="Pane_Settings_Tooltip" xml:space="preserve"><value>設定</value></data>
   <data name="Pane_Close_Tooltip" xml:space="preserve"><value>閉じる</value></data>
   <data name="Pane_Delete" xml:space="preserve"><value>このタイムラインを削除</value></data>


### PR DESCRIPTION
closes #57

## 変更内容

### 一時停止・再開
- `WebView2.PointerEntered` → `PauseHardReloadTimer`（`DispatcherTimer.Stop()`、辞書は保持）
- `WebView2.PointerExited` → `ResumeHardReloadTimer`（`DispatcherTimer.Start()`、カウントリセット）

### 状態インジケーター
- `typeIcon`（ヘッダー左アイコン）に `ToolTip` を設定
- 1 秒ごとに更新するグローバル `DispatcherTimer`（`_hardReloadUiTimer`）で全タイムラインのツールチップを一括更新
  - アクティブ: `⏱ 残り M:SS でリロード`
  - 一時停止中: `⏸ リロード一時停止中`
  - 無効: ツールチップなし

### 残り時間の計算
- `_hardReloadStartTimes: Dictionary<WebView2, DateTimeOffset>` で開始時刻を記録
- `timer.Interval - (Now - startTime)` で残り時間を算出
- タイマーの Tick（リロード実行時）にも開始時刻を更新

### タイムライン削除時
- `_hardReloadUiUpdaters` / `_hardReloadStartTimes` から除去
- 全タイムライン削除後は `_hardReloadUiTimer` を停止・null 化