### PR TITLE
feat: OpenTweetInBrowser 機能を廃止 (#74)

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -35,7 +35,7 @@ namespace XTimelineViewer
     {
         public bool    SeparateComposeEnv    { get; set; } = false;
         public bool    OpenComposerInBrowser { get; set; } = false;
-        public bool    OpenTweetInBrowser    { get; set; } = false;
+
         public string  Theme                 { get; set; } = "Default"; // "Light" | "Dark" | "Default"
         public int     AutoActivateMinutes   { get; set; } = 0;
         public string  Language              { get; set; } = "system";  // "system" | "ja-JP" | "en-US"
@@ -184,51 +184,6 @@ namespace XTimelineViewer
                         if (k === 'Backspace' && ni) { e.preventDefault(); history.back(); return; }
                     }
                 }, true);
-            })();
-            """;
-
-        // ツイート permalink 遷移を外部ブラウザーへ転送するスクリプト。
-        // 2層構成:
-        //   1. capture 相クリック横取り: <a href="/status/"> を React より先にブロック
-        //   2. pushState 横取り: React onClick 経由の SPA 遷移を orig + back() で戻す
-        // window._xtvOpenTweetInBrowser を ExecuteScriptAsync で切り替えて有効/無効を制御する。
-        private static readonly string TweetInterceptScript = """
-            (function() {
-                if (window._xtvTweet) return;
-                window._xtvTweet = true;
-
-                // Layer 1: <a href> クリックを capture 最優先で横取り
-                document.addEventListener('click', function(e) {
-                    if (!window._xtvOpenTweetInBrowser) return;
-                    var a = e.target.closest('a[href]');
-                    if (!a) return;
-                    try {
-                        var url = new URL(a.href);
-                        if (/\/status\/\d+/.test(url.pathname)) {
-                            e.preventDefault();
-                            e.stopImmediatePropagation();
-                            window.chrome.webview.postMessage('openTweet:' + url.href);
-                        }
-                    } catch(ex) {}
-                }, true);
-
-                // Layer 2: React onClick 経由の pushState を横取りして即 back()
-                var orig = history.pushState.bind(history);
-                history.pushState = function(state, title, url) {
-                    if (window._xtvOpenTweetInBrowser && url) {
-                        var s = url.toString();
-                        if (/\/status\/\d+/.test(s)) {
-                            try {
-                                var abs = new URL(s, location.origin).href;
-                                window.chrome.webview.postMessage('openTweet:' + abs);
-                            } catch(ex) {}
-                            orig(state, title, url);
-                            setTimeout(function() { history.back(); }, 0);
-                            return;
-                        }
-                    }
-                    orig(state, title, url);
-                };
             })();
             """;
 
@@ -452,17 +407,6 @@ namespace XTimelineViewer
             };
             panel.Children.Add(MakeRow(R.Get("Settings_OpenComposerInBrowser"), openPostToggle));
 
-            var openTweetToggle = new ToggleSwitch
-            {
-                IsOn                = _appSettings.OpenTweetInBrowser,
-                OnContent           = R.Get("Toggle_On"),
-                OffContent          = R.Get("Toggle_Off"),
-                Margin              = new Thickness(12, 0, 0, 0),
-                VerticalAlignment   = VerticalAlignment.Center,
-                HorizontalAlignment = HorizontalAlignment.Right
-            };
-            panel.Children.Add(MakeRow(R.Get("Settings_OpenTweetInBrowser"), openTweetToggle));
-
             var autoActivateBox = new NumberBox
             {
                 Value                   = _appSettings.AutoActivateMinutes,
@@ -501,7 +445,7 @@ namespace XTimelineViewer
             {
                 _appSettings.Theme = themeCombo.SelectedIndex switch { 1 => "Light", 2 => "Dark", _ => "Default" };
                 _appSettings.OpenComposerInBrowser = openPostToggle.IsOn;
-                _appSettings.OpenTweetInBrowser    = openTweetToggle.IsOn;
+
                 _appSettings.AutoActivateMinutes   = (int)Math.Clamp(autoActivateBox.Value, 0, 60);
                 _appSettings.ShowAutoActivateLabel = showAutoActivateLabelToggle.IsOn;
 
@@ -512,11 +456,6 @@ namespace XTimelineViewer
                 SaveSettings();
                 ApplySavedTheme();
 
-                var flag = _appSettings.OpenTweetInBrowser ? "true" : "false";
-                foreach (var wv in _webViews)
-                    if (wv.CoreWebView2 is not null)
-                        await wv.CoreWebView2.ExecuteScriptAsync(
-                            $"window._xtvOpenTweetInBrowser = {flag};");
                 ApplyAutoActivateTimer();
 
                 if (langChanged)
@@ -875,13 +814,6 @@ namespace XTimelineViewer
 
         private void OnWebViewMessageReceived(WebView2 senderWebView, string message)
         {
-            if (message.StartsWith("openTweet:") &&
-                Uri.TryCreate(message[10..], UriKind.Absolute, out var tweetUri))
-            {
-                _ = Windows.System.Launcher.LaunchUriAsync(tweetUri);
-                return;
-            }
-
             switch (message)
             {
                 case "focusNext": FocusAdjacentTimeline(senderWebView, +1); break;
@@ -1984,7 +1916,6 @@ namespace XTimelineViewer
             // キーボードショートカット：ブラウザ既定アクセラレータを無効化し JS で代替処理
             webView.CoreWebView2.Settings.AreBrowserAcceleratorKeysEnabled = false;
             await webView.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(KeyboardShortcutScript);
-            await webView.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(TweetInterceptScript);
             webView.CoreWebView2.WebMessageReceived += (s, e) =>
                 OnWebViewMessageReceived(webView, e.TryGetWebMessageAsString());
 
@@ -2007,12 +1938,6 @@ namespace XTimelineViewer
                     return;
                 }
 
-                if (_appSettings.OpenTweetInBrowser &&
-                    nav.AbsolutePath.Contains("/status/", StringComparison.OrdinalIgnoreCase))
-                {
-                    args.Cancel = true;
-                    await Windows.System.Launcher.LaunchUriAsync(nav);
-                }
             };
 
             webView.CoreWebView2.NavigationCompleted += async (s, args) =>
@@ -2022,11 +1947,6 @@ namespace XTimelineViewer
                     await ApplyHideSidebarAsync(webView, cfg.HideSidebar);
                     await ApplyHideComposeAsync(webView, EffectiveHideCompose(cfg, webView.CoreWebView2.Source));
                     await ApplyHideListHeaderAsync(webView, cfg.HideListHeader);
-
-                    // TweetInterceptScript のフラグを設定と同期する
-                    var flag = _appSettings.OpenTweetInBrowser ? "true" : "false";
-                    await webView.CoreWebView2.ExecuteScriptAsync(
-                        $"window._xtvOpenTweetInBrowser = {flag};");
 
                     // x.com/home の場合だけ新着ポスト自動表示機能を適用する
                     if (Uri.TryCreate(webView.CoreWebView2.Source, UriKind.Absolute, out var current) &&

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -41,7 +41,6 @@
   <data name="Section_About" xml:space="preserve"><value>About</value></data>
   <data name="Settings_SeparateCompose" xml:space="preserve"><value>Open Composer in Separate Profile (Deprecated)</value></data>
   <data name="Settings_OpenComposerInBrowser" xml:space="preserve"><value>Open Composer in External Browser</value></data>
-  <data name="Settings_OpenTweetInBrowser" xml:space="preserve"><value>Open Tweets in External Browser</value></data>
   <data name="Settings_AutoActivate" xml:space="preserve"><value>Auto-activate Home Timeline (min, 0 to disable)</value></data>
 
   <!-- Language selector items -->

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -41,7 +41,6 @@
   <data name="Section_About" xml:space="preserve"><value>バージョン情報</value></data>
   <data name="Settings_SeparateCompose" xml:space="preserve"><value>投稿画面を別プロファイルで開く（廃止予定）</value></data>
   <data name="Settings_OpenComposerInBrowser" xml:space="preserve"><value>新規投稿を外部ブラウザーで開く</value></data>
-  <data name="Settings_OpenTweetInBrowser" xml:space="preserve"><value>ツイートを外部ブラウザーで開く</value></data>
   <data name="Settings_AutoActivate" xml:space="preserve"><value>ホームタイムラインを定期的にアクティブ化（分、0 で無効）</value></data>
 
   <!-- Language selector items -->


### PR DESCRIPTION
## Summary
- `OpenTweetInBrowser` 試験機能（全ツイートリンクを外部ブラウザーで開く）を完全に削除
- 設定プロパティ、JS インジェクションスクリプト、メッセージハンドラー、NavigationStarting フォールバック、設定ダイアログ UI、リソース文字列をすべて除去
- タイムスタンプリンク専用の代替機能は #73 で対応予定

## Test plan
- [ ] ビルドが通ること（0 エラー確認済み）
- [ ] アプリ起動・タイムライン表示が正常であること
- [ ] 設定ダイアログに「ツイートを外部ブラウザーで開く」トグルが表示されないこと
- [ ] ツイートリンクのクリックが WebView 内で通常遷移すること

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)