### PR TITLE
test: xUnit テストプロジェクトと UI テストスクリプトを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ packages/
 test-cert.pfx
 test-cert.cer
 x_timeline_viewer.png
+
+# UI テスト成果物（実行のたびに生成される）
+test-screenshots/
+test-results.json

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -22,39 +22,6 @@ using Windows.UI;
 
 namespace XTimelineViewer
 {
-    internal class TimelineConfig
-    {
-        public string Url                  { get; set; } = "";
-        public double Width                { get; set; } = 350;
-        public bool   HideSidebar         { get; set; } = false;
-        public bool   HideCompose         { get; set; } = true;
-        public bool   HideListHeader       { get; set; } = false;
-        public bool   HardReloadEnabled    { get; set; } = false;
-        public int    HardReloadInterval   { get; set; } = 3;
-        public string ProfileId            { get; set; } = "default";
-    }
-
-    public class ProfileConfig
-    {
-        public string Id   { get; set; } = Guid.NewGuid().ToString("N");
-        public string Name { get; set; } = "";
-        public int?    BadgeColorIndex { get; set; }
-        public string? BadgeText       { get; set; }
-    }
-
-    internal class AppSettings
-    {
-        public bool    SeparateComposeEnv    { get; set; } = false;
-        public bool    OpenComposerInBrowser { get; set; } = false;
-        public bool    OpenTimestampInBrowser { get; set; } = false;
-        public string  Theme                 { get; set; } = "Default"; // "Light" | "Dark" | "Default"
-        public int     AutoActivateMinutes   { get; set; } = 0;
-        public string  Language              { get; set; } = "system";  // "system" | "ja-JP" | "en-US"
-        public string? LastUpdateCheck           { get; set; } = null;   // UTC ISO-8601
-        public string? CachedLatestVersion     { get; set; } = null;   // "v1.4.0" など
-        public bool    ShowAutoActivateLabel   { get; set; } = false;
-    }
-
     public sealed partial class MainWindow : Window
     {
         private static readonly string SaveFilePath      = GetDataFilePath("timelines.json");

--- a/Models.cs
+++ b/Models.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace XTimelineViewer
+{
+    internal class TimelineConfig
+    {
+        public string Url                { get; set; } = "";
+        public double Width              { get; set; } = 350;
+        public bool   HideSidebar       { get; set; } = false;
+        public bool   HideCompose       { get; set; } = true;
+        public bool   HideListHeader    { get; set; } = false;
+        public bool   HardReloadEnabled { get; set; } = false;
+        public int    HardReloadInterval{ get; set; } = 3;
+        public string ProfileId         { get; set; } = "default";
+    }
+
+    public class ProfileConfig
+    {
+        public string  Id             { get; set; } = Guid.NewGuid().ToString("N");
+        public string  Name           { get; set; } = "";
+        public int?    BadgeColorIndex{ get; set; }
+        public string? BadgeText      { get; set; }
+    }
+
+    internal class AppSettings
+    {
+        public bool    SeparateComposeEnv    { get; set; } = false;
+        public bool    OpenComposerInBrowser { get; set; } = false;
+        public bool    OpenTimestampInBrowser{ get; set; } = false;
+        public string  Theme                 { get; set; } = "Default"; // "Light" | "Dark" | "Default"
+        public int     AutoActivateMinutes   { get; set; } = 0;
+        public string  Language              { get; set; } = "system";  // "system" | "ja-JP" | "en-US"
+        public string? LastUpdateCheck       { get; set; } = null;      // UTC ISO-8601
+        public string? CachedLatestVersion   { get; set; } = null;      // "v1.4.0" など
+        public bool    ShowAutoActivateLabel { get; set; } = false;
+    }
+}

--- a/XTimelineViewer.Tests/Services/SettingsServiceTests.cs
+++ b/XTimelineViewer.Tests/Services/SettingsServiceTests.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using XTimelineViewer;
+using XTimelineViewer.Services;
+using Xunit;
+
+namespace XTimelineViewer.Tests.Services;
+
+public class SettingsServiceTests : IDisposable
+{
+    private readonly string _tempDir =
+        Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+
+    public SettingsServiceTests() => Directory.CreateDirectory(_tempDir);
+    public void Dispose()         => Directory.Delete(_tempDir, recursive: true);
+
+    private string At(string filename) => Path.Combine(_tempDir, filename);
+
+    // ── LoadSettings ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void LoadSettings_MissingFile_ReturnsDefaults()
+    {
+        var s = SettingsService.LoadSettings(At("settings.json"));
+        Assert.NotNull(s);
+        Assert.Equal("Default", s.Theme);
+        Assert.Equal("system",  s.Language);
+    }
+
+    [Fact]
+    public void LoadSettings_ValidJson_ReturnsCorrectValues()
+    {
+        File.WriteAllText(At("settings.json"),
+            """{"Theme":"Dark","Language":"ja-JP","AutoActivateMinutes":5}""");
+
+        var s = SettingsService.LoadSettings(At("settings.json"));
+        Assert.Equal("Dark",  s.Theme);
+        Assert.Equal("ja-JP", s.Language);
+        Assert.Equal(5,       s.AutoActivateMinutes);
+    }
+
+    [Fact]
+    public void LoadSettings_InvalidJson_ReturnsDefaults()
+    {
+        File.WriteAllText(At("settings.json"), "not { valid json }");
+
+        var s = SettingsService.LoadSettings(At("settings.json"));
+        Assert.NotNull(s);
+        Assert.Equal("Default", s.Theme);
+    }
+
+    [Fact]
+    public void LoadSettings_AlwaysDisablesSeparateComposeEnv()
+    {
+        File.WriteAllText(At("settings.json"), """{"SeparateComposeEnv":true}""");
+
+        var s = SettingsService.LoadSettings(At("settings.json"));
+        Assert.False(s.SeparateComposeEnv); // 廃止予定: 強制無効化 (#17)
+    }
+
+    // ── SaveSettings / Round-trip ─────────────────────────────────────────────
+
+    [Fact]
+    public void SaveSettings_CreatesFileAndParentDirectory()
+    {
+        var path = Path.Combine(_tempDir, "sub", "settings.json");
+
+        SettingsService.SaveSettings(path, new AppSettings());
+
+        Assert.True(File.Exists(path));
+    }
+
+    [Fact]
+    public void SaveAndLoadSettings_RoundTrip()
+    {
+        var path = At("settings.json");
+        var original = new AppSettings
+        {
+            Theme = "Light", Language = "en-US", AutoActivateMinutes = 10
+        };
+
+        SettingsService.SaveSettings(path, original);
+        var loaded = SettingsService.LoadSettings(path);
+
+        Assert.Equal("Light",  loaded.Theme);
+        Assert.Equal("en-US",  loaded.Language);
+        Assert.Equal(10,       loaded.AutoActivateMinutes);
+    }
+
+    // ── LoadProfiles ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void LoadProfiles_MissingFile_ReturnsEmpty()
+    {
+        var profiles = SettingsService.LoadProfiles(At("profiles.json"));
+        Assert.Empty(profiles);
+    }
+
+    [Fact]
+    public void LoadProfiles_InvalidJson_ReturnsEmpty()
+    {
+        File.WriteAllText(At("profiles.json"), "not json");
+
+        var profiles = SettingsService.LoadProfiles(At("profiles.json"));
+        Assert.Empty(profiles);
+    }
+
+    [Fact]
+    public void LoadProfiles_ValidJson_ReturnsProfiles()
+    {
+        File.WriteAllText(At("profiles.json"),
+            """[{"Id":"abc","Name":"Work"},{"Id":"def","Name":"Personal"}]""");
+
+        var profiles = SettingsService.LoadProfiles(At("profiles.json"));
+
+        Assert.Equal(2,          profiles.Count);
+        Assert.Equal("Work",     profiles[0].Name);
+        Assert.Equal("Personal", profiles[1].Name);
+    }
+
+    // ── SaveProfiles / Round-trip ─────────────────────────────────────────────
+
+    [Fact]
+    public void SaveAndLoadProfiles_RoundTrip()
+    {
+        var path = At("profiles.json");
+        var original = new List<ProfileConfig>
+        {
+            new() { Id = "aaa", Name = "Work"     },
+            new() { Id = "bbb", Name = "Personal" },
+        };
+
+        SettingsService.SaveProfiles(path, original);
+        var loaded = SettingsService.LoadProfiles(path);
+
+        Assert.Equal(2,          loaded.Count);
+        Assert.Equal("aaa",      loaded[0].Id);
+        Assert.Equal("Work",     loaded[0].Name);
+        Assert.Equal("Personal", loaded[1].Name);
+    }
+
+    // ── CleanupOrphanedProfileFolders ─────────────────────────────────────────
+
+    [Fact]
+    public void Cleanup_RemovesOrphanedFolders()
+    {
+        var dir = Path.Combine(_tempDir, "profiles");
+        Directory.CreateDirectory(Path.Combine(dir, "known1"));
+        Directory.CreateDirectory(Path.Combine(dir, "known2"));
+        Directory.CreateDirectory(Path.Combine(dir, "orphan"));
+
+        SettingsService.CleanupOrphanedProfileFolders(dir, ["known1", "known2"]);
+
+        Assert.True (Directory.Exists(Path.Combine(dir, "known1")));
+        Assert.True (Directory.Exists(Path.Combine(dir, "known2")));
+        Assert.False(Directory.Exists(Path.Combine(dir, "orphan")));
+    }
+
+    [Fact]
+    public void Cleanup_KeepsAllFolders_WhenAllAreKnown()
+    {
+        var dir = Path.Combine(_tempDir, "profiles");
+        Directory.CreateDirectory(Path.Combine(dir, "id1"));
+        Directory.CreateDirectory(Path.Combine(dir, "id2"));
+
+        SettingsService.CleanupOrphanedProfileFolders(dir, ["id1", "id2"]);
+
+        Assert.True(Directory.Exists(Path.Combine(dir, "id1")));
+        Assert.True(Directory.Exists(Path.Combine(dir, "id2")));
+    }
+
+    [Fact]
+    public void Cleanup_NonExistentDirectory_DoesNotThrow()
+    {
+        var ex = Record.Exception(() =>
+            SettingsService.CleanupOrphanedProfileFolders(
+                Path.Combine(_tempDir, "nonexistent"), []));
+        Assert.Null(ex);
+    }
+}

--- a/XTimelineViewer.Tests/XTimelineViewer.Tests.csproj
+++ b/XTimelineViewer.Tests/XTimelineViewer.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <!--
+    WinUI 3 プロジェクトを直接参照するとビルド依存が複雑になるため、
+    UI 非依存なファイルだけをリンクして参照する。
+  -->
+  <ItemGroup>
+    <Compile Include="..\Models.cs"                  Link="Models.cs" />
+    <Compile Include="..\Services\SettingsService.cs" Link="Services\SettingsService.cs" />
+  </ItemGroup>
+
+</Project>

--- a/XTimelineViewer.csproj
+++ b/XTimelineViewer.csproj
@@ -18,6 +18,12 @@
     <SelfContained>true</SelfContained>
   </PropertyGroup>
 
+  <!-- テストプロジェクトのファイルをメインビルドから除外 -->
+  <ItemGroup>
+    <Compile Remove="XTimelineViewer.Tests\**" />
+    <None Remove="XTimelineViewer.Tests\**" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250602001" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />

--- a/XTimelineViewer.sln
+++ b/XTimelineViewer.sln
@@ -1,19 +1,46 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XTimelineViewer", "XTimelineViewer.csproj", "{CADA32F0-B26D-7415-C036-E5B07B22512A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XTimelineViewer.Tests", "XTimelineViewer.Tests\XTimelineViewer.Tests.csproj", "{18A3C89C-91E4-46C8-B561-44ABDD7E5564}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x86 = Debug|x86
 		Release|x64 = Release|x64
+		Release|Any CPU = Release|Any CPU
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{CADA32F0-B26D-7415-C036-E5B07B22512A}.Debug|x64.ActiveCfg = Debug|x64
 		{CADA32F0-B26D-7415-C036-E5B07B22512A}.Debug|x64.Build.0 = Debug|x64
+		{CADA32F0-B26D-7415-C036-E5B07B22512A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CADA32F0-B26D-7415-C036-E5B07B22512A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CADA32F0-B26D-7415-C036-E5B07B22512A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CADA32F0-B26D-7415-C036-E5B07B22512A}.Debug|x86.Build.0 = Debug|Any CPU
 		{CADA32F0-B26D-7415-C036-E5B07B22512A}.Release|x64.ActiveCfg = Release|x64
 		{CADA32F0-B26D-7415-C036-E5B07B22512A}.Release|x64.Build.0 = Release|x64
+		{CADA32F0-B26D-7415-C036-E5B07B22512A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CADA32F0-B26D-7415-C036-E5B07B22512A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CADA32F0-B26D-7415-C036-E5B07B22512A}.Release|x86.ActiveCfg = Release|Any CPU
+		{CADA32F0-B26D-7415-C036-E5B07B22512A}.Release|x86.Build.0 = Release|Any CPU
+		{18A3C89C-91E4-46C8-B561-44ABDD7E5564}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{18A3C89C-91E4-46C8-B561-44ABDD7E5564}.Debug|x64.Build.0 = Debug|Any CPU
+		{18A3C89C-91E4-46C8-B561-44ABDD7E5564}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{18A3C89C-91E4-46C8-B561-44ABDD7E5564}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{18A3C89C-91E4-46C8-B561-44ABDD7E5564}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{18A3C89C-91E4-46C8-B561-44ABDD7E5564}.Debug|x86.Build.0 = Debug|Any CPU
+		{18A3C89C-91E4-46C8-B561-44ABDD7E5564}.Release|x64.ActiveCfg = Release|Any CPU
+		{18A3C89C-91E4-46C8-B561-44ABDD7E5564}.Release|x64.Build.0 = Release|Any CPU
+		{18A3C89C-91E4-46C8-B561-44ABDD7E5564}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{18A3C89C-91E4-46C8-B561-44ABDD7E5564}.Release|Any CPU.Build.0 = Release|Any CPU
+		{18A3C89C-91E4-46C8-B561-44ABDD7E5564}.Release|x86.ActiveCfg = Release|Any CPU
+		{18A3C89C-91E4-46C8-B561-44ABDD7E5564}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ui-tests.ps1
+++ b/ui-tests.ps1
@@ -4,7 +4,7 @@
 #
 # 事前準備:
 #   1. XTimelineViewer をビルド・起動しておく
-#   2. winapp がインストールされていること (winapp --version で確認)
+#   2. winapp v0.3+ がインストールされていること: winget install Microsoft.WinAppCli
 
 param([Parameter(Mandatory)][int]$AppPid)
 
@@ -12,7 +12,7 @@ $ErrorActionPreference = 'Continue'
 $pass = 0; $fail = 0; $results = @()
 
 # メインウィンドウの HWND を取得（PopupHost を除外）
-$windows = winapp ui list-windows -a $AppPid --json 2>$null | ConvertFrom-Json
+$windows = (winapp ui list-windows -a $AppPid --json 2>$null) -join "" | ConvertFrom-Json
 $hwnd = ($windows | Where-Object { $_.title -ne "PopupHost" } | Select-Object -First 1).hwnd
 if (-not $hwnd) {
     Write-Host "ERROR: XTimelineViewer (PID: $AppPid) が見つかりません" -ForegroundColor Red
@@ -24,15 +24,17 @@ New-Item -ItemType Directory -Force -Path "test-screenshots" | Out-Null
 function Test-UI {
     param([string]$Name, [scriptblock]$Script)
     try {
-        $output = & $Script 2>&1
-        if ($LASTEXITCODE -eq 0) {
+        $output = & $Script 2>&1          # 外部コマンドの exit code を保持するため Out-String より先に実行
+        $ec     = $LASTEXITCODE           # パイプライン前に即キャプチャ
+        $outputStr = $output -join "`n"
+        if ($ec -eq 0) {
             $script:pass++
             $script:results += @{ name = $Name; status = "PASS" }
             Write-Host "  PASS: $Name" -ForegroundColor Green
         } else {
             $script:fail++
-            $script:results += @{ name = $Name; status = "FAIL"; detail = "$output" }
-            Write-Host "  FAIL: $Name — $output" -ForegroundColor Red
+            $script:results += @{ name = $Name; status = "FAIL"; detail = $outputStr }
+            Write-Host "  FAIL: $Name — $outputStr" -ForegroundColor Red
         }
     } catch {
         $script:fail++
@@ -41,7 +43,7 @@ function Test-UI {
     }
 }
 
-# ── スクリーンショット（初期状態） ─────────────────────────────────────────────
+# ── 初期状態スクリーンショット ─────────────────────────────────────────────────
 winapp ui screenshot -a $AppPid -o "test-screenshots/00-initial.png" 2>$null
 
 # ── ツールバー要素の存在確認 ──────────────────────────────────────────────────
@@ -58,8 +60,7 @@ Write-Host "`n[メニュー]"
 Test-UI "メニューボタンをクリックできる" {
     winapp ui invoke "AppMenuBtn" -a $AppPid
 }
-Start-Sleep -Milliseconds 500
-
+Start-Sleep -Milliseconds 600
 winapp ui screenshot -a $AppPid -o "test-screenshots/01-menu-open.png" 2>$null
 
 Test-UI "設定メニュー項目 (AppSettingsMenuItem) が表示される" {
@@ -69,47 +70,67 @@ Test-UI "About メニュー項目 (AboutMenuItem) が表示される" {
     winapp ui wait-for "AboutMenuItem" -a $AppPid -t 3000
 }
 
-# メニューを閉じる（Escape）
-winapp ui key "Escape" -a $AppPid 2>$null
-Start-Sleep -Milliseconds 300
-
 # ── 設定ダイアログ ─────────────────────────────────────────────────────────────
 Write-Host "`n[設定ダイアログ]"
-Test-UI "メニューから設定を開ける" {
-    winapp ui invoke "AppMenuBtn" -a $AppPid
-    Start-Sleep -Milliseconds 400
+# メニュー項目をクリックするとメニューが閉じてダイアログが開く
+Test-UI "設定ダイアログを開ける" {
     winapp ui invoke "AppSettingsMenuItem" -a $AppPid
 }
 Start-Sleep -Milliseconds 800
 winapp ui screenshot -a $AppPid -o "test-screenshots/02-settings-dialog.png" 2>$null
 
+# ContentDialog のキャンセルボタンは AutomationId="CloseButton"（言語非依存）
 Test-UI "設定ダイアログにキャンセルボタンがある" {
-    winapp ui wait-for "Cancel" -a $AppPid -t 3000
+    winapp ui wait-for "CloseButton" -a $AppPid -t 3000
 }
-
-# ダイアログを閉じる
-winapp ui invoke "Cancel" -a $AppPid 2>$null
+Test-UI "設定ダイアログに保存ボタンがある" {
+    winapp ui wait-for "PrimaryButton" -a $AppPid -t 3000
+}
+Test-UI "設定ダイアログをキャンセルで閉じられる" {
+    winapp ui invoke "CloseButton" -a $AppPid
+}
 Start-Sleep -Milliseconds 500
 
 # ── アクセシビリティ確認 ───────────────────────────────────────────────────────
 Write-Host "`n[アクセシビリティ]"
-Test-UI "PostBtn に AutomationProperties.Name が設定されている" {
-    $prop = winapp ui get-property "PostBtn" -a $AppPid -p Name --json 2>$null | ConvertFrom-Json
-    if ($prop.value -and $prop.value.Length -gt 0) { exit 0 } else { exit 1 }
+# AutomationId（x:Name から生成）で要素が発見できることを確認
+Test-UI "PostBtn が AutomationId で発見できる" {
+    winapp ui wait-for "PostBtn" -a $AppPid -t 3000
 }
-Test-UI "AppMenuBtn に AutomationProperties.Name が設定されている" {
-    $prop = winapp ui get-property "AppMenuBtn" -a $AppPid -p Name --json 2>$null | ConvertFrom-Json
-    if ($prop.value -and $prop.value.Length -gt 0) { exit 0 } else { exit 1 }
+Test-UI "AppMenuBtn が AutomationId で発見できる" {
+    winapp ui wait-for "AppMenuBtn" -a $AppPid -t 3000
 }
+# AutomationProperties.Name が設定されていることをプロパティ取得で確認
+Test-UI "PostBtn に AutomationProperties.Name が設定されている（新規投稿）" {
+    $out = winapp ui get-property "PostBtn" -a $AppPid --property Name 2>&1
+    if (-not ($out -match "新規投稿|New Post")) { throw "Name プロパティ未設定。出力: $out" }
+}
+
+# ── About ダイアログ ──────────────────────────────────────────────────────────
+Write-Host "`n[About ダイアログ]"
+Test-UI "About ダイアログを開ける" {
+    winapp ui invoke "AppMenuBtn" -a $AppPid
+    Start-Sleep -Milliseconds 500
+    winapp ui invoke "AboutMenuItem" -a $AppPid
+}
+Start-Sleep -Milliseconds 800
+winapp ui screenshot -a $AppPid -o "test-screenshots/03-about-dialog.png" 2>$null
+
+Test-UI "About ダイアログに閉じるボタンがある" {
+    winapp ui wait-for "CloseButton" -a $AppPid -t 3000
+}
+Test-UI "About ダイアログを閉じられる" {
+    winapp ui invoke "CloseButton" -a $AppPid
+}
+Start-Sleep -Milliseconds 500
 
 # ── 最終スクリーンショット ─────────────────────────────────────────────────────
 winapp ui screenshot -a $AppPid -o "test-screenshots/99-final.png" 2>$null
 
-# ── 結果表示 ───────────────────────────────────────────────────────────────────
+# ── 結果 ───────────────────────────────────────────────────────────────────────
 Write-Host "`n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 Write-Host "結果: 成功 $pass / 失敗 $fail (合計 $($pass + $fail))"
 $results | ConvertTo-Json | Out-File "test-results.json"
-
 if ($fail -gt 0) {
     Write-Host "スクリーンショット: test-screenshots/ を確認してください"
     exit 1

--- a/ui-tests.ps1
+++ b/ui-tests.ps1
@@ -1,0 +1,119 @@
+# ui-tests.ps1 — XTimelineViewer UI Automation Tests
+# Usage: .\ui-tests.ps1 -AppPid <PID>
+#   AppPid: 実行中の XTimelineViewer のプロセス ID
+#
+# 事前準備:
+#   1. XTimelineViewer をビルド・起動しておく
+#   2. winapp がインストールされていること (winapp --version で確認)
+
+param([Parameter(Mandatory)][int]$AppPid)
+
+$ErrorActionPreference = 'Continue'
+$pass = 0; $fail = 0; $results = @()
+
+# メインウィンドウの HWND を取得（PopupHost を除外）
+$windows = winapp ui list-windows -a $AppPid --json 2>$null | ConvertFrom-Json
+$hwnd = ($windows | Where-Object { $_.title -ne "PopupHost" } | Select-Object -First 1).hwnd
+if (-not $hwnd) {
+    Write-Host "ERROR: XTimelineViewer (PID: $AppPid) が見つかりません" -ForegroundColor Red
+    exit 1
+}
+Write-Host "テスト対象: PID=$AppPid, HWND=$hwnd"
+New-Item -ItemType Directory -Force -Path "test-screenshots" | Out-Null
+
+function Test-UI {
+    param([string]$Name, [scriptblock]$Script)
+    try {
+        $output = & $Script 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            $script:pass++
+            $script:results += @{ name = $Name; status = "PASS" }
+            Write-Host "  PASS: $Name" -ForegroundColor Green
+        } else {
+            $script:fail++
+            $script:results += @{ name = $Name; status = "FAIL"; detail = "$output" }
+            Write-Host "  FAIL: $Name — $output" -ForegroundColor Red
+        }
+    } catch {
+        $script:fail++
+        $script:results += @{ name = $Name; status = "FAIL"; detail = "$_" }
+        Write-Host "  FAIL: $Name — $_" -ForegroundColor Red
+    }
+}
+
+# ── スクリーンショット（初期状態） ─────────────────────────────────────────────
+winapp ui screenshot -a $AppPid -o "test-screenshots/00-initial.png" 2>$null
+
+# ── ツールバー要素の存在確認 ──────────────────────────────────────────────────
+Write-Host "`n[ツールバー]"
+Test-UI "投稿ボタン (PostBtn) が存在する" {
+    winapp ui wait-for "PostBtn" -a $AppPid -t 3000
+}
+Test-UI "メニューボタン (AppMenuBtn) が存在する" {
+    winapp ui wait-for "AppMenuBtn" -a $AppPid -t 3000
+}
+
+# ── メニュー操作 ───────────────────────────────────────────────────────────────
+Write-Host "`n[メニュー]"
+Test-UI "メニューボタンをクリックできる" {
+    winapp ui invoke "AppMenuBtn" -a $AppPid
+}
+Start-Sleep -Milliseconds 500
+
+winapp ui screenshot -a $AppPid -o "test-screenshots/01-menu-open.png" 2>$null
+
+Test-UI "設定メニュー項目 (AppSettingsMenuItem) が表示される" {
+    winapp ui wait-for "AppSettingsMenuItem" -a $AppPid -t 3000
+}
+Test-UI "About メニュー項目 (AboutMenuItem) が表示される" {
+    winapp ui wait-for "AboutMenuItem" -a $AppPid -t 3000
+}
+
+# メニューを閉じる（Escape）
+winapp ui key "Escape" -a $AppPid 2>$null
+Start-Sleep -Milliseconds 300
+
+# ── 設定ダイアログ ─────────────────────────────────────────────────────────────
+Write-Host "`n[設定ダイアログ]"
+Test-UI "メニューから設定を開ける" {
+    winapp ui invoke "AppMenuBtn" -a $AppPid
+    Start-Sleep -Milliseconds 400
+    winapp ui invoke "AppSettingsMenuItem" -a $AppPid
+}
+Start-Sleep -Milliseconds 800
+winapp ui screenshot -a $AppPid -o "test-screenshots/02-settings-dialog.png" 2>$null
+
+Test-UI "設定ダイアログにキャンセルボタンがある" {
+    winapp ui wait-for "Cancel" -a $AppPid -t 3000
+}
+
+# ダイアログを閉じる
+winapp ui invoke "Cancel" -a $AppPid 2>$null
+Start-Sleep -Milliseconds 500
+
+# ── アクセシビリティ確認 ───────────────────────────────────────────────────────
+Write-Host "`n[アクセシビリティ]"
+Test-UI "PostBtn に AutomationProperties.Name が設定されている" {
+    $prop = winapp ui get-property "PostBtn" -a $AppPid -p Name --json 2>$null | ConvertFrom-Json
+    if ($prop.value -and $prop.value.Length -gt 0) { exit 0 } else { exit 1 }
+}
+Test-UI "AppMenuBtn に AutomationProperties.Name が設定されている" {
+    $prop = winapp ui get-property "AppMenuBtn" -a $AppPid -p Name --json 2>$null | ConvertFrom-Json
+    if ($prop.value -and $prop.value.Length -gt 0) { exit 0 } else { exit 1 }
+}
+
+# ── 最終スクリーンショット ─────────────────────────────────────────────────────
+winapp ui screenshot -a $AppPid -o "test-screenshots/99-final.png" 2>$null
+
+# ── 結果表示 ───────────────────────────────────────────────────────────────────
+Write-Host "`n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+Write-Host "結果: 成功 $pass / 失敗 $fail (合計 $($pass + $fail))"
+$results | ConvertTo-Json | Out-File "test-results.json"
+
+if ($fail -gt 0) {
+    Write-Host "スクリーンショット: test-screenshots/ を確認してください"
+    exit 1
+} else {
+    Write-Host "すべてのテストが成功しました！" -ForegroundColor Green
+    exit 0
+}


### PR DESCRIPTION
## 概要

#103 の対応。テストゼロの状態に xUnit ユニットテストと UI テストスクリプトを追加する。

## 変更内容

### `Models.cs`（新規）
`TimelineConfig` / `ProfileConfig` / `AppSettings` を `MainWindow.xaml.cs` から抽出。
WinUI 3 依存なしでテストから参照可能になった。

### `XTimelineViewer.Tests/`（新規 xUnit プロジェクト）
- `net8.0` ターゲット（WinUI 3 ビルド依存なし）
- `Models.cs` と `Services/SettingsService.cs` をファイルリンクで参照

**SettingsServiceTests — 13 テスト全グリーン ✅**

| テスト | 内容 |
|--------|------|
| `LoadSettings_MissingFile_ReturnsDefaults` | ファイルなし → デフォルト値 |
| `LoadSettings_ValidJson_ReturnsCorrectValues` | 正常 JSON → 値が復元される |
| `LoadSettings_InvalidJson_ReturnsDefaults` | 不正 JSON → デフォルト値 |
| `LoadSettings_AlwaysDisablesSeparateComposeEnv` | 廃止フラグが強制 false (#17) |
| `SaveSettings_CreatesFileAndParentDirectory` | ディレクトリも作成される |
| `SaveAndLoadSettings_RoundTrip` | 保存 → 読み込みで値が一致 |
| `LoadProfiles_MissingFile_ReturnsEmpty` | ファイルなし → 空リスト |
| `LoadProfiles_InvalidJson_ReturnsEmpty` | 不正 JSON → 空リスト |
| `LoadProfiles_ValidJson_ReturnsProfiles` | 正常 JSON → プロファイルが復元 |
| `SaveAndLoadProfiles_RoundTrip` | 保存 → 読み込みで値が一致 |
| `Cleanup_RemovesOrphanedFolders` | 孤立フォルダのみ削除 |
| `Cleanup_KeepsAllFolders_WhenAllAreKnown` | 既知フォルダは保持 |
| `Cleanup_NonExistentDirectory_DoesNotThrow` | 存在しないディレクトリでも例外なし |

### `ui-tests.ps1`（新規）
`winapp ui` を使った UI 自動化スクリプト。

```powershell
.\ui-tests.ps1 -AppPid <PID>
```

テスト内容: ツールバー要素の存在確認・メニュー開閉・設定ダイアログ・アクセシビリティ

Closes #103