### PR TITLE
chore: プロファイル関連 UI に「試験機能」ラベルを付与

### DIFF
--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -16,7 +16,7 @@
   <!-- App menu items -->
   <data name="Menu_NewProfile" xml:space="preserve"><value>New Profile</value></data>
   <data name="Menu_Settings" xml:space="preserve"><value>Settings</value></data>
-  <data name="Menu_ManageProfiles" xml:space="preserve"><value>Manage Profiles</value></data>
+  <data name="Menu_ManageProfiles" xml:space="preserve"><value>Manage Profiles (Experimental)</value></data>
   <data name="Menu_About" xml:space="preserve"><value>About XTimelineViewer</value></data>
 
   <!-- Add profile window -->
@@ -69,7 +69,7 @@
 
   <!-- Timeline pane settings dialog -->
   <data name="Timeline_Settings_Title" xml:space="preserve"><value>Settings</value></data>
-  <data name="Timeline_Profile" xml:space="preserve"><value>Profile</value></data>
+  <data name="Timeline_Profile" xml:space="preserve"><value>Profile (Experimental)</value></data>
   <data name="Timeline_Width" xml:space="preserve"><value>Timeline Width (px)</value></data>
   <data name="Timeline_Sidebar" xml:space="preserve"><value>X Sidebar</value></data>
   <data name="Timeline_Compose" xml:space="preserve"><value>Compose Area</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -16,7 +16,7 @@
   <!-- App menu items -->
   <data name="Menu_NewProfile" xml:space="preserve"><value>新規プロファイルの作成</value></data>
   <data name="Menu_Settings" xml:space="preserve"><value>設定</value></data>
-  <data name="Menu_ManageProfiles" xml:space="preserve"><value>プロファイルを管理</value></data>
+  <data name="Menu_ManageProfiles" xml:space="preserve"><value>プロファイルを管理（試験機能）</value></data>
   <data name="Menu_About" xml:space="preserve"><value>XTimelineViewer について</value></data>
 
   <!-- Add profile window -->
@@ -69,7 +69,7 @@
 
   <!-- Timeline pane settings dialog -->
   <data name="Timeline_Settings_Title" xml:space="preserve"><value>設定</value></data>
-  <data name="Timeline_Profile" xml:space="preserve"><value>プロファイル</value></data>
+  <data name="Timeline_Profile" xml:space="preserve"><value>プロファイル（試験機能）</value></data>
   <data name="Timeline_Width" xml:space="preserve"><value>タイムラインの幅（px）</value></data>
   <data name="Timeline_Sidebar" xml:space="preserve"><value>X のサイドバー</value></data>
   <data name="Timeline_Compose" xml:space="preserve"><value>投稿画面</value></data>


### PR DESCRIPTION
## Summary

- メニュー「プロファイルを管理」→「プロファイルを管理（試験機能）」
- 管理ウィンドウのタイトルにも同様に反映（同じリソース文字列を使用）
- タイムライン設定のプロファイル選択ラベル「プロファイル」→「プロファイル（試験機能）」
- en-US も同様に "(Experimental)" を付与

Closes #89

## Test plan

- [ ] メニューに「プロファイルを管理（試験機能）」と表示される
- [ ] 管理ウィンドウのタイトルに「試験機能」が表示される
- [ ] タイムライン設定のプロファイル欄に「試験機能」が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)