### PR TITLE
fix: ブックマークでヘッダーを隠すと最初の投稿が消える問題を修正

### DIFF
--- a/MainWindow.WebView2.cs
+++ b/MainWindow.WebView2.cs
@@ -80,10 +80,12 @@ namespace XTimelineViewer
                         css.push('div:has(>div>div>div>div>div>button[data-testid="app-bar-back"]){display:none!important}');
                         css.push('[data-testid="cellInnerDiv"]:has(a[href*="/i/lists/"][href$="/members"]){display:none!important}');
                     }
-                    // ブックマーク: 上部ナビバー＋nth-child(1)ブロック＋空フォルダの説明文を非表示
+                    // ブックマーク: 上部ナビバー＋タイトルブロック＋空フォルダの説明文を非表示
+                    // nth-child(1) は X の DOM 変更で最初の投稿まで隠れる問題があったため
+                    // :has(h2) でタイトル見出しを含む要素のみを対象にする (#115)
                     if(/^\/(i\/bookmarks|bookmarks)/.test(path)){
                         css.push('div:has(>div>div>div>div>div>button[data-testid="app-bar-back"]){display:none!important}');
-                        css.push('#react-root main section>div>div>div:nth-child(1){display:none!important}');
+                        css.push('#react-root main section>div>div>div:has(h2){display:none!important}');
                         css.push('[data-testid="emptyState"]{display:none!important}');
                     }
                     // プロフィール: ナビバー＋プロフィール情報カード（バナー・アバター・自己紹介・フォロー数）を非表示


### PR DESCRIPTION
## 概要

#115 の修正。ブックマークタイムラインでヘッダー非表示を有効にすると、最初の投稿まで消えてしまう問題を解消する。

## 原因

`BuildHideListHeaderJs` のブックマーク向け CSS セレクター：

```js
// Before（問題あり）
css.push('#react-root main section>div>div>div:nth-child(1){display:none!important}');
```

`:nth-child(1)` は「Bookmarks」タイトルブロックを狙っていたが、X の DOM 変更により最初のツイートも同じ条件に一致するようになっていた。

## 修正

```js
// After（修正後）
css.push('#react-root main section>div>div>div:has(h2){display:none!important}');
```

`:has(h2)` に変更することで、見出しテキスト（「ブックマーク」タイトル）を含む要素のみに限定し、ツイート要素は対象外にする。ツイートカードは `h2` を持たないため、誤マッチが発生しない。

Closes #115