### PR TITLE
feat: ハンバーガーメニューからタイムラインを追加できるようにする

### DIFF
--- a/MainWindow.Timeline.cs
+++ b/MainWindow.Timeline.cs
@@ -100,6 +100,21 @@ namespace XTimelineViewer
             url.Contains("x.com",       StringComparison.OrdinalIgnoreCase) ||
             url.Contains("twitter.com", StringComparison.OrdinalIgnoreCase);
 
+        // ── Quick add from menu (#120) ────────────────────────────────────────
+
+        internal const string HomeTimelineUrl          = "https://x.com/home";
+        internal const string NotificationsTimelineUrl = "https://x.com/notifications";
+        internal const string BookmarksTimelineUrl     = "https://x.com/i/bookmarks";
+
+        private void AddHomeTimelineItem_Click(object _, RoutedEventArgs __)
+            => AddTimeline(new TimelineConfig { Url = HomeTimelineUrl });
+
+        private void AddNotificationsTimelineItem_Click(object _, RoutedEventArgs __)
+            => AddTimeline(new TimelineConfig { Url = NotificationsTimelineUrl });
+
+        private void AddBookmarksTimelineItem_Click(object _, RoutedEventArgs __)
+            => AddTimeline(new TimelineConfig { Url = BookmarksTimelineUrl });
+
         // ── AddTimeline ───────────────────────────────────────────────────────
 
         private void AddTimeline(TimelineConfig cfg)

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -47,6 +47,24 @@
                     <FontIcon Glyph="&#xE700;" FontFamily="Segoe Fluent Icons" FontSize="14"/>
                     <Button.Flyout>
                         <MenuFlyout>
+                            <MenuFlyoutSubItem x:Name="AddTimelineSubMenu">
+                                <MenuFlyoutItem x:Name="AddHomeTimelineItem" Click="AddHomeTimelineItem_Click">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon x:Name="AddHomeIcon" FontFamily="Segoe Fluent Icons"/>
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
+                                <MenuFlyoutItem x:Name="AddNotificationsTimelineItem" Click="AddNotificationsTimelineItem_Click">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon x:Name="AddNotificationsIcon" FontFamily="Segoe Fluent Icons"/>
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
+                                <MenuFlyoutItem x:Name="AddBookmarksTimelineItem" Click="AddBookmarksTimelineItem_Click">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon x:Name="AddBookmarksIcon" FontFamily="Segoe Fluent Icons"/>
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
+                            </MenuFlyoutSubItem>
+                            <MenuFlyoutSeparator/>
                             <MenuFlyoutItem x:Name="ManageProfilesMenuItem" Click="ManageProfilesMenuItem_Click"/>
                             <MenuFlyoutSeparator/>
                             <MenuFlyoutItem x:Name="AppSettingsMenuItem" Click="AppSettingsMenuItem_Click"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -284,6 +284,15 @@ namespace XTimelineViewer
             ManageProfilesMenuItem.Text = R.Get("Menu_ManageProfiles");
             AppSettingsMenuItem.Text    = R.Get("Menu_Settings");
             AboutMenuItem.Text          = R.Get("Menu_About");
+
+            AddTimelineSubMenu.Text           = R.Get("Menu_AddTimeline");
+            AddHomeTimelineItem.Text          = R.Get("Timeline_Home");
+            AddNotificationsTimelineItem.Text = R.Get("Timeline_Notifications");
+            AddBookmarksTimelineItem.Text     = R.Get("Timeline_Bookmarks");
+            // アイコンは既存ペインと同じく URL 種別から導出して一貫性を保つ
+            AddHomeIcon.Glyph          = GetTimelineGlyph(HomeTimelineUrl);
+            AddNotificationsIcon.Glyph = GetTimelineGlyph(NotificationsTimelineUrl);
+            AddBookmarksIcon.Glyph     = GetTimelineGlyph(BookmarksTimelineUrl);
         }
 
         private async Task<ContentDialogResult> ShowDialogAsync(ContentDialog dlg)

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -19,6 +19,12 @@
   <data name="Menu_ManageProfiles" xml:space="preserve"><value>Manage Profiles (Experimental)</value></data>
   <data name="Menu_About" xml:space="preserve"><value>About XTimelineViewer</value></data>
 
+  <!-- Add timeline menu -->
+  <data name="Menu_AddTimeline" xml:space="preserve"><value>Add Timeline</value></data>
+  <data name="Timeline_Home" xml:space="preserve"><value>Home</value></data>
+  <data name="Timeline_Notifications" xml:space="preserve"><value>Notifications</value></data>
+  <data name="Timeline_Bookmarks" xml:space="preserve"><value>Bookmarks</value></data>
+
   <!-- Add profile window -->
   <data name="AddProfile_Title" xml:space="preserve"><value>Add New Profile</value></data>
   <data name="AddProfile_LoginHint" xml:space="preserve"><value>Sign in to X</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -19,6 +19,12 @@
   <data name="Menu_ManageProfiles" xml:space="preserve"><value>プロファイルを管理（試験機能）</value></data>
   <data name="Menu_About" xml:space="preserve"><value>XTimelineViewer について</value></data>
 
+  <!-- Add timeline menu -->
+  <data name="Menu_AddTimeline" xml:space="preserve"><value>タイムラインを追加</value></data>
+  <data name="Timeline_Home" xml:space="preserve"><value>ホーム</value></data>
+  <data name="Timeline_Notifications" xml:space="preserve"><value>通知</value></data>
+  <data name="Timeline_Bookmarks" xml:space="preserve"><value>ブックマーク</value></data>
+
   <!-- Add profile window -->
   <data name="AddProfile_Title" xml:space="preserve"><value>新しいプロファイルを追加</value></data>
   <data name="AddProfile_LoginHint" xml:space="preserve"><value>X にサインインしてください</value></data>

--- a/ui-tests.ps1
+++ b/ui-tests.ps1
@@ -91,6 +91,29 @@ Test-UI "設定ダイアログをキャンセルで閉じられる" {
 }
 Start-Sleep -Milliseconds 500
 
+# ── タイムライン追加メニュー (#120) ────────────────────────────────────────────
+# 注: 実際の追加は timelines.json を変更し状態を汚すため、ここでは
+#     サブメニューが開いて定型項目が表示されることのみを検証する。
+Write-Host "`n[タイムライン追加メニュー]"
+Test-UI "タイムライン追加サブメニューを展開できる" {
+    winapp ui invoke "AppMenuBtn" -a $AppPid
+    Start-Sleep -Milliseconds 500
+    winapp ui invoke "AddTimelineSubMenu" -a $AppPid
+}
+Start-Sleep -Milliseconds 500
+Test-UI "ホーム追加項目が表示される" {
+    winapp ui wait-for "AddHomeTimelineItem" -a $AppPid -t 3000
+}
+Test-UI "通知追加項目が表示される" {
+    winapp ui wait-for "AddNotificationsTimelineItem" -a $AppPid -t 3000
+}
+Test-UI "ブックマーク追加項目が表示される" {
+    winapp ui wait-for "AddBookmarksTimelineItem" -a $AppPid -t 3000
+}
+# メニューを閉じる（追加はしない）
+winapp ui invoke "AppMenuBtn" -a $AppPid 2>$null
+Start-Sleep -Milliseconds 500
+
 # ── アクセシビリティ確認 ───────────────────────────────────────────────────────
 Write-Host "`n[アクセシビリティ]"
 # AutomationId（x:Name から生成）で要素が発見できることを確認


### PR DESCRIPTION
## 概要

#120 の対応。右上の ☰ メニューから定型タイムライン（ホーム / 通知 / ブックマーク）をワンクリックで追加できるようにする。従来のドラッグ＆ドロップ追加もそのまま維持。

## 変更内容

### メニュー構成（`MainWindow.xaml`）

```
☰ メニュー
 ├ タイムラインを追加 ▶
 │   ├ 🏠 ホーム        → https://x.com/home
 │   ├ 🔔 通知          → https://x.com/notifications
 │   └ 🔖 ブックマーク   → https://x.com/i/bookmarks
 ├ プロファイルを管理
 ├ 設定
 └ バージョン情報
```

### コードビハインド

- `AddHomeTimelineItem_Click` 他 3 ハンドラ → `AddTimeline(new TimelineConfig { Url = ... })`
- 定型 URL を `HomeTimelineUrl` / `NotificationsTimelineUrl` / `BookmarksTimelineUrl` 定数に集約
- アイコンは既存 `GetTimelineGlyph()` を流用してペインと見た目を統一
- メニュー文言は resw（en-US / ja-JP）に追加し、`RefreshUIText()` で再適用 → 言語切替（#117）にも追随

### 維持

- 従来のドラッグ＆ドロップ追加（`MainArea_Drop`）は変更なし

## UI テスト（`ui-tests.ps1`）

サブメニューを展開して 3 項目が表示されることを検証する 3 テストを追加。
（実際の追加は `timelines.json` を変更し状態を汚すため自動テスト対象外。手動で追加→表示→復元を確認済み）

## 確認

- [x] ビルド成功（警告 0）
- [x] 実機でメニューからブックマークを追加 → 4 列目に表示されることを確認（スクリーンショット）
- [x] 確認後 `timelines.json` をバックアップから復元

## 留意点

追加先プロファイルは従来の D&D と同じく `default`。追加後にペイン設定でプロファイル変更が可能。

Closes #120