### PR TITLE
feat: 定期ハードリロードを URL 離脱中も一時停止する

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -111,6 +111,8 @@ namespace XTimelineViewer
         private readonly Dictionary<WebView2, DispatcherTimer>  _hardReloadTimers    = [];
         private readonly Dictionary<WebView2, DateTimeOffset>   _hardReloadStartTimes = [];
         private readonly Dictionary<WebView2, Action>           _hardReloadUiUpdaters = [];
+        private readonly HashSet<WebView2>                       _pointerOverWebViews  = [];
+        private readonly HashSet<WebView2>                       _urlDivergedWebViews  = [];
         private DispatcherTimer? _hardReloadUiTimer;
         private DispatcherTimer? _autoActivateTimer;
 
@@ -1030,8 +1032,8 @@ namespace XTimelineViewer
                 _focusedHeaderGrid = headerGrid;
                 foreach (var r in _headerRefreshers) r();
             };
-            webView.PointerEntered += (s, e) => PauseHardReloadTimer(webView);
-            webView.PointerExited  += (s, e) => ResumeHardReloadTimer(webView);
+            webView.PointerEntered += (s, e) => { _pointerOverWebViews.Add(webView);    EvaluateHardReloadPause(webView); };
+            webView.PointerExited  += (s, e) => { _pointerOverWebViews.Remove(webView); EvaluateHardReloadPause(webView); };
 
             _hardReloadUiUpdaters[webView] = () => UpdateHardReloadTooltip(webView, hardReloadTooltip);
             EnsureHardReloadUiTimer();
@@ -1202,6 +1204,8 @@ namespace XTimelineViewer
                     StopHardReloadTimer(webView);
                     _hardReloadUiUpdaters.Remove(webView);
                     _hardReloadStartTimes.Remove(webView);
+                    _pointerOverWebViews.Remove(webView);
+                    _urlDivergedWebViews.Remove(webView);
                     if (_hardReloadUiUpdaters.Count == 0)
                     {
                         _hardReloadUiTimer?.Stop();
@@ -1276,18 +1280,25 @@ namespace XTimelineViewer
             _hardReloadStartTimes.Remove(wv);
         }
 
-        private void PauseHardReloadTimer(WebView2 wv)
+        private void EvaluateHardReloadPause(WebView2 wv)
         {
-            if (_hardReloadTimers.TryGetValue(wv, out var t)) t.Stop();
-        }
-
-        private void ResumeHardReloadTimer(WebView2 wv)
-        {
-            if (_hardReloadTimers.TryGetValue(wv, out var t))
+            if (!_hardReloadTimers.TryGetValue(wv, out var t)) return;
+            bool shouldPause = _pointerOverWebViews.Contains(wv) || _urlDivergedWebViews.Contains(wv);
+            if (shouldPause && t.IsEnabled)
+                t.Stop();
+            else if (!shouldPause && !t.IsEnabled)
             {
                 _hardReloadStartTimes[wv] = DateTimeOffset.Now;
                 t.Start();
             }
+        }
+
+        private static bool IsOnBaseUrl(string currentUrl, string baseUrl)
+        {
+            if (!Uri.TryCreate(currentUrl, UriKind.Absolute, out var cur))  return false;
+            if (!Uri.TryCreate(baseUrl,    UriKind.Absolute, out var @base)) return false;
+            return string.Equals(cur.Host,         @base.Host,         StringComparison.OrdinalIgnoreCase)
+                && string.Equals(cur.AbsolutePath, @base.AbsolutePath, StringComparison.OrdinalIgnoreCase);
         }
 
         private void UpdateHardReloadTooltip(WebView2 wv, ToolTip tooltip)
@@ -1299,7 +1310,9 @@ namespace XTimelineViewer
             }
             if (!t.IsEnabled)
             {
-                tooltip.Content = R.Get("HardReload_Paused");
+                tooltip.Content = _urlDivergedWebViews.Contains(wv)
+                    ? R.Get("HardReload_Paused_Nav")
+                    : R.Get("HardReload_Paused");
                 return;
             }
             if (_hardReloadStartTimes.TryGetValue(wv, out var start))
@@ -1647,6 +1660,13 @@ namespace XTimelineViewer
             {
                 var env = await GetOrCreateEnvAsync();
                 await webView.EnsureCoreWebView2Async(env);
+                webView.CoreWebView2.SourceChanged += (s, e) =>
+                {
+                    bool diverged = !IsOnBaseUrl(webView.CoreWebView2.Source, cfg.Url);
+                    if (diverged) _urlDivergedWebViews.Add(webView);
+                    else          _urlDivergedWebViews.Remove(webView);
+                    EvaluateHardReloadPause(webView);
+                };
                 await LoadExtensionsAsync(webView);
                 ApplyThemeToWebViews();
             }

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -68,6 +68,7 @@
   <data name="Timeline_ReloadInterval" xml:space="preserve"><value>Auto-Reload Interval (min, 0 to disable)</value></data>
   <data name="HardReload_Active" xml:space="preserve"><value>🔄 Auto-Reload On: ⏱ {0}:{1} remaining</value></data>
   <data name="HardReload_Paused" xml:space="preserve"><value>⏸ Auto-Reload Paused</value></data>
+  <data name="HardReload_Paused_Nav" xml:space="preserve"><value>⏸ Browsing — Auto-Reload Paused</value></data>
   <data name="HardReload_Disabled" xml:space="preserve"><value>⏹ Auto-Reload Off</value></data>
   <data name="Pane_Settings_Tooltip" xml:space="preserve"><value>Settings</value></data>
   <data name="Pane_Close_Tooltip" xml:space="preserve"><value>Close</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -68,6 +68,7 @@
   <data name="Timeline_ReloadInterval" xml:space="preserve"><value>定期リロード間隔（分、0 で無効）</value></data>
   <data name="HardReload_Active" xml:space="preserve"><value>🔄 定期ハードリロード有効: ⏱ 残り {0}:{1}</value></data>
   <data name="HardReload_Paused" xml:space="preserve"><value>⏸ 定期ハードリロード一時停止中</value></data>
+  <data name="HardReload_Paused_Nav" xml:space="preserve"><value>⏸ ページ閲覧中（定期ハードリロード停止）</value></data>
   <data name="HardReload_Disabled" xml:space="preserve"><value>⏹ 定期ハードリロード無効</value></data>
   <data name="Pane_Settings_Tooltip" xml:space="preserve"><value>設定</value></data>
   <data name="Pane_Close_Tooltip" xml:space="preserve"><value>閉じる</value></data>


### PR DESCRIPTION
Closes #67

## Summary

- 定期ハードリロードの一時停止を **2条件の OR** で管理するよう変更
  - ① ポインターオーバー（`_pointerOverWebViews`）
  - ② URL 離脱（`_urlDivergedWebViews`）— `CoreWebView2.SourceChanged` で監視
  - どちらか一方でも該当すれば停止、両方解消されて初めて再開
- `PauseHardReloadTimer` / `ResumeHardReloadTimer` を削除し `EvaluateHardReloadPause` に一本化
- `IsOnBaseUrl` で AbsolutePath のみ比較（クエリパラメーターは無視）
- ツールチップに「ページ閲覧中」と「ポインターオーバー」を別文言で表示
- ペイン削除時に両セットからも除去

## Test plan

- [ ] 定期ハードリロードを有効にしたタイムラインで、投稿の詳細をクリックする
- [ ] 投稿詳細ページ閲覧中にマウスを外しても「⏸ ページ閲覧中」表示のまま再開しない
- [ ] ダブルクリック（元 URL に戻る）するとカウントダウンが再開する
- [ ] 元 URL にいる間はポインターオーバーで「⏸ 一時停止中」、外れると再開する（従来動作と同じ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)