### PR TITLE
feat: winget マニフェスト自動更新を追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,3 +59,9 @@ jobs:
               --title "$tag" \
               --generate-notes
           fi
+
+      - name: Publish to winget
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: daruyanagi.XTimelineViewer
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
## Summary
- `release.yml` に `vedantmgoyal9/winget-releaser@v2` ステップを追加
- タグ push → GitHub Release 作成後、自動で microsoft/winget-pkgs に PR を作成
- `WINGET_TOKEN` シークレットを登録済み

## Test plan
- [ ] 次回タグ push 時に winget-pkgs へ PR が自動作成されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)