### PR TITLE
refactor: Views/Models フォルダーに整理し MVVM 構造を導入 (#128)

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text.Json;
+using XTimelineViewer.Views;
 
 namespace XTimelineViewer
 {

--- a/Models/Models.cs
+++ b/Models/Models.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace XTimelineViewer
+namespace XTimelineViewer.Models
 {
     internal class TimelineConfig
     {

--- a/Services/SettingsService.cs
+++ b/Services/SettingsService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text.Json;
+using XTimelineViewer.Models;
 
 namespace XTimelineViewer.Services
 {

--- a/Views/AddProfileWindow.xaml
+++ b/Views/AddProfileWindow.xaml
@@ -1,5 +1,5 @@
 <Window
-    x:Class="XTimelineViewer.AddProfileWindow"
+    x:Class="XTimelineViewer.Views.AddProfileWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     Title="Add Profile">

--- a/Views/AddProfileWindow.xaml.cs
+++ b/Views/AddProfileWindow.xaml.cs
@@ -8,7 +8,9 @@ using System.IO;
 using System.Threading.Tasks;
 using Windows.Graphics;
 
-namespace XTimelineViewer
+using XTimelineViewer.Models;
+
+namespace XTimelineViewer.Views
 {
     public sealed partial class AddProfileWindow : Window
     {

--- a/Views/MainWindow.HardReload.cs
+++ b/Views/MainWindow.HardReload.cs
@@ -20,7 +20,9 @@ using Windows.Graphics;
 using Windows.Storage;
 using Windows.UI;
 
-namespace XTimelineViewer
+using XTimelineViewer.Models;
+
+namespace XTimelineViewer.Views
 {
     public sealed partial class MainWindow : Window
     {

--- a/Views/MainWindow.Post.cs
+++ b/Views/MainWindow.Post.cs
@@ -20,7 +20,9 @@ using Windows.Graphics;
 using Windows.Storage;
 using Windows.UI;
 
-namespace XTimelineViewer
+using XTimelineViewer.Models;
+
+namespace XTimelineViewer.Views
 {
     public sealed partial class MainWindow : Window
     {

--- a/Views/MainWindow.Profiles.cs
+++ b/Views/MainWindow.Profiles.cs
@@ -20,7 +20,9 @@ using Windows.Graphics;
 using Windows.Storage;
 using Windows.UI;
 
-namespace XTimelineViewer
+using XTimelineViewer.Models;
+
+namespace XTimelineViewer.Views
 {
     public sealed partial class MainWindow : Window
     {

--- a/Views/MainWindow.Settings.cs
+++ b/Views/MainWindow.Settings.cs
@@ -21,7 +21,9 @@ using Windows.Storage;
 using Windows.UI;
 using XTimelineViewer.Services;
 
-namespace XTimelineViewer
+using XTimelineViewer.Models;
+
+namespace XTimelineViewer.Views
 {
     public sealed partial class MainWindow : Window
     {

--- a/Views/MainWindow.Theme.cs
+++ b/Views/MainWindow.Theme.cs
@@ -20,7 +20,9 @@ using Windows.Graphics;
 using Windows.Storage;
 using Windows.UI;
 
-namespace XTimelineViewer
+using XTimelineViewer.Models;
+
+namespace XTimelineViewer.Views
 {
     public sealed partial class MainWindow : Window
     {

--- a/Views/MainWindow.Timeline.cs
+++ b/Views/MainWindow.Timeline.cs
@@ -20,7 +20,9 @@ using Windows.Graphics;
 using Windows.Storage;
 using Windows.UI;
 
-namespace XTimelineViewer
+using XTimelineViewer.Models;
+
+namespace XTimelineViewer.Views
 {
     public sealed partial class MainWindow : Window
     {

--- a/Views/MainWindow.Updates.cs
+++ b/Views/MainWindow.Updates.cs
@@ -20,7 +20,9 @@ using Windows.Graphics;
 using Windows.Storage;
 using Windows.UI;
 
-namespace XTimelineViewer
+using XTimelineViewer.Models;
+
+namespace XTimelineViewer.Views
 {
     public sealed partial class MainWindow : Window
     {

--- a/Views/MainWindow.WebView2.cs
+++ b/Views/MainWindow.WebView2.cs
@@ -20,7 +20,9 @@ using Windows.Graphics;
 using Windows.Storage;
 using Windows.UI;
 
-namespace XTimelineViewer
+using XTimelineViewer.Models;
+
+namespace XTimelineViewer.Views
 {
     public sealed partial class MainWindow : Window
     {

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -1,5 +1,5 @@
 <Window
-    x:Class="XTimelineViewer.MainWindow"
+    x:Class="XTimelineViewer.Views.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     Title="XTimelineViewer">

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -21,7 +21,9 @@ using Windows.Storage;
 using Windows.UI;
 using XTimelineViewer.ViewModels;
 
-namespace XTimelineViewer
+using XTimelineViewer.Models;
+
+namespace XTimelineViewer.Views
 {
     public sealed partial class MainWindow : Window
     {

--- a/Views/ManageProfilesWindow.xaml
+++ b/Views/ManageProfilesWindow.xaml
@@ -1,5 +1,5 @@
 <Window
-    x:Class="XTimelineViewer.ManageProfilesWindow"
+    x:Class="XTimelineViewer.Views.ManageProfilesWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     Title="Manage Profiles">

--- a/Views/ManageProfilesWindow.xaml.cs
+++ b/Views/ManageProfilesWindow.xaml.cs
@@ -11,7 +11,9 @@ using System.Runtime.InteropServices;
 using Windows.Graphics;
 using Windows.UI;
 
-namespace XTimelineViewer
+using XTimelineViewer.Models;
+
+namespace XTimelineViewer.Views
 {
     public sealed partial class ManageProfilesWindow : Window
     {

--- a/XTimelineViewer.Tests/Services/SettingsServiceTests.cs
+++ b/XTimelineViewer.Tests/Services/SettingsServiceTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using XTimelineViewer;
+using XTimelineViewer.Models;
 using XTimelineViewer.Services;
 using Xunit;
 

--- a/XTimelineViewer.Tests/XTimelineViewer.Tests.csproj
+++ b/XTimelineViewer.Tests/XTimelineViewer.Tests.csproj
@@ -26,7 +26,7 @@
     UI 非依存なファイルだけをリンクして参照する。
   -->
   <ItemGroup>
-    <Compile Include="..\Models.cs"                  Link="Models.cs" />
+    <Compile Include="..\Models\Models.cs"             Link="Models\Models.cs" />
     <Compile Include="..\Services\SettingsService.cs" Link="Services\SettingsService.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- MainWindow / AddProfileWindow / ManageProfilesWindow を `Views/` フォルダーに移動
- `Models.cs` を `Models/` フォルダーに移動
- 名前空間を `XTimelineViewer.Views` / `XTimelineViewer.Models` に変更
- `App.xaml.cs`、`Services/SettingsService.cs`、テストプロジェクトの参照を更新

## 変更後の構造
```
XTimelineViewer/
├── App.xaml / App.xaml.cs
├── PackageContext.cs, R.cs
├── Models/
│   └── Models.cs
├── Views/
│   ├── MainWindow.xaml / .xaml.cs + 8 partial class
│   ├── AddProfileWindow.xaml / .xaml.cs
│   └── ManageProfilesWindow.xaml / .xaml.cs
├── ViewModels/
│   └── MainWindowViewModel.cs
└── Services/
    └── SettingsService.cs
```

## Test plan
- [x] アプリが正常に起動すること
- [x] タイムライン追加・設定変更が動作すること
- [x] xUnit テスト 13 件が全パスすること（確認済み ✅）

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)