### PR TITLE
feat: AutomationProperties をインタラクティブ要素に追加

### DIFF
--- a/AddProfileWindow.xaml.cs
+++ b/AddProfileWindow.xaml.cs
@@ -1,4 +1,5 @@
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Web.WebView2.Core;
 using System;
@@ -24,6 +25,8 @@ namespace XTimelineViewer
             CancelBtn.Content = R.Get("Button_Cancel");
             CreateBtn.Content = R.Get("AddProfile_CreateBtn");
             ProfileNameBox.PlaceholderText = R.Get("AddProfile_FallbackLabel");
+            AutomationProperties.SetName(ProfileNameBox, R.Get("AddProfile_FallbackLabel"));
+            AutomationProperties.SetName(LoginWebView,   R.Get("AddProfile_LoginHint"));
             _ = InitAsync();
         }
 

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using System;
@@ -282,6 +283,8 @@ namespace XTimelineViewer
             DropHintSubtitle.Text = R.Get("DropHintSubtitle.Text");
             ToolTipService.SetToolTip(PostBtn, R.Get("PostBtn_Tooltip"));
             ToolTipService.SetToolTip(AppMenuBtn, R.Get("AppMenu_Tooltip"));
+            AutomationProperties.SetName(PostBtn,   R.Get("PostBtn_Tooltip"));
+            AutomationProperties.SetName(AppMenuBtn, R.Get("AppMenu_Tooltip"));
             ManageProfilesMenuItem.Text = R.Get("Menu_ManageProfiles");
             AppSettingsMenuItem.Text     = R.Get("Menu_Settings");
             AboutMenuItem.Text       = R.Get("Menu_About");
@@ -1326,6 +1329,8 @@ namespace XTimelineViewer
                 Padding = new Thickness(0)
             };
             ToolTipService.SetToolTip(settingsBtn, R.Get("Pane_Settings_Tooltip"));
+            AutomationProperties.SetName(settingsBtn, R.Get("Pane_Settings_Tooltip"));
+            AutomationProperties.SetName(webView, displayText);
 
             buttonPanel.Children.Add(settingsBtn);
 

--- a/ManageProfilesWindow.xaml.cs
+++ b/ManageProfilesWindow.xaml.cs
@@ -1,5 +1,6 @@
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using System;
@@ -38,6 +39,7 @@ namespace XTimelineViewer
             CancelBtn.Content = R.Get("Button_Cancel");
             SaveBtn.Content = R.Get("Button_Save");
             AddProfileLabel.Text = R.Get("Menu_NewProfile");
+            AutomationProperties.SetName(AddProfileBtn, R.Get("Menu_NewProfile"));
 
             var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
             SetWindowLongPtr(hwnd, GWLP_HWNDPARENT, ownerHwnd);


### PR DESCRIPTION
## 概要

#99 で報告されたアクセシビリティ対応として、スクリーンリーダー向けの `AutomationProperties.Name` を未設定だった要素に追加する。

## 変更内容

新規リソース文字列の追加なし。既存の Tooltip / ラベル用キーを再利用。

| 要素 | ファイル | 設定値 |
|------|---------|--------|
| `AppMenuBtn`（ハンバーガーアイコン） | MainWindow.xaml.cs | `AppMenu_Tooltip` = "Menu" |
| `PostBtn`（投稿ボタン） | MainWindow.xaml.cs | `PostBtn_Tooltip` = "New Post" |
| `settingsBtn`（タイムラインペイン歯車） | MainWindow.xaml.cs | `Pane_Settings_Tooltip` = "Settings" |
| `webView`（タイムライン領域） | MainWindow.xaml.cs | URL 表示テキスト（例: "x.com/home"） |
| `ProfileNameBox` | AddProfileWindow.xaml.cs | `AddProfile_FallbackLabel` = "Profile Name" |
| `LoginWebView` | AddProfileWindow.xaml.cs | `AddProfile_LoginHint` = "Sign in to X" |
| `AddProfileBtn` | ManageProfilesWindow.xaml.cs | `Menu_NewProfile` = "New Profile" |

## 確認

- [x] C# コンパイルエラーなし
- [x] Narrator でアクセシブルネームを確認

Closes #99