### PR TITLE
feat: プロファイル管理 UI を実装

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -48,6 +48,7 @@
                     <Button.Flyout>
                         <MenuFlyout>
                             <MenuFlyoutItem x:Name="NewProfileMenuItem" Click="NewProfileMenuItem_Click"/>
+                            <MenuFlyoutItem x:Name="ManageProfilesMenuItem" Click="ManageProfilesMenuItem_Click"/>
                             <MenuFlyoutSeparator/>
                             <MenuFlyoutItem x:Name="AppSettingsMenuItem" Click="AppSettingsMenuItem_Click"/>
                             <MenuFlyoutSeparator/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -36,6 +36,8 @@ namespace XTimelineViewer
     {
         public string Id   { get; set; } = Guid.NewGuid().ToString("N");
         public string Name { get; set; } = "";
+        public int?    BadgeColorIndex { get; set; }
+        public string? BadgeText       { get; set; }
     }
 
     internal class AppSettings
@@ -279,8 +281,9 @@ namespace XTimelineViewer
             DropHintSubtitle.Text = R.Get("DropHintSubtitle.Text");
             ToolTipService.SetToolTip(PostBtn, R.Get("PostBtn_Tooltip"));
             ToolTipService.SetToolTip(AppMenuBtn, R.Get("AppMenu_Tooltip"));
-            NewProfileMenuItem.Text  = R.Get("Menu_NewProfile");
-            AppSettingsMenuItem.Text = R.Get("Menu_Settings");
+            NewProfileMenuItem.Text      = R.Get("Menu_NewProfile");
+            ManageProfilesMenuItem.Text = R.Get("Menu_ManageProfiles");
+            AppSettingsMenuItem.Text     = R.Get("Menu_Settings");
             AboutMenuItem.Text       = R.Get("Menu_About");
             Closed += async (s, e) => await SaveTimelinesAsync();
             ((FrameworkElement)Content).ActualThemeChanged += (s, e) => ApplyThemeToWebViews();
@@ -425,6 +428,136 @@ namespace XTimelineViewer
                 Debug.WriteLine($"[Profile] Saved to profiles.json: Id={profile.Id}, Name={profile.Name}");
             };
             win.Activate();
+        }
+
+        private void ManageProfilesMenuItem_Click(object _, RoutedEventArgs __)
+        {
+            var ownerHwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+            var win = new ManageProfilesWindow(_profiles, ProfileBadgeColors, ownerHwnd);
+            win.ProfilesChanged += (__, args) =>
+            {
+                foreach (var change in args.Changes)
+                {
+                    var p = _profiles.FirstOrDefault(p => p.Id == change.ProfileId);
+                    if (p == null) continue;
+                    p.Name = change.NewName;
+                    p.BadgeColorIndex = change.NewColorIndex;
+                    p.BadgeText = change.NewBadgeText;
+                }
+                SaveProfiles();
+                RefreshAllProfileBadges();
+            };
+            win.ProfileResetRequested += async (__, profileId) =>
+            {
+                RemoveTimelinesForProfile(profileId);
+                _profileEnvs.Remove(profileId);
+                try
+                {
+                    var defaultDir = Path.Combine(
+                        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                        "XTimelineViewer", "EBWebView");
+                    if (Directory.Exists(defaultDir))
+                        Directory.Delete(defaultDir, recursive: true);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"[Profile] Failed to delete default profile data: {ex.Message}");
+                }
+                await SaveTimelinesAsync();
+                Debug.WriteLine("[Profile] Default profile reset");
+            };
+            win.ProfileDeleteRequested += async (__, profileId) =>
+            {
+                RemoveTimelinesForProfile(profileId);
+                _profileEnvs.Remove(profileId);
+                var profile = _profiles.FirstOrDefault(p => p.Id == profileId);
+                if (profile != null) _profiles.Remove(profile);
+                if (_profiles.Count == 0)
+                    _profiles.Add(new ProfileConfig { Id = "default", Name = "Default" });
+                SaveProfiles();
+                try
+                {
+                    var folder = Path.Combine(GetProfilesDataDir(), profileId);
+                    if (Directory.Exists(folder))
+                        Directory.Delete(folder, recursive: true);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"[Profile] Failed to delete profile folder: {ex.Message}");
+                }
+                await SaveTimelinesAsync();
+                RefreshAllProfileBadges();
+                Debug.WriteLine($"[Profile] Deleted: {profileId}");
+            };
+            win.Activate();
+        }
+
+        private void RefreshAllProfileBadges()
+        {
+            for (int i = 0; i < _configs.Count && i < TimelinePanel.Children.Count; i++)
+            {
+                var pane = (Grid)TimelinePanel.Children[i];
+                var headerGrid = pane.Children.OfType<Grid>().FirstOrDefault();
+                if (headerGrid == null) continue;
+                var oldBadge = headerGrid.Children.OfType<Border>()
+                    .FirstOrDefault(b => Grid.GetColumn(b) == 1);
+                if (oldBadge != null)
+                    headerGrid.Children.Remove(oldBadge);
+                var newBadge = CreateProfileBadge(_configs[i].ProfileId);
+                Grid.SetColumn(newBadge, 1);
+                headerGrid.Children.Add(newBadge);
+            }
+        }
+
+        private void RemoveTimelinesForProfile(string profileId)
+        {
+            var indices = new List<int>();
+            for (int i = 0; i < _configs.Count; i++)
+                if (_configs[i].ProfileId == profileId)
+                    indices.Add(i);
+
+            for (int i = indices.Count - 1; i >= 0; i--)
+            {
+                var idx = indices[i];
+                if (idx >= TimelinePanel.Children.Count) continue;
+                var pane = (Grid)TimelinePanel.Children[idx];
+                var wv = pane.Children.OfType<WebView2>().FirstOrDefault();
+                if (wv != null)
+                {
+                    StopHardReloadTimer(wv);
+                    _hardReloadUiUpdaters.Remove(wv);
+                    _hardReloadStartTimes.Remove(wv);
+                    _pointerOverWebViews.Remove(wv);
+                    _urlDivergedWebViews.Remove(wv);
+                    _webViews.Remove(wv);
+                    _webViewToPane.Remove(wv);
+                    try { wv.Close(); } catch { }
+                }
+                var headerGrid = pane.Children.OfType<Grid>().FirstOrDefault();
+                if (headerGrid != null)
+                {
+                    _homeHeaderGrids.Remove(headerGrid);
+                    if (_focusedHeaderGrid == headerGrid)
+                        _focusedHeaderGrid = null;
+                }
+                _paneToSetFocus.Remove(pane);
+                TimelinePanel.Children.RemoveAt(idx);
+                _configs.RemoveAt(idx);
+            }
+
+            if (_hardReloadUiUpdaters.Count == 0)
+            {
+                _hardReloadUiTimer?.Stop();
+                _hardReloadUiTimer = null;
+            }
+            if (_focusedHeaderGrid == null)
+                foreach (var r in _headerRefreshers) r();
+
+            if (TimelinePanel.Children.Count == 0)
+            {
+                TimelineScroll.Visibility = Visibility.Collapsed;
+                DropHintBorder.Visibility = Visibility.Visible;
+            }
         }
 
         private async void AppSettingsMenuItem_Click(object _, RoutedEventArgs __)
@@ -1080,13 +1213,22 @@ namespace XTimelineViewer
             return ProfileBadgeColors[hash % ProfileBadgeColors.Length];
         }
 
+        private Color GetProfileColor(ProfileConfig? profile, string profileId)
+        {
+            if (profile?.BadgeColorIndex is int idx && idx >= 0 && idx < ProfileBadgeColors.Length)
+                return ProfileBadgeColors[idx];
+            return GetProfileColor(profileId);
+        }
+
         private Border CreateProfileBadge(string profileId)
         {
             var showBadge = _profiles.Count > 1 && profileId != "default";
             var profile = _profiles.FirstOrDefault(p => p.Id == profileId);
             var name = profile?.Name ?? profileId;
-            var badgeText = name.Length > 3 ? name[..3] : name;
-            var color = GetProfileColor(profileId);
+            var badgeText = profile?.BadgeText is { Length: > 0 } custom
+                ? custom
+                : (name.Length > 3 ? name[..3] : name);
+            var color = GetProfileColor(profile, profileId);
 
             return new Border
             {

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -252,6 +252,7 @@ namespace XTimelineViewer
             var env = await CoreWebView2Environment.CreateWithOptionsAsync(
                 FindEdgeDevVersionFolder() ?? "", userDataFolder, options);
             _profileEnvs[profileId] = env;
+            Debug.WriteLine($"[Profile] Env created: profileId={profileId}, UserDataFolder={env.UserDataFolder}");
             return env;
         }
 
@@ -433,7 +434,8 @@ namespace XTimelineViewer
         private void ManageProfilesMenuItem_Click(object _, RoutedEventArgs __)
         {
             var ownerHwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
-            var win = new ManageProfilesWindow(_profiles, ProfileBadgeColors, ownerHwnd);
+            var win = new ManageProfilesWindow(_profiles, ProfileBadgeColors, ownerHwnd,
+                profileId => _configs.Count(c => c.ProfileId == profileId));
             win.ProfilesChanged += (__, args) =>
             {
                 foreach (var change in args.Changes)
@@ -446,25 +448,6 @@ namespace XTimelineViewer
                 }
                 SaveProfiles();
                 RefreshAllProfileBadges();
-            };
-            win.ProfileResetRequested += async (__, profileId) =>
-            {
-                RemoveTimelinesForProfile(profileId);
-                _profileEnvs.Remove(profileId);
-                try
-                {
-                    var defaultDir = Path.Combine(
-                        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                        "XTimelineViewer", "EBWebView");
-                    if (Directory.Exists(defaultDir))
-                        Directory.Delete(defaultDir, recursive: true);
-                }
-                catch (Exception ex)
-                {
-                    Debug.WriteLine($"[Profile] Failed to delete default profile data: {ex.Message}");
-                }
-                await SaveTimelinesAsync();
-                Debug.WriteLine("[Profile] Default profile reset");
             };
             win.ProfileDeleteRequested += async (__, profileId) =>
             {

--- a/ManageProfilesWindow.xaml
+++ b/ManageProfilesWindow.xaml
@@ -1,0 +1,30 @@
+<Window
+    x:Class="XTimelineViewer.ManageProfilesWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Title="Manage Profiles">
+
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" Padding="0">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <ScrollViewer Grid.Row="0"
+                      VerticalScrollBarVisibility="Auto"
+                      Padding="16,12">
+            <StackPanel x:Name="ProfileList" Spacing="0"/>
+        </ScrollViewer>
+
+        <StackPanel Grid.Row="1"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Spacing="8"
+                    Padding="16,12">
+            <Button x:Name="CancelBtn" Click="CancelBtn_Click"/>
+            <Button x:Name="SaveBtn"
+                    Style="{StaticResource AccentButtonStyle}"
+                    Click="SaveBtn_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/ManageProfilesWindow.xaml.cs
+++ b/ManageProfilesWindow.xaml.cs
@@ -1,0 +1,225 @@
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Windows.Graphics;
+using Windows.UI;
+
+namespace XTimelineViewer
+{
+    public sealed partial class ManageProfilesWindow : Window
+    {
+        private readonly List<ProfileConfig> _profiles;
+        private readonly Color[] _badgeColors;
+        private readonly List<(ProfileConfig profile, TextBox nameBox, ComboBox colorBox, TextBox badgeTextBox, Grid row)> _rows = [];
+
+        public event EventHandler<ProfileChangedEventArgs>? ProfilesChanged;
+        public event EventHandler<string>? ProfileResetRequested;
+        public event EventHandler<string>? ProfileDeleteRequested;
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+        private const int GWLP_HWNDPARENT = -8;
+
+        public ManageProfilesWindow(List<ProfileConfig> profiles, Color[] badgeColors, IntPtr ownerHwnd)
+        {
+            this.InitializeComponent();
+            _profiles = profiles;
+            _badgeColors = badgeColors;
+            AppWindow.Resize(new SizeInt32(520, 400));
+            Title = R.Get("Menu_ManageProfiles");
+            CancelBtn.Content = R.Get("Button_Cancel");
+            SaveBtn.Content = R.Get("Button_Save");
+
+            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+            SetWindowLongPtr(hwnd, GWLP_HWNDPARENT, ownerHwnd);
+            if (AppWindow.Presenter is OverlappedPresenter presenter)
+            {
+                presenter.IsModal = true;
+                presenter.IsResizable = false;
+            }
+
+            BuildList();
+        }
+
+        private void BuildList()
+        {
+            ProfileList.Children.Clear();
+            _rows.Clear();
+
+            foreach (var profile in _profiles)
+            {
+                var row = new Grid { Margin = new Thickness(0, 4, 0, 4) };
+                row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+                row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+                row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+                row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+                var colorIdx = profile.BadgeColorIndex
+                    ?? (Math.Abs(profile.Id.GetHashCode()) % _badgeColors.Length);
+                var colorBox = new ComboBox
+                {
+                    Width             = 50,
+                    Margin            = new Thickness(0, 0, 6, 0),
+                    Padding           = new Thickness(4),
+                    VerticalAlignment = VerticalAlignment.Center,
+                };
+                for (int i = 0; i < _badgeColors.Length; i++)
+                {
+                    colorBox.Items.Add(new Border
+                    {
+                        Width        = 16,
+                        Height       = 16,
+                        CornerRadius = new CornerRadius(3),
+                        Background   = new SolidColorBrush(_badgeColors[i]),
+                    });
+                }
+                colorBox.SelectedIndex = colorIdx;
+                Grid.SetColumn(colorBox, 0);
+
+                var nameBox = new TextBox
+                {
+                    Text              = profile.Name,
+                    MinWidth          = 100,
+                    Margin            = new Thickness(0, 0, 6, 0),
+                    VerticalAlignment = VerticalAlignment.Center,
+                };
+                Grid.SetColumn(nameBox, 1);
+
+                var name = profile.Name;
+                var defaultBadgeText = name.Length > 3 ? name[..3] : name;
+                var badgeTextBox = new TextBox
+                {
+                    Text            = profile.BadgeText ?? defaultBadgeText,
+                    MaxLength       = 5,
+                    Width           = 60,
+                    Margin          = new Thickness(0, 0, 6, 0),
+                    VerticalAlignment = VerticalAlignment.Center,
+                    PlaceholderText = defaultBadgeText,
+                };
+                Grid.SetColumn(badgeTextBox, 2);
+
+                var actionBtn = new Button
+                {
+                    VerticalAlignment = VerticalAlignment.Center,
+                    MinWidth          = 60,
+                };
+
+                if (profile.Id == "default")
+                {
+                    actionBtn.Content = R.Get("Profile_Reset");
+                    actionBtn.Click += async (s, e) =>
+                    {
+                        var dlg = new ContentDialog
+                        {
+                            Title             = R.Get("Profile_ResetConfirmTitle"),
+                            Content           = R.Get("Profile_ResetConfirmBody"),
+                            PrimaryButtonText = R.Get("Profile_ResetConfirm"),
+                            CloseButtonText   = R.Get("Button_Cancel"),
+                            DefaultButton     = ContentDialogButton.Close,
+                            XamlRoot          = Content.XamlRoot,
+                            RequestedTheme    = ((FrameworkElement)Content).ActualTheme,
+                        };
+                        if (await dlg.ShowAsync() == ContentDialogResult.Primary)
+                        {
+                            ProfileResetRequested?.Invoke(this, "default");
+                            Debug.WriteLine("[Profile] Default profile reset requested");
+                        }
+                    };
+                }
+                else
+                {
+                    actionBtn.Content = R.Get("Profile_Delete");
+                    var capturedProfile = profile;
+                    var capturedRow = row;
+                    actionBtn.Click += async (s, e) =>
+                    {
+                        var dlg = new ContentDialog
+                        {
+                            Title             = R.Get("Profile_DeleteConfirmTitle"),
+                            Content           = string.Format(R.Get("Profile_DeleteConfirmBody"), "?"),
+                            PrimaryButtonText = R.Get("Profile_DeleteConfirm"),
+                            CloseButtonText   = R.Get("Button_Cancel"),
+                            DefaultButton     = ContentDialogButton.Close,
+                            XamlRoot          = Content.XamlRoot,
+                            RequestedTheme    = ((FrameworkElement)Content).ActualTheme,
+                        };
+                        if (await dlg.ShowAsync() == ContentDialogResult.Primary)
+                        {
+                            ProfileDeleteRequested?.Invoke(this, capturedProfile.Id);
+                            capturedRow.Visibility = Visibility.Collapsed;
+                            Debug.WriteLine($"[Profile] Delete requested: {capturedProfile.Id}");
+                        }
+                    };
+                }
+                Grid.SetColumn(actionBtn, 3);
+
+                row.Children.Add(colorBox);
+                row.Children.Add(nameBox);
+                row.Children.Add(badgeTextBox);
+                row.Children.Add(actionBtn);
+                ProfileList.Children.Add(row);
+                _rows.Add((profile, nameBox, colorBox, badgeTextBox, row));
+            }
+        }
+
+        private void SaveBtn_Click(object sender, RoutedEventArgs e)
+        {
+            var changes = new List<ProfileChange>();
+            foreach (var (profile, nameBox, colorBox, badgeTextBox, row) in _rows)
+            {
+                if (row.Visibility == Visibility.Collapsed) continue;
+
+                var newName = nameBox.Text.Trim();
+                if (newName.Length == 0) newName = profile.Name;
+
+                var newColorIdx = colorBox.SelectedIndex;
+                var defaultColorIdx = profile.BadgeColorIndex
+                    ?? (Math.Abs(profile.Id.GetHashCode()) % _badgeColors.Length);
+
+                var newBadgeText = badgeTextBox.Text.Trim();
+                var defaultText = newName.Length > 3 ? newName[..3] : newName;
+
+                bool changed = newName != profile.Name
+                    || newColorIdx != defaultColorIdx
+                    || newBadgeText != (profile.BadgeText ?? defaultText);
+
+                if (changed)
+                {
+                    changes.Add(new ProfileChange
+                    {
+                        ProfileId     = profile.Id,
+                        NewName       = newName,
+                        NewColorIndex = newColorIdx,
+                        NewBadgeText  = newBadgeText.Length > 0 ? newBadgeText : null,
+                    });
+                }
+            }
+
+            if (changes.Count > 0)
+                ProfilesChanged?.Invoke(this, new ProfileChangedEventArgs { Changes = changes });
+
+            Close();
+        }
+
+        private void CancelBtn_Click(object sender, RoutedEventArgs e) => Close();
+    }
+
+    public class ProfileChange
+    {
+        public string  ProfileId     { get; set; } = "";
+        public string  NewName       { get; set; } = "";
+        public int     NewColorIndex { get; set; }
+        public string? NewBadgeText  { get; set; }
+    }
+
+    public class ProfileChangedEventArgs : EventArgs
+    {
+        public List<ProfileChange> Changes { get; set; } = [];
+    }
+}

--- a/ManageProfilesWindow.xaml.cs
+++ b/ManageProfilesWindow.xaml.cs
@@ -16,21 +16,22 @@ namespace XTimelineViewer
     {
         private readonly List<ProfileConfig> _profiles;
         private readonly Color[] _badgeColors;
+        private readonly Func<string, int> _getTimelineCount;
         private readonly List<(ProfileConfig profile, TextBox nameBox, ComboBox colorBox, TextBox badgeTextBox, Grid row)> _rows = [];
 
         public event EventHandler<ProfileChangedEventArgs>? ProfilesChanged;
-        public event EventHandler<string>? ProfileResetRequested;
         public event EventHandler<string>? ProfileDeleteRequested;
 
         [DllImport("user32.dll")]
         private static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
         private const int GWLP_HWNDPARENT = -8;
 
-        public ManageProfilesWindow(List<ProfileConfig> profiles, Color[] badgeColors, IntPtr ownerHwnd)
+        public ManageProfilesWindow(List<ProfileConfig> profiles, Color[] badgeColors, IntPtr ownerHwnd, Func<string, int> getTimelineCount)
         {
             this.InitializeComponent();
             _profiles = profiles;
             _badgeColors = badgeColors;
+            _getTimelineCount = getTimelineCount;
             AppWindow.Resize(new SizeInt32(520, 400));
             Title = R.Get("Menu_ManageProfiles");
             CancelBtn.Content = R.Get("Button_Cancel");
@@ -113,24 +114,7 @@ namespace XTimelineViewer
                 if (profile.Id == "default")
                 {
                     actionBtn.Content = R.Get("Profile_Reset");
-                    actionBtn.Click += async (s, e) =>
-                    {
-                        var dlg = new ContentDialog
-                        {
-                            Title             = R.Get("Profile_ResetConfirmTitle"),
-                            Content           = R.Get("Profile_ResetConfirmBody"),
-                            PrimaryButtonText = R.Get("Profile_ResetConfirm"),
-                            CloseButtonText   = R.Get("Button_Cancel"),
-                            DefaultButton     = ContentDialogButton.Close,
-                            XamlRoot          = Content.XamlRoot,
-                            RequestedTheme    = ((FrameworkElement)Content).ActualTheme,
-                        };
-                        if (await dlg.ShowAsync() == ContentDialogResult.Primary)
-                        {
-                            ProfileResetRequested?.Invoke(this, "default");
-                            Debug.WriteLine("[Profile] Default profile reset requested");
-                        }
-                    };
+                    actionBtn.IsEnabled = false;
                 }
                 else
                 {
@@ -142,7 +126,7 @@ namespace XTimelineViewer
                         var dlg = new ContentDialog
                         {
                             Title             = R.Get("Profile_DeleteConfirmTitle"),
-                            Content           = string.Format(R.Get("Profile_DeleteConfirmBody"), "?"),
+                            Content           = string.Format(R.Get("Profile_DeleteConfirmBody"), _getTimelineCount(capturedProfile.Id)),
                             PrimaryButtonText = R.Get("Profile_DeleteConfirm"),
                             CloseButtonText   = R.Get("Button_Cancel"),
                             DefaultButton     = ContentDialogButton.Close,

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -16,6 +16,7 @@
   <!-- App menu items -->
   <data name="Menu_NewProfile" xml:space="preserve"><value>New Profile</value></data>
   <data name="Menu_Settings" xml:space="preserve"><value>Settings</value></data>
+  <data name="Menu_ManageProfiles" xml:space="preserve"><value>Manage Profiles</value></data>
   <data name="Menu_About" xml:space="preserve"><value>About XTimelineViewer</value></data>
 
   <!-- Add profile window -->
@@ -88,6 +89,16 @@
   <data name="Pane_Close_Tooltip" xml:space="preserve"><value>Close</value></data>
   <data name="Pane_Delete" xml:space="preserve"><value>Remove This Timeline</value></data>
   <data name="DragCaption" xml:space="preserve"><value>Add Timeline</value></data>
+
+  <!-- Profile management -->
+  <data name="Profile_Reset" xml:space="preserve"><value>Reset</value></data>
+  <data name="Profile_Delete" xml:space="preserve"><value>Delete</value></data>
+  <data name="Profile_ResetConfirmTitle" xml:space="preserve"><value>Reset Profile</value></data>
+  <data name="Profile_ResetConfirmBody" xml:space="preserve"><value>All cookies and login data will be deleted. Timelines using this profile will need to sign in again.</value></data>
+  <data name="Profile_ResetConfirm" xml:space="preserve"><value>Reset</value></data>
+  <data name="Profile_DeleteConfirmTitle" xml:space="preserve"><value>Delete Profile</value></data>
+  <data name="Profile_DeleteConfirmBody" xml:space="preserve"><value>{0} timeline(s) using this profile will also be removed.</value></data>
+  <data name="Profile_DeleteConfirm" xml:space="preserve"><value>Delete</value></data>
 
   <!-- Error dialogs -->
   <data name="ExtLoadError_Title" xml:space="preserve"><value>Failed to Load Extensions</value></data>

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -94,7 +94,7 @@
   <data name="Profile_Reset" xml:space="preserve"><value>Reset</value></data>
   <data name="Profile_Delete" xml:space="preserve"><value>Delete</value></data>
   <data name="Profile_ResetConfirmTitle" xml:space="preserve"><value>Reset Profile</value></data>
-  <data name="Profile_ResetConfirmBody" xml:space="preserve"><value>All cookies and login data will be deleted. Timelines using this profile will need to sign in again.</value></data>
+  <data name="Profile_ResetConfirmBody" xml:space="preserve"><value>All cookies and login data will be deleted. Timelines using this profile will be removed, and data will be cleared on next launch.</value></data>
   <data name="Profile_ResetConfirm" xml:space="preserve"><value>Reset</value></data>
   <data name="Profile_DeleteConfirmTitle" xml:space="preserve"><value>Delete Profile</value></data>
   <data name="Profile_DeleteConfirmBody" xml:space="preserve"><value>{0} timeline(s) using this profile will also be removed.</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -16,6 +16,7 @@
   <!-- App menu items -->
   <data name="Menu_NewProfile" xml:space="preserve"><value>新規プロファイルの作成</value></data>
   <data name="Menu_Settings" xml:space="preserve"><value>設定</value></data>
+  <data name="Menu_ManageProfiles" xml:space="preserve"><value>プロファイルを管理</value></data>
   <data name="Menu_About" xml:space="preserve"><value>XTimelineViewer について</value></data>
 
   <!-- Add profile window -->
@@ -88,6 +89,16 @@
   <data name="Pane_Close_Tooltip" xml:space="preserve"><value>閉じる</value></data>
   <data name="Pane_Delete" xml:space="preserve"><value>このタイムラインを削除</value></data>
   <data name="DragCaption" xml:space="preserve"><value>タイムラインを追加</value></data>
+
+  <!-- Profile management -->
+  <data name="Profile_Reset" xml:space="preserve"><value>初期化</value></data>
+  <data name="Profile_Delete" xml:space="preserve"><value>削除</value></data>
+  <data name="Profile_ResetConfirmTitle" xml:space="preserve"><value>プロファイルの初期化</value></data>
+  <data name="Profile_ResetConfirmBody" xml:space="preserve"><value>Cookie やログイン情報がすべて削除されます。このプロファイルを使用しているタイムラインは再度ログインが必要です。</value></data>
+  <data name="Profile_ResetConfirm" xml:space="preserve"><value>初期化する</value></data>
+  <data name="Profile_DeleteConfirmTitle" xml:space="preserve"><value>プロファイルの削除</value></data>
+  <data name="Profile_DeleteConfirmBody" xml:space="preserve"><value>このプロファイルを使用している {0} 個のタイムラインも削除されます。</value></data>
+  <data name="Profile_DeleteConfirm" xml:space="preserve"><value>削除する</value></data>
 
   <!-- Error dialogs -->
   <data name="ExtLoadError_Title" xml:space="preserve"><value>拡張機能の読み込みに失敗しました</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -94,7 +94,7 @@
   <data name="Profile_Reset" xml:space="preserve"><value>初期化</value></data>
   <data name="Profile_Delete" xml:space="preserve"><value>削除</value></data>
   <data name="Profile_ResetConfirmTitle" xml:space="preserve"><value>プロファイルの初期化</value></data>
-  <data name="Profile_ResetConfirmBody" xml:space="preserve"><value>Cookie やログイン情報がすべて削除されます。このプロファイルを使用しているタイムラインは再度ログインが必要です。</value></data>
+  <data name="Profile_ResetConfirmBody" xml:space="preserve"><value>Cookie やログイン情報がすべて削除されます。このプロファイルを使用しているタイムラインは削除され、次回起動時にデータが消去されます。</value></data>
   <data name="Profile_ResetConfirm" xml:space="preserve"><value>初期化する</value></data>
   <data name="Profile_DeleteConfirmTitle" xml:space="preserve"><value>プロファイルの削除</value></data>
   <data name="Profile_DeleteConfirmBody" xml:space="preserve"><value>このプロファイルを使用している {0} 個のタイムラインも削除されます。</value></data>


### PR DESCRIPTION
## Summary

- ハンバーガーメニューに「プロファイルを管理」項目を追加
- 専用の `ManageProfilesWindow`（モーダル風ウィンドウ）でプロファイルを一覧管理
  - 名前変更
  - バッジ色の選択（8色パレット）
  - バッジテキストのカスタマイズ
  - default 以外のプロファイルの削除（関連タイムラインも削除）
  - default プロファイルの初期化は保留（#86）
- `ProfileConfig` に `BadgeColorIndex` / `BadgeText` プロパティを追加
- `RemoveTimelinesForProfile` ヘルパーで全クリーンアップを一元化

Closes #66

## Known Issues

- 子ウィンドウのモーダル動作が不完全（メインウィンドウの操作をブロックできない）→ #84 で別途対応
- default プロファイルの初期化は WebView2 のフォルダロック問題により保留 → #86 で別途対応

## Test plan

- [ ] メニューから「プロファイルを管理」ウィンドウが開く
- [ ] プロファイル名を変更して保存 → 反映される
- [ ] バッジ色を変更して保存 → タイムラインヘッダーのバッジ色が変わる
- [ ] バッジテキストを変更して保存 → バッジ表示が変わる
- [ ] default の「初期化」ボタンがグレーアウトされている
- [ ] default 以外の「削除」→ 確認ダイアログに正しいタイムライン数が表示される
- [ ] 削除実行後 → タイムライン削除・プロファイル削除
- [ ] 全プロファイル削除後 → default が自動再生成、ドロップヒント画面に戻る
- [ ] キャンセルで変更が破棄される

🤖 Generated with [Claude Code](https://claude.com/claude-code)