### PR TITLE
feat: 再起動なしで UI 言語設定を即時反映する

### DIFF
--- a/MainWindow.Settings.cs
+++ b/MainWindow.Settings.cs
@@ -215,14 +215,11 @@ namespace XTimelineViewer
 
                 if (langChanged)
                 {
-                    var notifDlg = new ContentDialog
-                    {
-                        Content         = R.Get("RestartRequired"),
-                        CloseButtonText = R.Get("Button_Close"),
-                        XamlRoot        = Content.XamlRoot,
-                        RequestedTheme  = ((FrameworkElement)Content).ActualTheme
-                    };
-                    await ShowDialogAsync(notifDlg);
+                    // 再起動なしで即時反映する (#117)。
+                    // "system" の場合はシステム言語にフォールバックさせるため null を渡す。
+                    var locale = newLang == "system" ? null : newLang;
+                    R.Reload(locale);
+                    RefreshUIText();
                 }
             }
         }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -250,16 +250,7 @@ namespace XTimelineViewer
             var iconPath = Path.Combine(AppContext.BaseDirectory, "Assets", "AppIcon.ico");
             if (File.Exists(iconPath)) AppWindow.SetIcon(iconPath);
             Title = "XTimelineViewer";
-            PostLabel.Text       = R.Get("PostLabel.Text");
-            DropHintTitle.Text   = R.Get("DropHintTitle.Text");
-            DropHintSubtitle.Text = R.Get("DropHintSubtitle.Text");
-            ToolTipService.SetToolTip(PostBtn, R.Get("PostBtn_Tooltip"));
-            ToolTipService.SetToolTip(AppMenuBtn, R.Get("AppMenu_Tooltip"));
-            AutomationProperties.SetName(PostBtn,   R.Get("PostBtn_Tooltip"));
-            AutomationProperties.SetName(AppMenuBtn, R.Get("AppMenu_Tooltip"));
-            ManageProfilesMenuItem.Text = R.Get("Menu_ManageProfiles");
-            AppSettingsMenuItem.Text     = R.Get("Menu_Settings");
-            AboutMenuItem.Text       = R.Get("Menu_About");
+            RefreshUIText();
             Closed += async (s, e) =>
             {
                 _hardReloadUiTimer?.Stop();
@@ -277,6 +268,22 @@ namespace XTimelineViewer
             UpdateMenuUpdateBadge();
             _ = RestoreTimelinesAsync();
             _ = CheckForUpdatesInBackgroundAsync();
+        }
+
+        // ツールバー・メニューなど常駐 UI の静的テキストを現在の言語で再適用する。
+        // 起動時のほか、言語切り替え後（#117）にも呼ばれる。
+        private void RefreshUIText()
+        {
+            PostLabel.Text        = R.Get("PostLabel.Text");
+            DropHintTitle.Text    = R.Get("DropHintTitle.Text");
+            DropHintSubtitle.Text = R.Get("DropHintSubtitle.Text");
+            ToolTipService.SetToolTip(PostBtn,    R.Get("PostBtn_Tooltip"));
+            ToolTipService.SetToolTip(AppMenuBtn, R.Get("AppMenu_Tooltip"));
+            AutomationProperties.SetName(PostBtn,    R.Get("PostBtn_Tooltip"));
+            AutomationProperties.SetName(AppMenuBtn, R.Get("AppMenu_Tooltip"));
+            ManageProfilesMenuItem.Text = R.Get("Menu_ManageProfiles");
+            AppSettingsMenuItem.Text    = R.Get("Menu_Settings");
+            AboutMenuItem.Text          = R.Get("Menu_About");
         }
 
         private async Task<ContentDialogResult> ShowDialogAsync(ContentDialog dlg)

--- a/R.cs
+++ b/R.cs
@@ -23,6 +23,14 @@ namespace XTimelineViewer
             _dict = LoadResw(locale) ?? LoadResw("en-US") ?? [];
         }
 
+        // 実行中に言語を切り替えるためリソース辞書を再読み込みする (#117)。
+        // languageOverride が null の場合はシステム言語にフォールバックする。
+        internal static void Reload(string? languageOverride = null)
+        {
+            _initialized = false;
+            Initialize(languageOverride);
+        }
+
         // システム言語から使用する resw ロケールフォルダー名を決定する。
         // ja 系は "ja-JP"、それ以外は "en-US" にフォールバックする。
         private static string ResolveSystemLocale()

--- a/ui-tests.ps1
+++ b/ui-tests.ps1
@@ -184,13 +184,13 @@ Test-UI "言語を English に変更して保存できる" {
 }
 Start-Sleep -Milliseconds 800
 
-Test-UI "言語変更後に再起動通知ダイアログが表示される" {
-    winapp ui wait-for "CloseButton" -a $AppPid -t 3000
+# 再起動なしで即時反映される (#117)。再起動通知ダイアログは出ない。
+# PostBtn の AutomationProperties.Name が英語 "New Post" に変わることで検証する。
+Test-UI "言語変更が即座に UI に反映される（PostBtn → New Post）" {
+    $out = winapp ui get-property "PostBtn" -a $AppPid --property Name 2>&1
+    if (-not ($out -match "New Post")) { throw "英語に切り替わっていない。出力: $out" }
 }
-Test-UI "再起動通知を閉じられる" {
-    winapp ui invoke "CloseButton" -a $AppPid
-}
-Start-Sleep -Milliseconds 500
+winapp ui screenshot -a $AppPid -o "test-screenshots/06-lang-english.png" 2>$null
 
 Test-UI "言語をシステムに戻して保存できる" {
     winapp ui invoke "AppMenuBtn" -a $AppPid
@@ -199,19 +199,20 @@ Test-UI "言語をシステムに戻して保存できる" {
     Start-Sleep -Milliseconds 800
     winapp ui invoke "LanguageComboBox" -a $AppPid
     Start-Sleep -Milliseconds 400
-    $slug = Get-ComboItem -ComboId "LanguageComboBox" -ItemText "システム言語" -TargetPid $AppPid
-    if (-not $slug) { throw "システム言語 アイテムが見つからない" }
+    # この時点で UI は英語なので "System Language" でアイテムを探す
+    $slug = Get-ComboItem -ComboId "LanguageComboBox" -ItemText "System Language" -TargetPid $AppPid
+    if (-not $slug) { throw "System Language アイテムが見つからない" }
     winapp ui invoke $slug -a $AppPid
     Start-Sleep -Milliseconds 200
     winapp ui invoke "PrimaryButton" -a $AppPid
 }
 Start-Sleep -Milliseconds 800
 
-Test-UI "言語戻し後の再起動通知を閉じられる" {
-    winapp ui wait-for "CloseButton" -a $AppPid -t 3000
-    winapp ui invoke "CloseButton" -a $AppPid
+# システム言語（日本語環境）に戻り、PostBtn が "新規投稿" に即時で戻ることを検証する。
+Test-UI "言語が即座にシステム言語へ戻る（PostBtn → 新規投稿）" {
+    $out = winapp ui get-property "PostBtn" -a $AppPid --property Name 2>&1
+    if (-not ($out -match "新規投稿")) { throw "システム言語に戻っていない。出力: $out" }
 }
-Start-Sleep -Milliseconds 500
 
 # ── 最終スクリーンショット ─────────────────────────────────────────────────────
 winapp ui screenshot -a $AppPid -o "test-screenshots/99-final.png" 2>$null


### PR DESCRIPTION
## 概要

#117 の対応。言語設定を変更したときに、アプリを再起動せず即座に UI へ反映する。
従来は「次回起動時に反映されます」という通知が出て再起動が必要だった。

## 実装

### `R.cs` — `Reload()` を追加

```csharp
internal static void Reload(string? languageOverride = null)
{
    _initialized = false;   // ガードをリセット
    Initialize(languageOverride);
}
```

### `MainWindow.xaml.cs` — `RefreshUIText()` を追加

コンストラクタにあった静的テキスト初期化を共通メソッドへ括り出し、起動時と言語切り替え後の両方から呼べるようにした。

### `MainWindow.Settings.cs` — 再起動通知を廃止

```csharp
if (langChanged)
{
    var locale = newLang == "system" ? null : newLang;
    R.Reload(locale);
    RefreshUIText();   // 即時反映
}
```

## UI テスト更新（`ui-tests.ps1`）

再起動通知が出なくなったため、テストを実挙動に合わせて更新した。

| 変更 | 内容 |
|------|------|
| 削除 | 再起動通知ダイアログ前提のテスト 3 件 |
| 追加 | English に変更 → `PostBtn.Name` が "New Post" になる |
| 追加 | システムに戻す → `PostBtn.Name` が "新規投稿" に戻る |

**全 21 テスト PASS ✅**（スクリーンショットで投稿ボタンが "Post" に即時変化することも確認）

## 即時反映される範囲

設定/About/プロファイル各ダイアログは開くたびに `R.Get()` を呼ぶため自動対応。ツールチップ系も 1 秒タイマーで再評価される。

## 既知の制限

タイムラインペインのヘッダーに埋め込まれた歯車ボタンのツールチップのみ、次にペインを作り直すまで旧言語のまま（軽微）。

Closes #117