### PR TITLE
feat: 設定ボタンをハンバーガーメニューに変更し About ダイアログを分離

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -37,9 +37,17 @@
                         Spacing="4"
                         HorizontalAlignment="Right"
                         VerticalAlignment="Center">
-                <Button x:Name="AppSettingsBtn" Width="32" Height="32" Padding="0" FontSize="14"
-                        Click="AppSettingsBtn_Click">
-                    <FontIcon Glyph="&#xE713;" FontFamily="Segoe Fluent Icons" FontSize="14"/>
+                <Button x:Name="AppMenuBtn" Width="32" Height="32" Padding="0" FontSize="14">
+                    <FontIcon Glyph="&#xE700;" FontFamily="Segoe Fluent Icons" FontSize="14"/>
+                    <Button.Flyout>
+                        <MenuFlyout>
+                            <MenuFlyoutItem x:Name="NewProfileMenuItem" IsEnabled="False"/>
+                            <MenuFlyoutSeparator/>
+                            <MenuFlyoutItem x:Name="AppSettingsMenuItem" Click="AppSettingsMenuItem_Click"/>
+                            <MenuFlyoutSeparator/>
+                            <MenuFlyoutItem x:Name="AboutMenuItem" Click="AboutMenuItem_Click"/>
+                        </MenuFlyout>
+                    </Button.Flyout>
                 </Button>
             </StackPanel>
         </Grid>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,4 +1,4 @@
-using Microsoft.UI.Xaml;
+﻿using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using System;
@@ -266,7 +266,10 @@ namespace XTimelineViewer
             DropHintTitle.Text   = R.Get("DropHintTitle.Text");
             DropHintSubtitle.Text = R.Get("DropHintSubtitle.Text");
             ToolTipService.SetToolTip(PostBtn, R.Get("PostBtn_Tooltip"));
-            ToolTipService.SetToolTip(AppSettingsBtn, R.Get("AppSettingsBtn_Tooltip"));
+            ToolTipService.SetToolTip(AppMenuBtn, R.Get("AppMenu_Tooltip"));
+            NewProfileMenuItem.Text  = R.Get("Menu_NewProfile");
+            AppSettingsMenuItem.Text = R.Get("Menu_Settings");
+            AboutMenuItem.Text       = R.Get("Menu_About");
             Closed += async (s, e) => await SaveTimelinesAsync();
             ((FrameworkElement)Content).ActualThemeChanged += (s, e) => ApplyThemeToWebViews();
             LoadSettings();
@@ -332,7 +335,7 @@ namespace XTimelineViewer
             ApplyThemeToWebViews();
         }
 
-        private async void AppSettingsBtn_Click(object _, RoutedEventArgs __)
+        private async void AppSettingsMenuItem_Click(object _, RoutedEventArgs __)
         {
             var themeCombo = new ComboBox
             {
@@ -357,24 +360,6 @@ namespace XTimelineViewer
                 Directory.CreateDirectory(folder);
                 await Windows.System.Launcher.LaunchFolderPathAsync(folder);
             };
-
-            var version = System.Reflection.Assembly.GetExecutingAssembly()
-                              .GetName().Version?.ToString(3) ?? R.Get("Version_Unknown");
-
-            var edgeChannel = FindEdgeDevVersionFolder() is not null
-                ? R.Get("EdgeChannel_Dev")
-                : R.Get("EdgeChannel_Runtime");
-            string edgeVersion;
-            try
-            {
-                edgeVersion = CoreWebView2Environment.GetAvailableBrowserVersionString(
-                    FindEdgeDevVersionFolder() ?? "");
-            }
-            catch
-            {
-                edgeVersion = _webViewEnv?.BrowserVersionString ?? R.Get("Version_Unknown");
-            }
-            var versionInfoText = $"XTimelineViewer v{version}\r\n{edgeChannel} {edgeVersion}";
 
             static Grid MakeRow(string label, FrameworkElement control, Thickness? margin = null)
             {
@@ -458,17 +443,76 @@ namespace XTimelineViewer
                 Width                   = 160,
             };
             panel.Children.Add(MakeRow(R.Get("Settings_AutoActivate"), autoActivateBox));
-            panel.Children.Add(new NavigationViewItemSeparator { Margin = new Thickness(0, 12, 0, 8) });
-            panel.Children.Add(new TextBlock
-            {
-                Text       = R.Get("Section_About"),
-                FontWeight = Microsoft.UI.Text.FontWeights.SemiBold
-            });
 
-            var monoFont   = new FontFamily("Cascadia Mono, Consolas, Courier New");
+            var dlg = new ContentDialog
+            {
+                Title             = R.Get("AppSettings_Title"),
+                Content           = panel,
+                PrimaryButtonText = R.Get("Button_Save"),
+                CloseButtonText   = R.Get("Button_Cancel"),
+                DefaultButton     = ContentDialogButton.Primary,
+                XamlRoot          = Content.XamlRoot,
+                RequestedTheme    = ((FrameworkElement)Content).ActualTheme
+            };
+
+                        if (await dlg.ShowAsync() == ContentDialogResult.Primary)
+            {
+                _appSettings.Theme = themeCombo.SelectedIndex switch { 1 => "Light", 2 => "Dark", _ => "Default" };
+                _appSettings.OpenComposerInBrowser = openPostToggle.IsOn;
+                _appSettings.OpenTweetInBrowser    = openTweetToggle.IsOn;
+                _appSettings.AutoActivateMinutes   = (int)Math.Clamp(autoActivateBox.Value, 0, 60);
+
+                var newLang    = langValues[Math.Max(0, Math.Min(langCombo.SelectedIndex, langValues.Length - 1))];
+                var langChanged = newLang != _appSettings.Language;
+                _appSettings.Language = newLang;
+
+                SaveSettings();
+                ApplySavedTheme();
+
+                var flag = _appSettings.OpenTweetInBrowser ? "true" : "false";
+                foreach (var wv in _webViews)
+                    if (wv.CoreWebView2 is not null)
+                        await wv.CoreWebView2.ExecuteScriptAsync(
+                            $"window._xtvOpenTweetInBrowser = {flag};");
+                ApplyAutoActivateTimer();
+
+                if (langChanged)
+                {
+                    var notifDlg = new ContentDialog
+                    {
+                        Content         = R.Get("RestartRequired"),
+                        CloseButtonText = R.Get("Button_Close"),
+                        XamlRoot        = Content.XamlRoot,
+                        RequestedTheme  = ((FrameworkElement)Content).ActualTheme
+                    };
+                    await notifDlg.ShowAsync();
+                }
+            }
+        }
+
+        private async void AboutMenuItem_Click(object _, RoutedEventArgs __)
+        {
+            var version = System.Reflection.Assembly.GetExecutingAssembly()
+                              .GetName().Version?.ToString(3) ?? R.Get("Version_Unknown");
+
+            var edgeChannel = FindEdgeDevVersionFolder() is not null
+                ? R.Get("EdgeChannel_Dev")
+                : R.Get("EdgeChannel_Runtime");
+            string edgeVersion;
+            try
+            {
+                edgeVersion = CoreWebView2Environment.GetAvailableBrowserVersionString(
+                    FindEdgeDevVersionFolder() ?? "");
+            }
+            catch
+            {
+                edgeVersion = _webViewEnv?.BrowserVersionString ?? R.Get("Version_Unknown");
+            }
+            var versionInfoText = $"XTimelineViewer v{version}\r\n{edgeChannel} {edgeVersion}";
+
+            var monoFont = new FontFamily("Cascadia Mono, Consolas, Courier New");
             var versionInfoBox = new StackPanel
             {
-                Margin  = new Thickness(0, 6, 0, 0),
                 Spacing = 2,
                 Children =
                 {
@@ -532,53 +576,19 @@ namespace XTimelineViewer
             actionsPanel.Children.Add(copyBtn);
             actionsPanel.Children.Add(issueBtn);
 
+            var panel = new StackPanel { Spacing = 8, MinWidth = 300 };
             panel.Children.Add(versionInfoBox);
             panel.Children.Add(actionsPanel);
 
             var dlg = new ContentDialog
             {
-                Title             = R.Get("AppSettings_Title"),
-                Content           = panel,
-                PrimaryButtonText = R.Get("Button_Save"),
-                CloseButtonText   = R.Get("Button_Cancel"),
-                DefaultButton     = ContentDialogButton.Primary,
-                XamlRoot          = Content.XamlRoot,
-                RequestedTheme    = ((FrameworkElement)Content).ActualTheme
+                Title           = R.Get("About_Title"),
+                Content         = panel,
+                CloseButtonText = R.Get("Button_Close"),
+                XamlRoot        = Content.XamlRoot,
+                RequestedTheme  = ((FrameworkElement)Content).ActualTheme
             };
-
-            if (await dlg.ShowAsync() == ContentDialogResult.Primary)
-            {
-                _appSettings.Theme = themeCombo.SelectedIndex switch { 1 => "Light", 2 => "Dark", _ => "Default" };
-                _appSettings.OpenComposerInBrowser = openPostToggle.IsOn;
-                _appSettings.OpenTweetInBrowser    = openTweetToggle.IsOn;
-                _appSettings.AutoActivateMinutes   = (int)Math.Clamp(autoActivateBox.Value, 0, 60);
-
-                var newLang    = langValues[Math.Max(0, Math.Min(langCombo.SelectedIndex, langValues.Length - 1))];
-                var langChanged = newLang != _appSettings.Language;
-                _appSettings.Language = newLang;
-
-                SaveSettings();
-                ApplySavedTheme();
-
-                var flag = _appSettings.OpenTweetInBrowser ? "true" : "false";
-                foreach (var wv in _webViews)
-                    if (wv.CoreWebView2 is not null)
-                        await wv.CoreWebView2.ExecuteScriptAsync(
-                            $"window._xtvOpenTweetInBrowser = {flag};");
-                ApplyAutoActivateTimer();
-
-                if (langChanged)
-                {
-                    var notifDlg = new ContentDialog
-                    {
-                        Content         = R.Get("RestartRequired"),
-                        CloseButtonText = R.Get("Button_Close"),
-                        XamlRoot        = Content.XamlRoot,
-                        RequestedTheme  = ((FrameworkElement)Content).ActualTheme
-                    };
-                    await notifDlg.ShowAsync();
-                }
-            }
+            await dlg.ShowAsync();
         }
 
         // ── Theme ─────────────────────────────────────────────────────────────

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -11,6 +11,15 @@
   <!-- Toolbar tooltips -->
   <data name="PostBtn_Tooltip" xml:space="preserve"><value>New Post</value></data>
   <data name="AppSettingsBtn_Tooltip" xml:space="preserve"><value>App Settings</value></data>
+  <data name="AppMenu_Tooltip" xml:space="preserve"><value>Menu</value></data>
+
+  <!-- App menu items -->
+  <data name="Menu_NewProfile" xml:space="preserve"><value>New Profile</value></data>
+  <data name="Menu_Settings" xml:space="preserve"><value>Settings</value></data>
+  <data name="Menu_About" xml:space="preserve"><value>About XTimelineViewer</value></data>
+
+  <!-- About dialog -->
+  <data name="About_Title" xml:space="preserve"><value>About XTimelineViewer</value></data>
 
   <!-- Theme selector items -->
   <data name="Theme_System" xml:space="preserve"><value>System</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -11,6 +11,15 @@
   <!-- Toolbar tooltips -->
   <data name="PostBtn_Tooltip" xml:space="preserve"><value>新規投稿</value></data>
   <data name="AppSettingsBtn_Tooltip" xml:space="preserve"><value>アプリ設定</value></data>
+  <data name="AppMenu_Tooltip" xml:space="preserve"><value>メニュー</value></data>
+
+  <!-- App menu items -->
+  <data name="Menu_NewProfile" xml:space="preserve"><value>新規プロファイルの作成</value></data>
+  <data name="Menu_Settings" xml:space="preserve"><value>設定</value></data>
+  <data name="Menu_About" xml:space="preserve"><value>XTimelineViewer について</value></data>
+
+  <!-- About dialog -->
+  <data name="About_Title" xml:space="preserve"><value>XTimelineViewer について</value></data>
 
   <!-- Theme selector items -->
   <data name="Theme_System" xml:space="preserve"><value>システム</value></data>


### PR DESCRIPTION
closes #59

## 変更内容

### XAML
- `AppSettingsBtn`（⚙ Button）→ `AppMenuBtn`（☰ Button + MenuFlyout）
  - `NewProfileMenuItem`：`IsEnabled="False"`（#3 実装待ち）
  - `AppSettingsMenuItem`：既存の設定ダイアログを表示
  - `AboutMenuItem`：新規 About ダイアログを表示

### コードビハインド
- `AppSettingsBtn_Click` → `AppSettingsMenuItem_Click` にリネーム
- 設定ダイアログから「バージョン情報」セクション（version/edge 情報・コピーボタン・Issue 報告リンク）を削除
- `AboutMenuItem_Click` を新規追加（移設したバージョン情報・コピーボタン・Issue 報告リンクを表示）
- メニュー項目テキストを `R.Get()` で設定（i18n 対応）

### リソース文字列
| キー | ja-JP | en-US |
|---|---|---|
| `AppMenu_Tooltip` | メニュー | Menu |
| `Menu_NewProfile` | 新規プロファイルの作成 | New Profile |
| `Menu_Settings` | 設定 | Settings |
| `Menu_About` | XTimelineViewer について | About XTimelineViewer |
| `About_Title` | XTimelineViewer について | About XTimelineViewer |