### PR TITLE
fix: CS8604 null 参照警告を修正

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -387,7 +387,7 @@ namespace XTimelineViewer
                 _autoActivateStartTime = DateTimeOffset.Now;
                 if (_pointerOverWebViews.Count > 0)                 return;  // ① ポインターオーバー中
                 if (_dialogOpenCount > 0)                           return;  // ② ダイアログ表示中
-                if (_homeHeaderGrids.Contains(_focusedHeaderGrid))  return;  // ④ ホームにフォーカス中
+                if (_focusedHeaderGrid is not null && _homeHeaderGrids.Contains(_focusedHeaderGrid))  return;  // ④ ホームにフォーカス中
 
                 foreach (var wv in _webViews)
                 {
@@ -1347,7 +1347,7 @@ namespace XTimelineViewer
 
             void SetFocus()
             {
-                if (_homeHeaderGrids.Contains(_focusedHeaderGrid) && !_homeHeaderGrids.Contains(headerGrid))
+                if (_focusedHeaderGrid is not null && _homeHeaderGrids.Contains(_focusedHeaderGrid) && !_homeHeaderGrids.Contains(headerGrid))
                     RestartAutoActivateTimer();  // ホームから別タイムラインへ
                 _focusedHeaderGrid = headerGrid;
                 foreach (var r in _headerRefreshers) r();
@@ -1363,7 +1363,7 @@ namespace XTimelineViewer
             };
             webView.GotFocus   += (s, e) =>
             {
-                if (_homeHeaderGrids.Contains(_focusedHeaderGrid) && !_homeHeaderGrids.Contains(headerGrid))
+                if (_focusedHeaderGrid is not null && _homeHeaderGrids.Contains(_focusedHeaderGrid) && !_homeHeaderGrids.Contains(headerGrid))
                     RestartAutoActivateTimer();  // ホームから別タイムラインへ
                 _focusedHeaderGrid = headerGrid;
                 foreach (var r in _headerRefreshers) r();


### PR DESCRIPTION
## Summary
- `_focusedHeaderGrid` が null の場合に `HashSet<Grid>.Contains()` へ渡される CS8604 警告を 3 箇所修正
- `_focusedHeaderGrid is not null &&` の null チェックを追加

Closes #92

## Test plan
- [x] `dotnet build -c Release` で CS8604 警告が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)