### PR TITLE
fix: メニュー・ペインのアイコン欠落を修正し、メニュー全体にアイコンを整備

### DIFF
--- a/MainWindow.WebView2.cs
+++ b/MainWindow.WebView2.cs
@@ -26,19 +26,22 @@ namespace XTimelineViewer
     {
         // ── WebView2 init ─────────────────────────────────────────────────────
 
+        // グリフは Segoe Fluent Icons の私用領域(PUA)コードポイント。
+        // 生の PUA 文字を直書きするとエンコーディング事故で欠落するため (#122)、
+        // 必ず "\uXXXX" エスケープ表記で記述すること。
         private static string GetTimelineGlyph(string url)
         {
             if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return "";
             var p = uri.AbsolutePath;
-            if (p.StartsWith("/home"))                                return ""; // Home
-            if (p.StartsWith("/notifications"))                       return ""; // Bell
-            if (p.StartsWith("/search") || p.StartsWith("/explore")) return ""; // Search
+            if (p.StartsWith("/home"))                                return "\uE80F"; // Home
+            if (p.StartsWith("/notifications"))                       return "\uE7E7"; // Bell
+            if (p.StartsWith("/search") || p.StartsWith("/explore")) return "\uE71E"; // Search
             if (p == "/bookmarks" || p.StartsWith("/bookmarks/") ||
-                p == "/i/bookmarks" || p.StartsWith("/i/bookmarks/")) return ""; // Bookmark
-            if (p.StartsWith("/i/lists/"))                            return ""; // BulletedList
-            if (p.StartsWith("/messages"))                            return ""; // Chat
-            if (System.Text.RegularExpressions.Regex.IsMatch(p, @"^/[^/]+$")) return ""; // Contact
-            return ""; // Globe
+                p == "/i/bookmarks" || p.StartsWith("/i/bookmarks/")) return "\uE734"; // Bookmark
+            if (p.StartsWith("/i/lists/"))                            return "\uE71D"; // BulletedList
+            if (p.StartsWith("/messages"))                            return "\uE8BD"; // Chat
+            if (System.Text.RegularExpressions.Regex.IsMatch(p, @"^/[^/]+$")) return "\uE77B"; // Contact
+            return "\uE774"; // Globe
         }
 
         private static bool IsProfilePath(string p) =>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -48,6 +48,9 @@
                     <Button.Flyout>
                         <MenuFlyout>
                             <MenuFlyoutSubItem x:Name="AddTimelineSubMenu">
+                                <MenuFlyoutSubItem.Icon>
+                                    <FontIcon Glyph="&#xE710;" FontFamily="Segoe Fluent Icons"/>
+                                </MenuFlyoutSubItem.Icon>
                                 <MenuFlyoutItem x:Name="AddHomeTimelineItem" Click="AddHomeTimelineItem_Click">
                                     <MenuFlyoutItem.Icon>
                                         <FontIcon x:Name="AddHomeIcon" FontFamily="Segoe Fluent Icons"/>
@@ -65,11 +68,23 @@
                                 </MenuFlyoutItem>
                             </MenuFlyoutSubItem>
                             <MenuFlyoutSeparator/>
-                            <MenuFlyoutItem x:Name="ManageProfilesMenuItem" Click="ManageProfilesMenuItem_Click"/>
+                            <MenuFlyoutItem x:Name="ManageProfilesMenuItem" Click="ManageProfilesMenuItem_Click">
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon Glyph="&#xE716;" FontFamily="Segoe Fluent Icons"/>
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
                             <MenuFlyoutSeparator/>
-                            <MenuFlyoutItem x:Name="AppSettingsMenuItem" Click="AppSettingsMenuItem_Click"/>
+                            <MenuFlyoutItem x:Name="AppSettingsMenuItem" Click="AppSettingsMenuItem_Click">
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon Glyph="&#xE713;" FontFamily="Segoe Fluent Icons"/>
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
                             <MenuFlyoutSeparator/>
-                            <MenuFlyoutItem x:Name="AboutMenuItem" Click="AboutMenuItem_Click"/>
+                            <MenuFlyoutItem x:Name="AboutMenuItem" Click="AboutMenuItem_Click">
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon Glyph="&#xE946;" FontFamily="Segoe Fluent Icons"/>
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
                         </MenuFlyout>
                     </Button.Flyout>
                 </Button>


### PR DESCRIPTION
## 概要

#122 の対応。ハンバーガーメニューおよびタイムラインペインのアイコンが表示されない不具合を修正し、あわせてメニュー一段目にもアイコンを整備する。

## 原因（daruyanagi さんの推測どおり）

`#101` の partial class 分割時に、`GetTimelineGlyph()` の私用領域(PUA)グリフ文字が**エンコーディング事故で欠落**し、全戻り値が空文字列になっていた。

`git show v1.4.0:MainWindow.xaml.cs` で確認したところ、v1.4.0 では各グリフが `len=1`（正常）→ 現行 main では `len=0`（空）。`GetTimelineGlyph()` はペインヘッダーと追加メニューの両方で使われていたため、双方でアイコンが消えていた。

## 修正内容

### `GetTimelineGlyph()` のグリフ復元（バグ修正）

v1.4.0 から正しいコードポイントを復元。**生 PUA 直書きをやめ `"\uXXXX"` エスケープ表記に統一**（再発防止）。

| 種別 | グリフ |
|------|--------|
| Home | `` |
| Bell | `` |
| Search | `` |
| Bookmark | `` |
| BulletedList | `` |
| Chat | `` |
| Contact | `` |
| Globe | `` |

### メニュー一段目にアイコン追加（機能追加）

XAML の数値文字参照（`&#xXXXX;`、ASCII で安全）で付与：

| メニュー項目 | グリフ |
|-------------|--------|
| タイムラインを追加（サブメニュー見出し）| Add `E710` |
| プロファイルを管理 | People `E716` |
| 設定 | Setting `E713` |
| バージョン情報 | Info `E946` |

## 確認

- [x] ビルド成功（警告 0）
- [x] タイムラインヘッダーの種別アイコンが復活
- [x] メニュー一段目（追加・プロファイル・設定・About）にアイコン表示
- [x] タイムライン追加サブメニュー（ホーム・通知・ブックマーク）にアイコン表示
- スクリーンショットで視覚確認

## 再発防止

PUA グリフは今後 `"\uXXXX"`（C#）/ `&#xXXXX;`（XAML）のエスケープ表記で記述するルールをコードコメントに明記した。

Closes #122