### PR TITLE
refactor: MainWindowViewModel を導入し x:Bind で Visibility を制御（#102 フェーズ1）

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -6,3 +6,4 @@
 - [コードベースに言語文字列を埋め込まない](feedback_no_hardcoded_strings.md) — 多言語対応のため UI 文字列は .resw リソースファイルに書き、コードに直接埋め込まない。
 - [WinUI 3 unpackaged モードでの言語切り替え](feedback_winui3_language_switching.md) — PrimaryLanguageOverride は MSIX パッケージ ID 必須。unpackaged では resw ファイル直接パースを使う。
 - [イシューは daruyanagi にアサイン](feedback_assign_issues.md) — gh issue create に毎回 --assignee daruyanagi を付ける。
+- [イシュー解決前にコメントをすべて読む](feedback_read_issue_comments.md) — 実装前に gh issue view <number> --comments でコメントまで確認する。本文だけ読んで着手しない。

--- a/MainWindow.Profiles.cs
+++ b/MainWindow.Profiles.cs
@@ -131,11 +131,7 @@ namespace XTimelineViewer
             if (_focusedHeaderGrid == null)
                 foreach (var r in _headerRefreshers) r();
 
-            if (TimelinePanel.Children.Count == 0)
-            {
-                TimelineScroll.Visibility = Visibility.Collapsed;
-                DropHintBorder.Visibility = Visibility.Visible;
-            }
+            ViewModel.HasTimelines = TimelinePanel.Children.Count > 0;
         }
 
         private static readonly Color[] ProfileBadgeColors =

--- a/MainWindow.Timeline.cs
+++ b/MainWindow.Timeline.cs
@@ -107,8 +107,7 @@ namespace XTimelineViewer
             _configs.Add(cfg);
             _ = SaveTimelinesAsync();
 
-            DropHintBorder.Visibility = Visibility.Collapsed;
-            TimelineScroll.Visibility = Visibility.Visible;
+            ViewModel.HasTimelines = true;
 
             // Pane
             var pane = new Grid
@@ -453,11 +452,7 @@ namespace XTimelineViewer
                     await SaveTimelinesAsync();
 
                     TimelinePanel.Children.Remove(pane);
-                    if (TimelinePanel.Children.Count == 0)
-                    {
-                        TimelineScroll.Visibility = Visibility.Collapsed;
-                        DropHintBorder.Visibility = Visibility.Visible;
-                    }
+                    ViewModel.HasTimelines = TimelinePanel.Children.Count > 0;
                 }
                 else if (result == ContentDialogResult.Primary)
                 {

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -74,6 +74,7 @@
 
             <!-- Empty state hint -->
             <Border x:Name="DropHintBorder"
+                    Visibility="{x:Bind ViewModel.DropHintBorderVisibility, Mode=OneWay}"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     BorderBrush="{ThemeResource SystemControlForegroundBaseMediumBrush}"
@@ -97,11 +98,11 @@
 
             <!-- Timeline scroll area -->
             <ScrollViewer x:Name="TimelineScroll"
+                          Visibility="{x:Bind ViewModel.TimelineScrollVisibility, Mode=OneWay}"
                           HorizontalScrollMode="Enabled"
                           HorizontalScrollBarVisibility="Auto"
                           VerticalScrollMode="Disabled"
-                          VerticalScrollBarVisibility="Hidden"
-                          Visibility="Collapsed">
+                          VerticalScrollBarVisibility="Hidden">
                 <StackPanel x:Name="TimelinePanel"
                             Orientation="Horizontal"
                             Padding="4"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -19,11 +19,15 @@ using Windows.ApplicationModel.DataTransfer;
 using Windows.Graphics;
 using Windows.Storage;
 using Windows.UI;
+using XTimelineViewer.ViewModels;
 
 namespace XTimelineViewer
 {
     public sealed partial class MainWindow : Window
     {
+        /// <summary>x:Bind のバインディングソース。XAML から参照される。</summary>
+        public MainWindowViewModel ViewModel { get; } = new();
+
         private static readonly string SaveFilePath      = GetDataFilePath("timelines.json");
         private static readonly string SettingsFilePath  = GetDataFilePath("settings.json");
         private static readonly string ProfilesFilePath  = GetDataFilePath("profiles.json");

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -1,0 +1,45 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Microsoft.UI.Xaml;
+
+namespace XTimelineViewer.ViewModels
+{
+    /// <summary>
+    /// MainWindow の ViewModel（フェーズ1）。
+    /// 現時点ではタイムライン有無を管理し、UI の表示状態を制御する。
+    /// _configs / _appSettings / _profiles の移動はフェーズ2（#108）で対応予定。
+    /// </summary>
+    public class MainWindowViewModel : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        private void NotifyPropertyChanged([CallerMemberName] string? name = null)
+            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+
+        // ── タイムラインの有無 ────────────────────────────────────────────────────
+
+        private bool _hasTimelines;
+
+        /// <summary>タイムラインが1件以上存在するとき true。</summary>
+        public bool HasTimelines
+        {
+            get => _hasTimelines;
+            set
+            {
+                if (_hasTimelines == value) return;
+                _hasTimelines = value;
+                NotifyPropertyChanged();
+                NotifyPropertyChanged(nameof(TimelineScrollVisibility));
+                NotifyPropertyChanged(nameof(DropHintBorderVisibility));
+            }
+        }
+
+        /// <summary>タイムラインスクロールエリアの Visibility。タイムラインがあれば Visible。</summary>
+        public Visibility TimelineScrollVisibility
+            => HasTimelines ? Visibility.Visible : Visibility.Collapsed;
+
+        /// <summary>空状態ヒントの Visibility。タイムラインがなければ Visible。</summary>
+        public Visibility DropHintBorderVisibility
+            => HasTimelines ? Visibility.Collapsed : Visibility.Visible;
+    }
+}


### PR DESCRIPTION
## 概要

#102 フェーズ1。MVVM パターンの基盤を導入し、`DropHintBorder` と `TimelineScroll` の Visibility を `x:Bind` で制御する。

## 変更内容

### `ViewModels/MainWindowViewModel.cs`（新規）

```csharp
public class MainWindowViewModel : INotifyPropertyChanged
{
    public bool HasTimelines { get; set; }  // INPC あり
    public Visibility TimelineScrollVisibility  => HasTimelines ? Visible   : Collapsed;
    public Visibility DropHintBorderVisibility  => HasTimelines ? Collapsed : Visible;
}
```

### `MainWindow.xaml` — x:Bind に移行

```xml
<Border Visibility="{x:Bind ViewModel.DropHintBorderVisibility, Mode=OneWay}">
<ScrollViewer Visibility="{x:Bind ViewModel.TimelineScrollVisibility, Mode=OneWay}">
```

### コードビハインド（3か所）

```csharp
// Before:
DropHintBorder.Visibility = Visibility.Collapsed;
TimelineScroll.Visibility = Visibility.Visible;

// After:
ViewModel.HasTimelines = true;
```

## スコープ外（別途対応）

`_configs` / `_appSettings` / `_profiles` の ViewModel 移動と全面 x:Bind 移行は、UI 依存が深く MVVM 化が前提のため、サービスクラス抽出（#108 フェーズ2）と合わせて設計する。

## 確認

- [x] ビルド成功（警告 0）
- [x] UI テスト 15/15 PASS

Closes #102