### PR TITLE
feat: About ダイアログを Fluent 2 準拠デザインにリニューアル

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -516,38 +516,48 @@ namespace XTimelineViewer
                 $"- {R.Get("IssueLabel_Symptoms")}:\n");
             var issueUrl = $"https://github.com/daruyanagi/XTimelineViewer/issues/new?labels=bug&title=&body={issueBody}";
 
-            // ── Header (icon + name + version + copyright) ────────────────────
+            // ── Header (icon left + name/version/copyright right) ─────────────
             var iconPath = Path.Combine(AppContext.BaseDirectory, "Assets", "StoreLogo.png");
-            var header = new StackPanel { Spacing = 4, Margin = new Thickness(0, 0, 0, 8) };
 
-            if (File.Exists(iconPath))
-                header.Children.Add(new Microsoft.UI.Xaml.Controls.Image
-                {
-                    Source = new Microsoft.UI.Xaml.Media.Imaging.BitmapImage(new Uri(iconPath)),
-                    Width  = 48,
-                    Height = 48,
-                    HorizontalAlignment = HorizontalAlignment.Left,
-                    Margin = new Thickness(0, 0, 0, 4),
-                });
-
-            header.Children.Add(new TextBlock
+            var textStack = new StackPanel
+            {
+                Spacing           = 3,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            textStack.Children.Add(new TextBlock
             {
                 Text       = "XTimelineViewer",
                 FontSize   = 20,
                 FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
             });
-            header.Children.Add(new TextBlock
+            textStack.Children.Add(new TextBlock
             {
                 Text     = $"v{version}",
                 FontSize = 13,
                 Opacity  = 0.7,
             });
-            header.Children.Add(new TextBlock
+            textStack.Children.Add(new TextBlock
             {
                 Text     = R.Get("About_Copyright"),
                 FontSize = 12,
                 Opacity  = 0.6,
             });
+
+            var titleRow = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Spacing     = 12,
+                Margin      = new Thickness(0, 0, 0, 8),
+            };
+            if (File.Exists(iconPath))
+                titleRow.Children.Add(new Microsoft.UI.Xaml.Controls.Image
+                {
+                    Source              = new Microsoft.UI.Xaml.Media.Imaging.BitmapImage(new Uri(iconPath)),
+                    Width               = 48,
+                    Height              = 48,
+                    VerticalAlignment   = VerticalAlignment.Top,
+                });
+            titleRow.Children.Add(textStack);
 
             var copyBtn = new Button
             {
@@ -566,7 +576,7 @@ namespace XTimelineViewer
                         new TextBlock { Text = R.Get("Button_Copy") },
                     }
                 },
-                Margin = new Thickness(0, 8, 0, 0),
+                Margin = new Thickness(0, 4, 0, 0),
             };
             copyBtn.Click += (_, _) =>
             {
@@ -574,6 +584,9 @@ namespace XTimelineViewer
                 dp.SetText(versionInfoText);
                 Clipboard.SetContent(dp);
             };
+
+            var header = new StackPanel { Spacing = 4, Margin = new Thickness(0, 0, 0, 4) };
+            header.Children.Add(titleRow);
             header.Children.Add(copyBtn);
 
             // ── Section helper ────────────────────────────────────────────────
@@ -592,29 +605,39 @@ namespace XTimelineViewer
                 return s;
             }
 
+            // ── Link helper (text + external icon) ────────────────────────────
+            HyperlinkButton MakeLink(string text, string url) => new HyperlinkButton
+            {
+                NavigateUri = new Uri(url),
+                Padding     = new Thickness(0),
+                Content     = new StackPanel
+                {
+                    Orientation     = Orientation.Horizontal,
+                    Spacing         = 4,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Children        =
+                    {
+                        new TextBlock { Text = text, VerticalAlignment = VerticalAlignment.Center },
+                        new FontIcon
+                        {
+                            Glyph      = "",
+                            FontFamily = new FontFamily("Segoe Fluent Icons"),
+                            FontSize   = 10,
+                            Opacity    = 0.6,
+                            VerticalAlignment = VerticalAlignment.Center,
+                        },
+                    }
+                },
+            };
+
             // ── Links ─────────────────────────────────────────────────────────
             var linksSection = MakeSection(R.Get("About_Links"));
-            linksSection.Children.Add(new HyperlinkButton
-            {
-                Content     = R.Get("About_Repository"),
-                NavigateUri = new Uri("https://github.com/daruyanagi/XTimelineViewer"),
-                Padding     = new Thickness(0),
-            });
-            linksSection.Children.Add(new HyperlinkButton
-            {
-                Content     = R.Get("Button_ReportIssue"),
-                NavigateUri = new Uri(issueUrl),
-                Padding     = new Thickness(0),
-            });
+            linksSection.Children.Add(MakeLink(R.Get("About_Repository"), "https://github.com/daruyanagi/XTimelineViewer"));
+            linksSection.Children.Add(MakeLink(R.Get("Button_ReportIssue"), issueUrl));
 
             // ── Acknowledgements ──────────────────────────────────────────────
             var acksSection = MakeSection(R.Get("About_Acknowledgements"));
-            acksSection.Children.Add(new HyperlinkButton
-            {
-                Content     = "TwitterTimelineLoader",
-                NavigateUri = new Uri("https://chromewebstore.google.com/detail/twittertimelineloader/ipmgjpmedafkmmadinmeoannpofakpbh"),
-                Padding     = new Thickness(0),
-            });
+            acksSection.Children.Add(MakeLink("TwitterTimelineLoader", "https://chromewebstore.google.com/detail/twittertimelineloader/ipmgjpmedafkmmadinmeoannpofakpbh"));
 
             // ── License ───────────────────────────────────────────────────────
             var licenseSection = MakeSection(R.Get("About_License"));

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -510,28 +510,44 @@ namespace XTimelineViewer
             }
             var versionInfoText = $"XTimelineViewer v{version}\r\n{edgeChannel} {edgeVersion}";
 
-            var monoFont = new FontFamily("Cascadia Mono, Consolas, Courier New");
-            var versionInfoBox = new StackPanel
-            {
-                Spacing = 2,
-                Children =
+            var issueBody = Uri.EscapeDataString(
+                $"- {R.Get("IssueLabel_AppVersion")}: v{version}\n" +
+                $"- {R.Get("IssueLabel_EdgeVersion")}: {edgeChannel} {edgeVersion}\n" +
+                $"- {R.Get("IssueLabel_Symptoms")}:\n");
+            var issueUrl = $"https://github.com/daruyanagi/XTimelineViewer/issues/new?labels=bug&title=&body={issueBody}";
+
+            // ── Header (icon + name + version + copyright) ────────────────────
+            var iconPath = Path.Combine(AppContext.BaseDirectory, "Assets", "StoreLogo.png");
+            var header = new StackPanel { Spacing = 4, Margin = new Thickness(0, 0, 0, 8) };
+
+            if (File.Exists(iconPath))
+                header.Children.Add(new Microsoft.UI.Xaml.Controls.Image
                 {
-                    new TextBlock
-                    {
-                        Text                   = $"XTimelineViewer v{version}",
-                        FontFamily             = monoFont,
-                        FontSize               = 11,
-                        IsTextSelectionEnabled = true,
-                    },
-                    new TextBlock
-                    {
-                        Text                   = $"{edgeChannel} {edgeVersion}",
-                        FontFamily             = monoFont,
-                        FontSize               = 11,
-                        IsTextSelectionEnabled = true,
-                    },
-                }
-            };
+                    Source = new Microsoft.UI.Xaml.Media.Imaging.BitmapImage(new Uri(iconPath)),
+                    Width  = 48,
+                    Height = 48,
+                    HorizontalAlignment = HorizontalAlignment.Left,
+                    Margin = new Thickness(0, 0, 0, 4),
+                });
+
+            header.Children.Add(new TextBlock
+            {
+                Text       = "XTimelineViewer",
+                FontSize   = 20,
+                FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+            });
+            header.Children.Add(new TextBlock
+            {
+                Text     = $"v{version}",
+                FontSize = 13,
+                Opacity  = 0.7,
+            });
+            header.Children.Add(new TextBlock
+            {
+                Text     = R.Get("About_Copyright"),
+                FontSize = 12,
+                Opacity  = 0.6,
+            });
 
             var copyBtn = new Button
             {
@@ -545,12 +561,12 @@ namespace XTimelineViewer
                         {
                             Glyph      = "",
                             FontFamily = new FontFamily("Segoe Fluent Icons"),
-                            FontSize   = 14
+                            FontSize   = 14,
                         },
-                        new TextBlock { Text = R.Get("Button_Copy") }
+                        new TextBlock { Text = R.Get("Button_Copy") },
                     }
                 },
-                Margin = new Thickness(0, 8, 8, 0)
+                Margin = new Thickness(0, 8, 0, 0),
             };
             copyBtn.Click += (_, _) =>
             {
@@ -558,27 +574,73 @@ namespace XTimelineViewer
                 dp.SetText(versionInfoText);
                 Clipboard.SetContent(dp);
             };
+            header.Children.Add(copyBtn);
 
-            var issueBody = Uri.EscapeDataString(
-                $"- {R.Get("IssueLabel_AppVersion")}: v{version}\n" +
-                $"- {R.Get("IssueLabel_EdgeVersion")}: {edgeChannel} {edgeVersion}\n" +
-                $"- {R.Get("IssueLabel_Symptoms")}:\n");
-            var issueUrl = $"https://github.com/daruyanagi/XTimelineViewer/issues/new?labels=bug&title=&body={issueBody}";
+            // ── Section helper ────────────────────────────────────────────────
+            static StackPanel MakeSection(string title)
+            {
+                var s = new StackPanel { Spacing = 4, Margin = new Thickness(0, 12, 0, 0) };
+                s.Children.Add(new NavigationViewItemSeparator { Margin = new Thickness(0, 0, 0, 8) });
+                s.Children.Add(new TextBlock
+                {
+                    Text       = title,
+                    FontSize   = 12,
+                    FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+                    Opacity    = 0.8,
+                    Margin     = new Thickness(0, 0, 0, 4),
+                });
+                return s;
+            }
 
-            var issueBtn = new HyperlinkButton
+            // ── Links ─────────────────────────────────────────────────────────
+            var linksSection = MakeSection(R.Get("About_Links"));
+            linksSection.Children.Add(new HyperlinkButton
+            {
+                Content     = R.Get("About_Repository"),
+                NavigateUri = new Uri("https://github.com/daruyanagi/XTimelineViewer"),
+                Padding     = new Thickness(0),
+            });
+            linksSection.Children.Add(new HyperlinkButton
             {
                 Content     = R.Get("Button_ReportIssue"),
-                Margin      = new Thickness(0, 8, 0, 0),
                 NavigateUri = new Uri(issueUrl),
-            };
+                Padding     = new Thickness(0),
+            });
 
-            var actionsPanel = new StackPanel { Orientation = Orientation.Horizontal };
-            actionsPanel.Children.Add(copyBtn);
-            actionsPanel.Children.Add(issueBtn);
+            // ── Acknowledgements ──────────────────────────────────────────────
+            var acksSection = MakeSection(R.Get("About_Acknowledgements"));
+            acksSection.Children.Add(new HyperlinkButton
+            {
+                Content     = "TwitterTimelineLoader",
+                NavigateUri = new Uri("https://chromewebstore.google.com/detail/twittertimelineloader/ipmgjpmedafkmmadinmeoannpofakpbh"),
+                Padding     = new Thickness(0),
+            });
 
-            var panel = new StackPanel { Spacing = 8, MinWidth = 300 };
-            panel.Children.Add(versionInfoBox);
-            panel.Children.Add(actionsPanel);
+            // ── License ───────────────────────────────────────────────────────
+            var licenseSection = MakeSection(R.Get("About_License"));
+            licenseSection.Children.Add(new TextBlock
+            {
+                Text                   = "MIT License",
+                IsTextSelectionEnabled = true,
+                FontSize               = 13,
+            });
+
+            // ── Components ────────────────────────────────────────────────────
+            var componentsSection = MakeSection(R.Get("About_Components"));
+            componentsSection.Children.Add(new TextBlock
+            {
+                Text                   = $"{edgeChannel}  {edgeVersion}",
+                IsTextSelectionEnabled = true,
+                FontSize               = 13,
+                Opacity                = 0.8,
+            });
+
+            var panel = new StackPanel { MinWidth = 320 };
+            panel.Children.Add(header);
+            panel.Children.Add(linksSection);
+            panel.Children.Add(acksSection);
+            panel.Children.Add(licenseSection);
+            panel.Children.Add(componentsSection);
 
             var dlg = new ContentDialog
             {
@@ -586,12 +648,12 @@ namespace XTimelineViewer
                 Content         = panel,
                 CloseButtonText = R.Get("Button_Close"),
                 XamlRoot        = Content.XamlRoot,
-                RequestedTheme  = ((FrameworkElement)Content).ActualTheme
+                RequestedTheme  = ((FrameworkElement)Content).ActualTheme,
             };
             await dlg.ShowAsync();
         }
 
-        // ── Theme ─────────────────────────────────────────────────────────────
+                // ── Theme ─────────────────────────────────────────────────────────────
 
         private async void PostBtn_Click(object _, RoutedEventArgs __)
         {

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -92,4 +92,12 @@
   <data name="ExtSettings_Format" xml:space="preserve"><value>{0} Settings</value></data>
   <data name="ExtSettings_Homepage" xml:space="preserve"><value>Open Homepage</value></data>
   <data name="ExtSettings_StoreLink" xml:space="preserve"><value>Open in Chrome Web Store</value></data>
+
+  <!-- About dialog sections -->
+  <data name="About_Copyright" xml:space="preserve"><value>© 2026 daruyanagi</value></data>
+  <data name="About_Links" xml:space="preserve"><value>Links</value></data>
+  <data name="About_Repository" xml:space="preserve"><value>GitHub Repository</value></data>
+  <data name="About_Acknowledgements" xml:space="preserve"><value>Acknowledgements</value></data>
+  <data name="About_License" xml:space="preserve"><value>License</value></data>
+  <data name="About_Components" xml:space="preserve"><value>Components</value></data>
 </root>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -92,4 +92,12 @@
   <data name="ExtSettings_Format" xml:space="preserve"><value>{0} の設定</value></data>
   <data name="ExtSettings_Homepage" xml:space="preserve"><value>ホームページを開く</value></data>
   <data name="ExtSettings_StoreLink" xml:space="preserve"><value>Chrome Web Store で開く</value></data>
+
+  <!-- About dialog sections -->
+  <data name="About_Copyright" xml:space="preserve"><value>© 2026 daruyanagi</value></data>
+  <data name="About_Links" xml:space="preserve"><value>リンク</value></data>
+  <data name="About_Repository" xml:space="preserve"><value>GitHub リポジトリ</value></data>
+  <data name="About_Acknowledgements" xml:space="preserve"><value>謝辞</value></data>
+  <data name="About_License" xml:space="preserve"><value>ライセンス</value></data>
+  <data name="About_Components" xml:space="preserve"><value>コンポーネント</value></data>
 </root>


### PR DESCRIPTION
Closes #61

## Summary

- アプリアイコン（`Assets/StoreLogo.png` 48px）をダイアログ上部に表示
- アプリ名 20px SemiBold・バージョン 13px・著作権表記 12px の Fluent 2 準拠ヘッダー
- バージョン情報コピーボタンをヘッダー直下に配置
- `NavigationViewItemSeparator` でセクション区切りを実装
  - **リンク**: GitHub リポジトリ / Issue 報告
  - **謝辞**: TwitterTimelineLoader（Chrome Web Store リンク）
  - **ライセンス**: MIT License
  - **コンポーネント**: WebView2 バージョン文字列
- 新規 resw キー 6 件（`About_Copyright` / `About_Links` / `About_Repository` / `About_Acknowledgements` / `About_License` / `About_Components`）を ja-JP・en-US 両方に追加

## Test plan

- [ ] ハンバーガーメニュー →「XTimelineViewer について」を開く
- [ ] アプリアイコン・アプリ名・バージョン・著作権が表示される
- [ ] 「バージョン情報をコピー」ボタンでクリップボードにコピーされる
- [ ] GitHub リポジトリ・Issue リンクが正しく開く
- [ ] TwitterTimelineLoader の Chrome Web Store リンクが開く
- [ ] MIT License / WebView2 バージョンが表示される
- [ ] ライト・ダークテーマ両方で見た目が正常
- [ ] 言語を英語に切り替えても文字列が正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)