### PR TITLE
feat: 新規プロファイル作成をプロファイル管理ウィンドウに統合

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -47,7 +47,6 @@
                     <FontIcon Glyph="&#xE700;" FontFamily="Segoe Fluent Icons" FontSize="14"/>
                     <Button.Flyout>
                         <MenuFlyout>
-                            <MenuFlyoutItem x:Name="NewProfileMenuItem" Click="NewProfileMenuItem_Click"/>
                             <MenuFlyoutItem x:Name="ManageProfilesMenuItem" Click="ManageProfilesMenuItem_Click"/>
                             <MenuFlyoutSeparator/>
                             <MenuFlyoutItem x:Name="AppSettingsMenuItem" Click="AppSettingsMenuItem_Click"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -282,7 +282,6 @@ namespace XTimelineViewer
             DropHintSubtitle.Text = R.Get("DropHintSubtitle.Text");
             ToolTipService.SetToolTip(PostBtn, R.Get("PostBtn_Tooltip"));
             ToolTipService.SetToolTip(AppMenuBtn, R.Get("AppMenu_Tooltip"));
-            NewProfileMenuItem.Text      = R.Get("Menu_NewProfile");
             ManageProfilesMenuItem.Text = R.Get("Menu_ManageProfiles");
             AppSettingsMenuItem.Text     = R.Get("Menu_Settings");
             AboutMenuItem.Text       = R.Get("Menu_About");
@@ -419,18 +418,6 @@ namespace XTimelineViewer
             ApplyThemeToWebViews();
         }
 
-        private void NewProfileMenuItem_Click(object _, RoutedEventArgs __)
-        {
-            var win = new AddProfileWindow();
-            win.ProfileCreated += (__, profile) =>
-            {
-                _profiles.Add(profile);
-                SaveProfiles();
-                Debug.WriteLine($"[Profile] Saved to profiles.json: Id={profile.Id}, Name={profile.Name}");
-            };
-            win.Activate();
-        }
-
         private void ManageProfilesMenuItem_Click(object _, RoutedEventArgs __)
         {
             var ownerHwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
@@ -448,6 +435,12 @@ namespace XTimelineViewer
                 }
                 SaveProfiles();
                 RefreshAllProfileBadges();
+            };
+            win.ProfileCreated += (__, profile) =>
+            {
+                SaveProfiles();
+                RefreshAllProfileBadges();
+                Debug.WriteLine($"[Profile] Saved to profiles.json: Id={profile.Id}, Name={profile.Name}");
             };
             win.ProfileDeleteRequested += async (__, profileId) =>
             {

--- a/ManageProfilesWindow.xaml
+++ b/ManageProfilesWindow.xaml
@@ -13,7 +13,18 @@
         <ScrollViewer Grid.Row="0"
                       VerticalScrollBarVisibility="Auto"
                       Padding="16,12">
-            <StackPanel x:Name="ProfileList" Spacing="0"/>
+            <StackPanel Spacing="8">
+                <StackPanel x:Name="ProfileList" Spacing="0"/>
+                <Button x:Name="AddProfileBtn" Click="AddProfileBtn_Click"
+                        HorizontalAlignment="Stretch"
+                        Padding="8,6"
+                        Margin="0,4,0,0">
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <FontIcon Glyph="&#xE710;" FontFamily="Segoe Fluent Icons" FontSize="12" VerticalAlignment="Center"/>
+                        <TextBlock x:Name="AddProfileLabel" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Button>
+            </StackPanel>
         </ScrollViewer>
 
         <StackPanel Grid.Row="1"

--- a/ManageProfilesWindow.xaml.cs
+++ b/ManageProfilesWindow.xaml.cs
@@ -21,6 +21,7 @@ namespace XTimelineViewer
 
         public event EventHandler<ProfileChangedEventArgs>? ProfilesChanged;
         public event EventHandler<string>? ProfileDeleteRequested;
+        public event EventHandler<ProfileConfig>? ProfileCreated;
 
         [DllImport("user32.dll")]
         private static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
@@ -36,6 +37,7 @@ namespace XTimelineViewer
             Title = R.Get("Menu_ManageProfiles");
             CancelBtn.Content = R.Get("Button_Cancel");
             SaveBtn.Content = R.Get("Button_Save");
+            AddProfileLabel.Text = R.Get("Menu_NewProfile");
 
             var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
             SetWindowLongPtr(hwnd, GWLP_HWNDPARENT, ownerHwnd);
@@ -192,6 +194,18 @@ namespace XTimelineViewer
         }
 
         private void CancelBtn_Click(object sender, RoutedEventArgs e) => Close();
+
+        private void AddProfileBtn_Click(object sender, RoutedEventArgs e)
+        {
+            var win = new AddProfileWindow();
+            win.ProfileCreated += (__, profile) =>
+            {
+                _profiles.Add(profile);
+                ProfileCreated?.Invoke(this, profile);
+                BuildList();
+            };
+            win.Activate();
+        }
     }
 
     public class ProfileChange


### PR DESCRIPTION
## Summary

- ハンバーガーメニューから「新規プロファイルの作成」を削除
- プロファイル管理ウィンドウの一覧下に「+ 新規プロファイルの作成」ボタンを追加
- プロファイル作成完了後、管理ウィンドウのリストが即座に更新される
- プロファイル関連操作が管理ウィンドウに集約され、メニューがすっきり

Closes #87

## Test plan

- [x] ハンバーガーメニューに「新規プロファイルの作成」が表示されない
- [x] 「プロファイルを管理」ウィンドウに「+ 新規プロファイルの作成」ボタンがある
- [x] ボタンクリックで AddProfileWindow が開く
- [x] プロファイル作成完了後、管理ウィンドウのリストに新しいプロファイルが即座に表示される
- [x] 作成後に profiles.json に保存されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)