### PR TITLE
fix: 拡張機能設定ダイアログに明暗テーマを適用 (#126)

### DIFF
--- a/MainWindow.Post.cs
+++ b/MainWindow.Post.cs
@@ -41,7 +41,6 @@ namespace XTimelineViewer
                 Content         = webView,
                 CloseButtonText = R.Get("Button_Close"),
                 XamlRoot        = Content.XamlRoot,
-                RequestedTheme  = ((FrameworkElement)Content).ActualTheme
             };
 
             var env = _appSettings.SeparateComposeEnv

--- a/MainWindow.Settings.cs
+++ b/MainWindow.Settings.cs
@@ -187,7 +187,6 @@ namespace XTimelineViewer
                 CloseButtonText   = R.Get("Button_Cancel"),
                 DefaultButton     = ContentDialogButton.Primary,
                 XamlRoot          = Content.XamlRoot,
-                RequestedTheme    = ((FrameworkElement)Content).ActualTheme
             };
 
                         if (await ShowDialogAsync(dlg) == ContentDialogResult.Primary)
@@ -463,7 +462,6 @@ namespace XTimelineViewer
                 Content         = panel,
                 CloseButtonText = R.Get("Button_Close"),
                 XamlRoot        = Content.XamlRoot,
-                RequestedTheme  = ((FrameworkElement)Content).ActualTheme,
             };
             await ShowDialogAsync(dlg);
         }

--- a/MainWindow.Updates.cs
+++ b/MainWindow.Updates.cs
@@ -101,7 +101,6 @@ namespace XTimelineViewer
                 PrimaryButtonText = R.Get("CheckUpdate_WingetConfirm"),
                 CloseButtonText   = R.Get("Button_Cancel"),
                 XamlRoot          = Content.XamlRoot,
-                RequestedTheme    = ((FrameworkElement)Content).ActualTheme,
             };
 
             if (await ShowDialogAsync(confirmDlg) != ContentDialogResult.Primary) return;

--- a/MainWindow.WebView2.cs
+++ b/MainWindow.WebView2.cs
@@ -324,13 +324,29 @@ namespace XTimelineViewer
 
                 var env = await GetOrCreateProfileEnvAsync("default");
                 await optWebView.EnsureCoreWebView2Async(env);
-                optWebView.CoreWebView2.Profile.PreferredColorScheme =
-                    ((FrameworkElement)Content).ActualTheme switch
+                var isDark = ((FrameworkElement)Content).ActualTheme == ElementTheme.Dark;
+                optWebView.CoreWebView2.Profile.PreferredColorScheme = isDark
+                    ? CoreWebView2PreferredColorScheme.Dark
+                    : CoreWebView2PreferredColorScheme.Light;
+                // 拡張機能ページが prefers-color-scheme 未対応の場合に備え、
+                // WebView2 背景色を合わせ、ページ読み込み後に CSS を注入する
+                if (isDark)
+                {
+                    optWebView.DefaultBackgroundColor = Windows.UI.Color.FromArgb(255, 32, 32, 32);
+                    optWebView.CoreWebView2.NavigationCompleted += async (s, e) =>
                     {
-                        ElementTheme.Light => CoreWebView2PreferredColorScheme.Light,
-                        ElementTheme.Dark  => CoreWebView2PreferredColorScheme.Dark,
-                        _                  => CoreWebView2PreferredColorScheme.Auto,
+                        await optWebView.CoreWebView2.ExecuteScriptAsync("""
+                            if (!window.matchMedia('(prefers-color-scheme: dark)').matches ||
+                                getComputedStyle(document.body).backgroundColor === 'rgb(255, 255, 255)') {
+                                document.documentElement.style.cssText += 'background:#202020!important;color:#e0e0e0!important';
+                                document.body.style.cssText += 'background:#202020!important;color:#e0e0e0!important';
+                                document.querySelectorAll('input,select,textarea,button').forEach(el => {
+                                    el.style.cssText += 'background:#333!important;color:#e0e0e0!important;border-color:#555!important';
+                                });
+                            }
+                        """);
                     };
+                }
                 optWebView.Source = new Uri(optPageUrl);
                 await ShowDialogAsync(dlg);
             };

--- a/MainWindow.WebView2.cs
+++ b/MainWindow.WebView2.cs
@@ -324,6 +324,13 @@ namespace XTimelineViewer
 
                 var env = await GetOrCreateProfileEnvAsync("default");
                 await optWebView.EnsureCoreWebView2Async(env);
+                optWebView.CoreWebView2.Profile.PreferredColorScheme =
+                    ((FrameworkElement)Content).ActualTheme switch
+                    {
+                        ElementTheme.Light => CoreWebView2PreferredColorScheme.Light,
+                        ElementTheme.Dark  => CoreWebView2PreferredColorScheme.Dark,
+                        _                  => CoreWebView2PreferredColorScheme.Auto,
+                    };
                 optWebView.Source = new Uri(optPageUrl);
                 await ShowDialogAsync(dlg);
             };

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -284,6 +284,9 @@ namespace XTimelineViewer
 
         private async Task<ContentDialogResult> ShowDialogAsync(ContentDialog dlg)
         {
+            // すべてのダイアログに現在のテーマを自動適用して設定漏れを防ぐ (#126)
+            dlg.RequestedTheme = ((FrameworkElement)Content).ActualTheme;
+
             _dialogOpenCount++;
             try   { return await dlg.ShowAsync(); }
             finally


### PR DESCRIPTION
## Summary
- `ShowDialogAsync` で `RequestedTheme` を自動適用し、今後のダイアログ追加時にテーマ設定漏れを防止
- 拡張機能設定ダイアログの WebView2 に `PreferredColorScheme` を追加
- 各ダイアログの冗長になった `RequestedTheme` 個別設定を削除（4か所）

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `MainWindow.xaml.cs` | `ShowDialogAsync` にテーマ自動適用を追加 |
| `MainWindow.WebView2.cs` | 拡張機能 WebView2 に `PreferredColorScheme` を設定 |
| `MainWindow.Settings.cs` | 冗長な `RequestedTheme` を削除（2か所） |
| `MainWindow.Post.cs` | 冗長な `RequestedTheme` を削除 |
| `MainWindow.Updates.cs` | 冗長な `RequestedTheme` を削除 |

## Test plan
- [ ] ダークモードで拡張機能設定ダイアログを開き、ダイアログ・WebView2 ともに暗い配色になること
- [ ] ライトモードで拡張機能設定ダイアログを開き、明るい配色になること
- [ ] アプリ設定・About・投稿・winget 更新ダイアログのテーマが従来通り正しく適用されること

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)