### PR TITLE
refactor: SettingsService を抽出（#108）

### DIFF
--- a/MainWindow.Settings.cs
+++ b/MainWindow.Settings.cs
@@ -19,6 +19,7 @@ using Windows.ApplicationModel.DataTransfer;
 using Windows.Graphics;
 using Windows.Storage;
 using Windows.UI;
+using XTimelineViewer.Services;
 
 namespace XTimelineViewer
 {
@@ -26,29 +27,17 @@ namespace XTimelineViewer
     {
         private void LoadSettings()
         {
-            try
-            {
-                var json = File.ReadAllText(SettingsFilePath);
-                _appSettings = JsonSerializer.Deserialize<AppSettings>(json) ?? new();
-            }
-            catch { /* ファイルが存在しない場合などは無視 */ }
-            _appSettings.SeparateComposeEnv = false; // 廃止予定: 強制無効化 (#17)
+            _appSettings = SettingsService.LoadSettings(SettingsFilePath);
         }
 
         private void SaveSettings()
         {
-            Directory.CreateDirectory(Path.GetDirectoryName(SettingsFilePath)!);
-            File.WriteAllText(SettingsFilePath, JsonSerializer.Serialize(_appSettings, JsonOptions));
+            SettingsService.SaveSettings(SettingsFilePath, _appSettings);
         }
 
         private void LoadProfiles()
         {
-            try
-            {
-                var json = File.ReadAllText(ProfilesFilePath);
-                _profiles = JsonSerializer.Deserialize<List<ProfileConfig>>(json) ?? [];
-            }
-            catch { /* ファイルが存在しない場合などは無視 */ }
+            _profiles = SettingsService.LoadProfiles(ProfilesFilePath);
             if (_profiles.Count == 0)
             {
                 _profiles.Add(new ProfileConfig { Id = "default", Name = "Default" });
@@ -58,35 +47,14 @@ namespace XTimelineViewer
 
         private void SaveProfiles()
         {
-            Directory.CreateDirectory(Path.GetDirectoryName(ProfilesFilePath)!);
-            File.WriteAllText(ProfilesFilePath, JsonSerializer.Serialize(_profiles, JsonOptions));
+            SettingsService.SaveProfiles(ProfilesFilePath, _profiles);
         }
 
         private void CleanupOrphanedProfiles()
         {
-            try
-            {
-                var dir = GetProfilesDataDir();
-                if (!Directory.Exists(dir)) return;
-                var knownIds = new HashSet<string>(_profiles.Select(p => p.Id));
-                foreach (var folder in Directory.GetDirectories(dir))
-                {
-                    var name = Path.GetFileName(folder);
-                    if (!knownIds.Contains(name))
-                    {
-                        try
-                        {
-                            Directory.Delete(folder, recursive: true);
-                            Debug.WriteLine($"[Profile] Cleaned up orphaned folder: {name}");
-                        }
-                        catch (Exception ex)
-                        {
-                            Debug.WriteLine($"[Profile] Failed to clean up orphaned folder: {name} ({ex.Message})");
-                        }
-                    }
-                }
-            }
-            catch { }
+            SettingsService.CleanupOrphanedProfileFolders(
+                GetProfilesDataDir(),
+                _profiles.Select(p => p.Id));
         }
 
         private async void AppSettingsMenuItem_Click(object _, RoutedEventArgs __)

--- a/Services/SettingsService.cs
+++ b/Services/SettingsService.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text.Json;
+
+namespace XTimelineViewer.Services
+{
+    /// <summary>
+    /// アプリ設定・プロファイルの JSON 永続化を担当するサービス。
+    /// UI 依存なし。MainWindow から状態を受け取り、ファイル I/O のみを行う。
+    /// </summary>
+    internal static class SettingsService
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+        // ── App settings ──────────────────────────────────────────────────────
+
+        public static AppSettings LoadSettings(string filePath)
+        {
+            try
+            {
+                var json = File.ReadAllText(filePath);
+                var settings = JsonSerializer.Deserialize<AppSettings>(json) ?? new();
+                settings.SeparateComposeEnv = false; // 廃止予定: 強制無効化 (#17)
+                return settings;
+            }
+            catch
+            {
+                return new() { SeparateComposeEnv = false };
+            }
+        }
+
+        public static void SaveSettings(string filePath, AppSettings settings)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+            File.WriteAllText(filePath, JsonSerializer.Serialize(settings, JsonOptions));
+        }
+
+        // ── Profiles ──────────────────────────────────────────────────────────
+
+        public static List<ProfileConfig> LoadProfiles(string filePath)
+        {
+            try
+            {
+                var json = File.ReadAllText(filePath);
+                return JsonSerializer.Deserialize<List<ProfileConfig>>(json) ?? [];
+            }
+            catch
+            {
+                return [];
+            }
+        }
+
+        public static void SaveProfiles(string filePath, List<ProfileConfig> profiles)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+            File.WriteAllText(filePath, JsonSerializer.Serialize(profiles, JsonOptions));
+        }
+
+        /// <summary>
+        /// <paramref name="profilesDir"/> 内のフォルダのうち
+        /// <paramref name="knownIds"/> に含まれないものを孤立フォルダとして削除する。
+        /// </summary>
+        public static void CleanupOrphanedProfileFolders(string profilesDir, IEnumerable<string> knownIds)
+        {
+            try
+            {
+                if (!Directory.Exists(profilesDir)) return;
+                var knownSet = new HashSet<string>(knownIds);
+                foreach (var folder in Directory.GetDirectories(profilesDir))
+                {
+                    var name = Path.GetFileName(folder);
+                    if (!knownSet.Contains(name))
+                    {
+                        try
+                        {
+                            Directory.Delete(folder, recursive: true);
+                            Debug.WriteLine($"[Profile] Cleaned up orphaned folder: {name}");
+                        }
+                        catch (Exception ex)
+                        {
+                            Debug.WriteLine($"[Profile] Failed to clean up orphaned folder: {name} ({ex.Message})");
+                        }
+                    }
+                }
+            }
+            catch { }
+        }
+    }
+}


### PR DESCRIPTION
## 概要

#108 の部分実装。UI 依存なしで安全に抽出できる `SettingsService` のみを対象とする。

## 変更内容

### `Services/SettingsService.cs`（新規）

設定・プロファイルの JSON ファイル I/O を担当する静的クラス。

| メソッド | 内容 |
|---------|------|
| `LoadSettings(filePath)` | `AppSettings` を JSON から読み込み |
| `SaveSettings(filePath, settings)` | `AppSettings` を JSON に書き込み |
| `LoadProfiles(filePath)` | `List<ProfileConfig>` を JSON から読み込み |
| `SaveProfiles(filePath, profiles)` | `List<ProfileConfig>` を JSON に書き込み |
| `CleanupOrphanedProfileFolders(dir, knownIds)` | 孤立プロファイルフォルダを削除 |

### `MainWindow.Settings.cs`

Load/Save メソッドが SettingsService への薄いラッパーになった。

## 残りのサービスについて

HardReloadManager・ThemeManager・WebView2Manager・TimelineService は UI 依存が深く、テスト整備または #102（MVVM 導入）と合わせて設計する必要がある。

Closes #108