### PR TITLE
test: テーマ・言語切り替えの UI テストを追加

### DIFF
--- a/MainWindow.Settings.cs
+++ b/MainWindow.Settings.cs
@@ -65,6 +65,7 @@ namespace XTimelineViewer
                 SelectedIndex = _appSettings.Theme switch { "Light" => 1, "Dark" => 2, _ => 0 },
                 MinWidth      = 140
             };
+            AutomationProperties.SetAutomationId(themeCombo, "ThemeComboBox");
 
             var langValues = new[] { "system", "ja-JP", "en-US" };
             var langIdx    = Array.IndexOf(langValues, _appSettings.Language);
@@ -74,6 +75,7 @@ namespace XTimelineViewer
                 SelectedIndex = langIdx < 0 ? 0 : langIdx,
                 MinWidth      = 140
             };
+            AutomationProperties.SetAutomationId(langCombo, "LanguageComboBox");
 
             var openFolderBtn = new Button { Content = R.Get("Button_OpenFolder") };
             openFolderBtn.Click += async (_, _) =>

--- a/ui-tests.ps1
+++ b/ui-tests.ps1
@@ -124,6 +124,95 @@ Test-UI "About ダイアログを閉じられる" {
 }
 Start-Sleep -Milliseconds 500
 
+# ── テーマ切り替え ─────────────────────────────────────────────────────────────
+Write-Host "`n[テーマ切り替え]"
+
+# ComboBox 内の指定テキストのアイテムスラグを返すヘルパー
+function Get-ComboItem {
+    param([string]$ComboId, [string]$ItemText, [int]$TargetPid)
+    $out = winapp ui inspect $ComboId -a $TargetPid 2>$null
+    ($out | Where-Object { $_ -match "ListItem.*$ItemText" } | Select-Object -First 1).Trim().Split(" ")[0]
+}
+
+Test-UI "テーマを Dark に変更して保存できる" {
+    winapp ui invoke "AppMenuBtn" -a $AppPid
+    Start-Sleep -Milliseconds 500
+    winapp ui invoke "AppSettingsMenuItem" -a $AppPid
+    Start-Sleep -Milliseconds 800
+    winapp ui invoke "ThemeComboBox" -a $AppPid   # 展開
+    Start-Sleep -Milliseconds 400
+    $slug = Get-ComboItem -ComboId "ThemeComboBox" -ItemText "ダーク" -TargetPid $AppPid
+    if (-not $slug) { throw "ダーク アイテムが見つからない" }
+    winapp ui invoke $slug -a $AppPid
+    Start-Sleep -Milliseconds 200
+    winapp ui invoke "PrimaryButton" -a $AppPid
+}
+Start-Sleep -Milliseconds 600
+winapp ui screenshot -a $AppPid -o "test-screenshots/04-dark-theme.png" 2>$null
+
+Test-UI "テーマをシステムに戻して保存できる" {
+    winapp ui invoke "AppMenuBtn" -a $AppPid
+    Start-Sleep -Milliseconds 500
+    winapp ui invoke "AppSettingsMenuItem" -a $AppPid
+    Start-Sleep -Milliseconds 800
+    winapp ui invoke "ThemeComboBox" -a $AppPid
+    Start-Sleep -Milliseconds 400
+    $slug = Get-ComboItem -ComboId "ThemeComboBox" -ItemText "システム" -TargetPid $AppPid
+    if (-not $slug) { throw "システム アイテムが見つからない" }
+    winapp ui invoke $slug -a $AppPid
+    Start-Sleep -Milliseconds 200
+    winapp ui invoke "PrimaryButton" -a $AppPid
+}
+Start-Sleep -Milliseconds 600
+winapp ui screenshot -a $AppPid -o "test-screenshots/05-system-theme.png" 2>$null
+
+# ── 言語切り替え ───────────────────────────────────────────────────────────────
+Write-Host "`n[言語切り替え]"
+
+Test-UI "言語を English に変更して保存できる" {
+    winapp ui invoke "AppMenuBtn" -a $AppPid
+    Start-Sleep -Milliseconds 500
+    winapp ui invoke "AppSettingsMenuItem" -a $AppPid
+    Start-Sleep -Milliseconds 800
+    winapp ui invoke "LanguageComboBox" -a $AppPid
+    Start-Sleep -Milliseconds 400
+    $slug = Get-ComboItem -ComboId "LanguageComboBox" -ItemText "English" -TargetPid $AppPid
+    if (-not $slug) { throw "English アイテムが見つからない" }
+    winapp ui invoke $slug -a $AppPid
+    Start-Sleep -Milliseconds 200
+    winapp ui invoke "PrimaryButton" -a $AppPid
+}
+Start-Sleep -Milliseconds 800
+
+Test-UI "言語変更後に再起動通知ダイアログが表示される" {
+    winapp ui wait-for "CloseButton" -a $AppPid -t 3000
+}
+Test-UI "再起動通知を閉じられる" {
+    winapp ui invoke "CloseButton" -a $AppPid
+}
+Start-Sleep -Milliseconds 500
+
+Test-UI "言語をシステムに戻して保存できる" {
+    winapp ui invoke "AppMenuBtn" -a $AppPid
+    Start-Sleep -Milliseconds 500
+    winapp ui invoke "AppSettingsMenuItem" -a $AppPid
+    Start-Sleep -Milliseconds 800
+    winapp ui invoke "LanguageComboBox" -a $AppPid
+    Start-Sleep -Milliseconds 400
+    $slug = Get-ComboItem -ComboId "LanguageComboBox" -ItemText "システム言語" -TargetPid $AppPid
+    if (-not $slug) { throw "システム言語 アイテムが見つからない" }
+    winapp ui invoke $slug -a $AppPid
+    Start-Sleep -Milliseconds 200
+    winapp ui invoke "PrimaryButton" -a $AppPid
+}
+Start-Sleep -Milliseconds 800
+
+Test-UI "言語戻し後の再起動通知を閉じられる" {
+    winapp ui wait-for "CloseButton" -a $AppPid -t 3000
+    winapp ui invoke "CloseButton" -a $AppPid
+}
+Start-Sleep -Milliseconds 500
+
 # ── 最終スクリーンショット ─────────────────────────────────────────────────────
 winapp ui screenshot -a $AppPid -o "test-screenshots/99-final.png" 2>$null
 


### PR DESCRIPTION
## 概要

#113 の対応。設定ダイアログのテーマ・言語切り替え操作を UI テストで自動検証する。

## 変更内容

### `MainWindow.Settings.cs`

設定ダイアログの ComboBox に `AutomationId` を付与し、テストから安定して参照できるようにした。

```csharp
AutomationProperties.SetAutomationId(themeCombo,    "ThemeComboBox");
AutomationProperties.SetAutomationId(langCombo,     "LanguageComboBox");
```

### `ui-tests.ps1`

**`Get-ComboItem` ヘルパー関数を追加**

`winapp ui inspect` でドロップダウンを展開後にアイテムのスラグを動的取得する。アドレスベースのスラグは起動ごとに変わるため、テキストマッチで特定する。

**[テーマ切り替え] セクション（2テスト）**

| テスト | 内容 |
|--------|------|
| テーマを Dark に変更して保存 | ThemeComboBox を展開→ダーク選択→保存→スクリーンショット |
| テーマをシステムに戻して保存 | 同様の操作でシステムに戻す |

**[言語切り替え] セクション（5テスト）**

| テスト | 内容 |
|--------|------|
| 言語を English に変更して保存 | LanguageComboBox で English を選択→保存 |
| 再起動通知ダイアログが表示される | CloseButton の出現を確認 |
| 再起動通知を閉じられる | CloseButton を invoke |
| 言語をシステムに戻して保存 | システム言語に戻す |
| 言語戻し後の通知を閉じる | 2回目の通知を閉じる |

## 確認

- [x] ビルド成功（警告 0）
- [x] UI テスト 22/22 PASS
- [x] スクリーンショットでダーク→ライト切り替えを視覚確認

Closes #113