### PR TITLE
refactor: Edge Dev 依存を除去 (#124)

### DIFF
--- a/MainWindow.Settings.cs
+++ b/MainWindow.Settings.cs
@@ -229,14 +229,11 @@ namespace XTimelineViewer
             var currentVersion = Assembly.GetExecutingAssembly().GetName().Version!;
             var versionStr     = currentVersion.ToString(3);
 
-            var edgeChannel = FindEdgeDevVersionFolder() is not null
-                ? R.Get("EdgeChannel_Dev")
-                : R.Get("EdgeChannel_Runtime");
+            var edgeChannel = R.Get("EdgeChannel_Runtime");
             string edgeVersion;
             try
             {
-                edgeVersion = CoreWebView2Environment.GetAvailableBrowserVersionString(
-                    FindEdgeDevVersionFolder() ?? "");
+                edgeVersion = CoreWebView2Environment.GetAvailableBrowserVersionString();
             }
             catch
             {

--- a/MainWindow.WebView2.cs
+++ b/MainWindow.WebView2.cs
@@ -391,7 +391,7 @@ namespace XTimelineViewer
                             MaxHeight = 300,
                             Content   = new TextBlock
                             {
-                                Text = $"EdgeDevAppDir: {EdgeDevAppDir}\n\nログ: {LogFilePath}\n\n{ex}",
+                                Text = $"ログ: {LogFilePath}\n\n{ex}",
                                 FontFamily = new FontFamily("Cascadia Mono, Consolas, Courier New"),
                                 FontSize   = 12,
                                 IsTextSelectionEnabled = true,

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -191,18 +191,6 @@ namespace XTimelineViewer
             })();
             """;
 
-        private static readonly string EdgeDevAppDir =
-            @"C:\Program Files (x86)\Microsoft\Edge Dev\Application";
-
-        private static string? FindEdgeDevVersionFolder()
-        {
-            if (!Directory.Exists(EdgeDevAppDir)) return null;
-            return Directory.GetDirectories(EdgeDevAppDir)
-                .Where(d => Version.TryParse(Path.GetFileName(d), out _))
-                .OrderByDescending(d => Version.Parse(Path.GetFileName(d)))
-                .FirstOrDefault();
-        }
-
         private static string GetProfilesDataDir()
         {
             if (PackageContext.IsPackaged)
@@ -223,7 +211,7 @@ namespace XTimelineViewer
                 Directory.CreateDirectory(userDataFolder);
             var options = new CoreWebView2EnvironmentOptions { AreBrowserExtensionsEnabled = true };
             var env = await CoreWebView2Environment.CreateWithOptionsAsync(
-                FindEdgeDevVersionFolder() ?? "", userDataFolder, options);
+                "", userDataFolder, options);
             _profileEnvs[profileId] = env;
             Debug.WriteLine($"[Profile] Env created: profileId={profileId}, UserDataFolder={env.UserDataFolder}");
             return env;
@@ -236,10 +224,9 @@ namespace XTimelineViewer
         private async Task<CoreWebView2Environment> GetOrCreateComposeEnvAsync()
         {
             if (_composeEnv is not null) return _composeEnv;
-            var versionFolder = FindEdgeDevVersionFolder();
             var options = new CoreWebView2EnvironmentOptions { AreBrowserExtensionsEnabled = false };
             _composeEnv = await CoreWebView2Environment.CreateWithOptionsAsync(
-                versionFolder ?? "", userDataFolder: ComposeUserDataFolder, options);
+                "", userDataFolder: ComposeUserDataFolder, options);
             return _composeEnv;
         }
 

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -113,7 +113,7 @@
   <!-- Version info -->
   <data name="Version_Unknown" xml:space="preserve"><value>Unknown</value></data>
   <data name="EdgeChannel_Runtime" xml:space="preserve"><value>WebView2 Runtime</value></data>
-  <data name="EdgeChannel_Dev" xml:space="preserve"><value>Edge Dev</value></data>
+
 
   <!-- Issue report body labels -->
   <data name="IssueLabel_AppVersion" xml:space="preserve"><value>App version</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -113,7 +113,7 @@
   <!-- Version info -->
   <data name="Version_Unknown" xml:space="preserve"><value>不明</value></data>
   <data name="EdgeChannel_Runtime" xml:space="preserve"><value>WebView2 ランタイム</value></data>
-  <data name="EdgeChannel_Dev" xml:space="preserve"><value>Edge Dev</value></data>
+
 
   <!-- Issue report body labels -->
   <data name="IssueLabel_AppVersion" xml:space="preserve"><value>アプリバージョン</value></data>


### PR DESCRIPTION
## Summary
- Edge Dev チャネルへの依存を除去し、WebView2 Runtime のみを使用するように変更
- `FindEdgeDevVersionFolder()` メソッドと `EdgeDevAppDir` 定数を削除
- About ダイアログの Edge Dev / Runtime 分岐を簡素化
- リソースキー `EdgeChannel_Dev` を削除（ja-JP / en-US）

## Background
ブラウザ拡張機能 API（`AreBrowserExtensionsEnabled` / `AddBrowserExtensionAsync`）は WebView2 SDK 1.0.2210.55 で安定版 Release SDK に昇格済み。Edge Dev チャネルは不要。

## Test plan
- [x] アプリが WebView2 Runtime で正常に起動すること
- [x] タイムラインが表示されること
- [x] 拡張機能が正常にロードされること
- [x] About ダイアログに「WebView2 ランタイム」とバージョンが表示されること

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)