### PR TITLE
refactor: ハードコードカラーを ThemeResource ブラシに移行

### DIFF
--- a/AddProfileWindow.xaml.cs
+++ b/AddProfileWindow.xaml.cs
@@ -48,6 +48,15 @@ namespace XTimelineViewer
             var env = await CoreWebView2Environment.CreateWithOptionsAsync("", folder, options);
             await LoginWebView.EnsureCoreWebView2Async(env);
 
+            // ウィンドウテーマを WebView2 にも反映する
+            LoginWebView.CoreWebView2.Profile.PreferredColorScheme =
+                ((FrameworkElement)Content).ActualTheme switch
+                {
+                    ElementTheme.Light => CoreWebView2PreferredColorScheme.Light,
+                    ElementTheme.Dark  => CoreWebView2PreferredColorScheme.Dark,
+                    _                  => CoreWebView2PreferredColorScheme.Auto,
+                };
+
             LoginWebView.Source = new Uri("https://x.com/i/flow/login");
 
             LoginWebView.CoreWebView2.NavigationCompleted += async (s, e) =>

--- a/App.xaml
+++ b/App.xaml
@@ -7,6 +7,22 @@
             <ResourceDictionary.MergedDictionaries>
                 <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
             </ResourceDictionary.MergedDictionaries>
+            <ResourceDictionary.ThemeDictionaries>
+                <!-- Dark -->
+                <ResourceDictionary x:Key="Default">
+                    <SolidColorBrush x:Key="TimelinePaneBackgroundBrush"          Color="#202020"/>
+                    <SolidColorBrush x:Key="TimelinePaneBorderBrush"              Color="#464646"/>
+                    <SolidColorBrush x:Key="TimelineHeaderBackgroundBrush"        Color="#37373C"/>
+                    <SolidColorBrush x:Key="TimelineHeaderFocusedBackgroundBrush" Color="#1D4E89"/>
+                </ResourceDictionary>
+                <!-- Light -->
+                <ResourceDictionary x:Key="Light">
+                    <SolidColorBrush x:Key="TimelinePaneBackgroundBrush"          Color="#FFFFFF"/>
+                    <SolidColorBrush x:Key="TimelinePaneBorderBrush"              Color="#D2D2D2"/>
+                    <SolidColorBrush x:Key="TimelineHeaderBackgroundBrush"        Color="#EBEBF0"/>
+                    <SolidColorBrush x:Key="TimelineHeaderFocusedBackgroundBrush" Color="#0078D4"/>
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -13,6 +13,7 @@ using System.Reflection;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.IO;
+using System.Runtime.InteropServices;
 using Microsoft.Web.WebView2.Core;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Graphics;
@@ -417,14 +418,31 @@ namespace XTimelineViewer
             _autoActivateTimer.Start();
         }
 
+        [DllImport("dwmapi.dll")]
+        private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attr, ref int attrValue, int attrSize);
+        private const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
+
+        private void ApplyTitleBarTheme(ElementTheme theme)
+        {
+            // Win32 タイトルバーは WinUI の RequestedTheme の影響を受けないため
+            // DWM 属性で直接ダークモードを指定する
+            var hwnd  = WinRT.Interop.WindowNative.GetWindowHandle(this);
+            var dark  = theme == ElementTheme.Dark ? 1
+                      : theme == ElementTheme.Light ? 0
+                      : (Application.Current.RequestedTheme == ApplicationTheme.Dark ? 1 : 0);
+            DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, ref dark, sizeof(int));
+        }
+
         private void ApplySavedTheme()
         {
-            ((FrameworkElement)Content).RequestedTheme = _appSettings.Theme switch
+            var theme = _appSettings.Theme switch
             {
                 "Light" => ElementTheme.Light,
                 "Dark"  => ElementTheme.Dark,
                 _       => ElementTheme.Default,
             };
+            ((FrameworkElement)Content).RequestedTheme = theme;
+            ApplyTitleBarTheme(theme);
             ApplyThemeToWebViews();
         }
 

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -422,14 +422,14 @@ namespace XTimelineViewer
         private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attr, ref int attrValue, int attrSize);
         private const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
 
-        private void ApplyTitleBarTheme(ElementTheme theme)
+        // Win32 タイトルバーは WinUI の RequestedTheme の影響を受けないため
+        // DWM 属性で直接ダークモードを指定する。子ウィンドウにも適用できるよう static に。
+        internal static void ApplyTitleBarTheme(Window window, ElementTheme theme)
         {
-            // Win32 タイトルバーは WinUI の RequestedTheme の影響を受けないため
-            // DWM 属性で直接ダークモードを指定する
-            var hwnd  = WinRT.Interop.WindowNative.GetWindowHandle(this);
-            var dark  = theme == ElementTheme.Dark ? 1
-                      : theme == ElementTheme.Light ? 0
-                      : (Application.Current.RequestedTheme == ApplicationTheme.Dark ? 1 : 0);
+            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(window);
+            var dark = theme == ElementTheme.Dark ? 1
+                     : theme == ElementTheme.Light ? 0
+                     : (Application.Current.RequestedTheme == ApplicationTheme.Dark ? 1 : 0);
             DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, ref dark, sizeof(int));
         }
 
@@ -442,7 +442,7 @@ namespace XTimelineViewer
                 _       => ElementTheme.Default,
             };
             ((FrameworkElement)Content).RequestedTheme = theme;
-            ApplyTitleBarTheme(theme);
+            ApplyTitleBarTheme(this, theme);
             ApplyThemeToWebViews();
         }
 
@@ -451,7 +451,9 @@ namespace XTimelineViewer
             var ownerHwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
             var win = new ManageProfilesWindow(_profiles, ProfileBadgeColors, ownerHwnd,
                 profileId => _configs.Count(c => c.ProfileId == profileId));
-            ((FrameworkElement)win.Content).RequestedTheme = ((FrameworkElement)Content).RequestedTheme;
+            var childTheme = ((FrameworkElement)Content).RequestedTheme;
+            ((FrameworkElement)win.Content).RequestedTheme = childTheme;
+            ApplyTitleBarTheme(win, childTheme);
             win.ProfilesChanged += (__, args) =>
             {
                 foreach (var change in args.Changes)

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1222,7 +1222,7 @@ namespace XTimelineViewer
                     Text       = badgeText,
                     FontSize   = 10,
                     FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
-                    Foreground = new SolidColorBrush(Color.FromArgb(255, 255, 255, 255)),
+                    Foreground = new SolidColorBrush(Microsoft.UI.Colors.White),
                 }
             };
         }
@@ -1260,15 +1260,13 @@ namespace XTimelineViewer
             // Theme
             void ApplyPaneTheme(ElementTheme theme)
             {
-                bool dark    = theme == ElementTheme.Dark;
                 bool focused = _focusedHeaderGrid == headerGrid;
-                pane.Background       = new SolidColorBrush(dark
-                    ? Color.FromArgb(255, 32, 32, 32) : Color.FromArgb(255, 255, 255, 255));
-                pane.BorderBrush      = new SolidColorBrush(dark
-                    ? Color.FromArgb(255, 70, 70, 70) : Color.FromArgb(255, 210, 210, 210));
-                headerGrid.Background = new SolidColorBrush(focused
-                    ? (dark ? Color.FromArgb(255, 29,  78, 137) : Color.FromArgb(255,   0, 120, 212))
-                    : (dark ? Color.FromArgb(255, 55,  55,  60) : Color.FromArgb(255, 235, 235, 240)));
+                var res = Application.Current.Resources;
+                pane.Background       = (Brush)res["TimelinePaneBackgroundBrush"];
+                pane.BorderBrush      = (Brush)res["TimelinePaneBorderBrush"];
+                headerGrid.Background = (Brush)res[focused
+                    ? "TimelineHeaderFocusedBackgroundBrush"
+                    : "TimelineHeaderBackgroundBrush"];
             }
             ApplyPaneTheme(((FrameworkElement)Content).ActualTheme);
             pane.ActualThemeChanged += (s, _) => ApplyPaneTheme(pane.ActualTheme);
@@ -1508,7 +1506,7 @@ namespace XTimelineViewer
                     Content             = R.Get("Pane_Delete"),
                     HorizontalAlignment = HorizontalAlignment.Stretch,
                     Margin              = new Thickness(0, 16, 0, 0),
-                    Foreground          = new SolidColorBrush(Color.FromArgb(255, 196, 43, 28)),
+                    Foreground          = (Brush)Application.Current.Resources["SystemFillColorCriticalBrush"],
                 };
 
                 var profileBox = new ComboBox { MinWidth = 200 };

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1260,11 +1260,15 @@ namespace XTimelineViewer
             // Theme
             void ApplyPaneTheme(ElementTheme theme)
             {
-                bool focused = _focusedHeaderGrid == headerGrid;
-                var res = Application.Current.Resources;
-                pane.Background       = (Brush)res["TimelinePaneBackgroundBrush"];
-                pane.BorderBrush      = (Brush)res["TimelinePaneBorderBrush"];
-                headerGrid.Background = (Brush)res[focused
+                // Application.Current.Resources はアプリレベルのテーマを参照するため、
+                // 要素単位で RequestedTheme を設定している場合に正しい辞書が返らない。
+                // pane.ActualTheme（解決済み）を使い ThemeDictionaries を直接引く。
+                bool focused   = _focusedHeaderGrid == headerGrid;
+                var themeKey   = theme == ElementTheme.Light ? "Light" : "Default";
+                var themeDict  = (ResourceDictionary)Application.Current.Resources.ThemeDictionaries[themeKey];
+                pane.Background       = (Brush)themeDict["TimelinePaneBackgroundBrush"];
+                pane.BorderBrush      = (Brush)themeDict["TimelinePaneBorderBrush"];
+                headerGrid.Background = (Brush)themeDict[focused
                     ? "TimelineHeaderFocusedBackgroundBrush"
                     : "TimelineHeaderBackgroundBrush"];
             }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -433,6 +433,7 @@ namespace XTimelineViewer
             var ownerHwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
             var win = new ManageProfilesWindow(_profiles, ProfileBadgeColors, ownerHwnd,
                 profileId => _configs.Count(c => c.ProfileId == profileId));
+            ((FrameworkElement)win.Content).RequestedTheme = ((FrameworkElement)Content).RequestedTheme;
             win.ProfilesChanged += (__, args) =>
             {
                 foreach (var change in args.Changes)

--- a/ManageProfilesWindow.xaml.cs
+++ b/ManageProfilesWindow.xaml.cs
@@ -200,6 +200,7 @@ namespace XTimelineViewer
         private void AddProfileBtn_Click(object sender, RoutedEventArgs e)
         {
             var win = new AddProfileWindow();
+            ((FrameworkElement)win.Content).RequestedTheme = ((FrameworkElement)Content).ActualTheme;
             win.ProfileCreated += (__, profile) =>
             {
                 _profiles.Add(profile);

--- a/ManageProfilesWindow.xaml.cs
+++ b/ManageProfilesWindow.xaml.cs
@@ -200,7 +200,9 @@ namespace XTimelineViewer
         private void AddProfileBtn_Click(object sender, RoutedEventArgs e)
         {
             var win = new AddProfileWindow();
-            ((FrameworkElement)win.Content).RequestedTheme = ((FrameworkElement)Content).ActualTheme;
+            var childTheme = ((FrameworkElement)Content).ActualTheme;
+            ((FrameworkElement)win.Content).RequestedTheme = childTheme;
+            MainWindow.ApplyTitleBarTheme(win, childTheme);
             win.ProfileCreated += (__, profile) =>
             {
                 _profiles.Add(profile);


### PR DESCRIPTION
## 概要

#100 で報告されたコードビハインドのハードコード RGB 値を、`App.xaml` の `ThemeDictionaries` と WinUI 標準トークンに置き換える。

## 変更内容

### App.xaml — ThemeDictionaries を新規追加

| リソースキー | Dark | Light |
|-------------|------|-------|
| `TimelinePaneBackgroundBrush` | `#202020` | `#FFFFFF` |
| `TimelinePaneBorderBrush` | `#464646` | `#D2D2D2` |
| `TimelineHeaderBackgroundBrush` | `#37373C` | `#EBEBF0` |
| `TimelineHeaderFocusedBackgroundBrush` | `#1D4E89` | `#0078D4` |

### MainWindow.xaml.cs

- `ApplyPaneTheme` を `Application.Current.Resources` 参照に書き換え（`dark ? ... : ...` のハードコード三項演算子を廃止）
- プロファイルバッジ文字色 → `Microsoft.UI.Colors.White`
- 削除ボタン文字色 → `SystemFillColorCriticalBrush`（WinUI 3 標準の Critical 色、ダークモードでも適切な赤になる）

## 確認

- [x] x64 Debug ビルド成功（警告 0）
- [ ] ライト／ダーク切り替えでタイムラインペインの色が正しく反映されることを確認

Closes #100