### PR TITLE
feat: 指定 Edge プロファイルで外部リンクを開く

### DIFF
--- a/Models/Models.cs
+++ b/Models/Models.cs
@@ -33,5 +33,7 @@ namespace XTimelineViewer.Models
         public string? LastUpdateCheck       { get; set; } = null;      // UTC ISO-8601
         public string? CachedLatestVersion   { get; set; } = null;      // "v1.4.0" など
         public bool    ShowAutoActivateLabel { get; set; } = false;
+        public string  ExternalBrowser       { get; set; } = "system";  // "system" | "edge"
+        public string  EdgeProfileDirectory  { get; set; } = "";        // "Default" | "Profile 1" など
     }
 }

--- a/Services/EdgeService.cs
+++ b/Services/EdgeService.cs
@@ -77,7 +77,14 @@ namespace XTimelineViewer.Services
                     {
                         displayName = name;
                     }
-                    result.Add(new EdgeProfile(dir, displayName));
+                    // サインイン済みアカウントのメールアドレス
+                    string userName = "";
+                    if (entry.Value.TryGetProperty("user_name", out var userNameProp) &&
+                        userNameProp.GetString() is { Length: > 0 } un)
+                    {
+                        userName = un;
+                    }
+                    result.Add(new EdgeProfile(dir, displayName, userName));
                 }
 
                 Debug.WriteLine($"[Edge] Enumerated {result.Count} profile(s)");
@@ -108,5 +115,8 @@ namespace XTimelineViewer.Services
     /// <summary>
     /// Edge プロファイル情報。
     /// </summary>
-    internal record EdgeProfile(string Directory, string DisplayName);
+    /// <param name="Directory">プロファイルのディレクトリ名（"Default", "Profile 1" など）</param>
+    /// <param name="DisplayName">表示名（"プロファイル 1" など）</param>
+    /// <param name="UserName">サインイン済みアカウントのメールアドレス（未サインインなら空文字）</param>
+    internal record EdgeProfile(string Directory, string DisplayName, string UserName);
 }

--- a/Services/EdgeService.cs
+++ b/Services/EdgeService.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text.Json;
+
+namespace XTimelineViewer.Services
+{
+    /// <summary>
+    /// Microsoft Edge の検出・プロファイル列挙・プロファイル指定起動を担当するサービス。
+    /// UI 依存なし。
+    /// </summary>
+    internal static class EdgeService
+    {
+        /// <summary>
+        /// Edge Stable チャネルの msedge.exe パスを返す。見つからなければ null。
+        /// </summary>
+        public static string? FindEdgePath()
+        {
+            var candidates = new[]
+            {
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+                    "Microsoft", "Edge", "Application", "msedge.exe"),
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+                    "Microsoft", "Edge", "Application", "msedge.exe"),
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                    "Microsoft", "Edge", "Application", "msedge.exe"),
+            };
+
+            foreach (var path in candidates)
+            {
+                if (File.Exists(path))
+                {
+                    Debug.WriteLine($"[Edge] Found: {path}");
+                    return path;
+                }
+            }
+
+            Debug.WriteLine("[Edge] msedge.exe not found");
+            return null;
+        }
+
+        /// <summary>
+        /// Edge Stable チャネルの User Data ディレクトリパスを返す。
+        /// </summary>
+        internal static string GetUserDataPath()
+        {
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "Microsoft", "Edge", "User Data");
+        }
+
+        /// <summary>
+        /// Edge のプロファイル一覧を列挙する。
+        /// Local State ファイルの profile.info_cache から取得する。
+        /// </summary>
+        public static List<EdgeProfile> EnumerateProfiles()
+        {
+            var result = new List<EdgeProfile>();
+            try
+            {
+                var localStatePath = Path.Combine(GetUserDataPath(), "Local State");
+                if (!File.Exists(localStatePath)) return result;
+
+                var json = File.ReadAllText(localStatePath);
+                using var doc = JsonDocument.Parse(json);
+
+                if (!doc.RootElement.TryGetProperty("profile", out var profileRoot)) return result;
+                if (!profileRoot.TryGetProperty("info_cache", out var infoCache)) return result;
+
+                foreach (var entry in infoCache.EnumerateObject())
+                {
+                    var dir = entry.Name; // "Default", "Profile 1" など
+                    var displayName = dir;
+                    if (entry.Value.TryGetProperty("name", out var nameProp) &&
+                        nameProp.GetString() is { Length: > 0 } name)
+                    {
+                        displayName = name;
+                    }
+                    result.Add(new EdgeProfile(dir, displayName));
+                }
+
+                Debug.WriteLine($"[Edge] Enumerated {result.Count} profile(s)");
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[Edge] EnumerateProfiles failed: {ex.Message}");
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// 指定プロファイルで Edge を使って URI を開く。
+        /// </summary>
+        public static void LaunchInProfile(string edgePath, string profileDirectory, Uri uri)
+        {
+            var args = $"--profile-directory=\"{profileDirectory}\" \"{uri.AbsoluteUri}\"";
+            Debug.WriteLine($"[Edge] Launch: {edgePath} {args}");
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = edgePath,
+                Arguments = args,
+                UseShellExecute = false,
+            });
+        }
+    }
+
+    /// <summary>
+    /// Edge プロファイル情報。
+    /// </summary>
+    internal record EdgeProfile(string Directory, string DisplayName);
+}

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -91,6 +91,13 @@
   <data name="AutoActivate_Disabled" xml:space="preserve"><value>⏹ Auto-Activate Off</value></data>
   <data name="AutoActivateLabel_Format" xml:space="preserve"><value>Home Timeline Auto-Activate: {0}</value></data>
   <data name="Settings_ShowAutoActivateLabel" xml:space="preserve"><value>Show auto-activate status in toolbar</value></data>
+
+  <!-- External browser settings -->
+  <data name="Section_ExternalBrowser" xml:space="preserve"><value>External Browser</value></data>
+  <data name="Settings_ExternalBrowser" xml:space="preserve"><value>Open links in</value></data>
+  <data name="Settings_EdgeProfile" xml:space="preserve"><value>Edge Profile</value></data>
+  <data name="Browser_System" xml:space="preserve"><value>System Default</value></data>
+  <data name="Browser_EdgeNotFound" xml:space="preserve"><value>Edge not found</value></data>
   <data name="Pane_Settings_Tooltip" xml:space="preserve"><value>Settings</value></data>
   <data name="Pane_Close_Tooltip" xml:space="preserve"><value>Close</value></data>
   <data name="Pane_Delete" xml:space="preserve"><value>Remove This Timeline</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -91,6 +91,13 @@
   <data name="AutoActivate_Disabled" xml:space="preserve"><value>⏹ 自動アクティブ化 無効</value></data>
   <data name="AutoActivateLabel_Format" xml:space="preserve"><value>ホームタイムラインの自動アクティブ化: {0}</value></data>
   <data name="Settings_ShowAutoActivateLabel" xml:space="preserve"><value>ツールバーに自動アクティブ化の状態を表示する</value></data>
+
+  <!-- External browser settings -->
+  <data name="Section_ExternalBrowser" xml:space="preserve"><value>外部ブラウザー</value></data>
+  <data name="Settings_ExternalBrowser" xml:space="preserve"><value>リンクを開くブラウザー</value></data>
+  <data name="Settings_EdgeProfile" xml:space="preserve"><value>Edge プロファイル</value></data>
+  <data name="Browser_System" xml:space="preserve"><value>システム既定</value></data>
+  <data name="Browser_EdgeNotFound" xml:space="preserve"><value>Edge が見つかりません</value></data>
   <data name="Pane_Settings_Tooltip" xml:space="preserve"><value>設定</value></data>
   <data name="Pane_Close_Tooltip" xml:space="preserve"><value>閉じる</value></data>
   <data name="Pane_Delete" xml:space="preserve"><value>このタイムラインを削除</value></data>

--- a/Views/MainWindow.Post.cs
+++ b/Views/MainWindow.Post.cs
@@ -29,7 +29,7 @@ namespace XTimelineViewer.Views
         private async void PostBtn_Click(object _, RoutedEventArgs __)
         {
             if (_appSettings.OpenComposerInBrowser)
-                _ = Windows.System.Launcher.LaunchUriAsync(new Uri("https://x.com/compose/post"));
+                _ = LaunchUriByEdgeProfileAsync(new Uri("https://x.com/compose/post"));
             else
                 await OpenPostDialogAsync();
         }
@@ -122,7 +122,7 @@ namespace XTimelineViewer.Views
             if (message.StartsWith("openTimestamp:") &&
                 Uri.TryCreate(message[14..], UriKind.Absolute, out var timestampUri))
             {
-                _ = Windows.System.Launcher.LaunchUriAsync(timestampUri);
+                _ = LaunchUriByEdgeProfileAsync(timestampUri);
                 return;
             }
 
@@ -132,7 +132,7 @@ namespace XTimelineViewer.Views
                 case "focusPrev": FocusAdjacentTimeline(senderWebView, -1); break;
                 case "newPost":
                     if (_appSettings.OpenComposerInBrowser)
-                        _ = Windows.System.Launcher.LaunchUriAsync(new Uri("https://x.com/compose/post"));
+                        _ = LaunchUriByEdgeProfileAsync(new Uri("https://x.com/compose/post"));
                     else
                         _ = OpenPostDialogAsync(senderWebView);
                     break;

--- a/Views/MainWindow.Settings.cs
+++ b/Views/MainWindow.Settings.cs
@@ -19,9 +19,8 @@ using Windows.ApplicationModel.DataTransfer;
 using Windows.Graphics;
 using Windows.Storage;
 using Windows.UI;
-using XTimelineViewer.Services;
-
 using XTimelineViewer.Models;
+using XTimelineViewer.Services;
 
 namespace XTimelineViewer.Views
 {
@@ -181,6 +180,60 @@ namespace XTimelineViewer.Views
             };
             panel.Children.Add(MakeRow(R.Get("Settings_ShowAutoActivateLabel"), showAutoActivateLabelToggle));
 
+            // ── 外部ブラウザー ────────────────────────────────────────────────
+            panel.Children.Add(new NavigationViewItemSeparator { Margin = new Thickness(0, 12, 0, 8) });
+            panel.Children.Add(new TextBlock
+            {
+                Text       = R.Get("Section_ExternalBrowser"),
+                FontWeight = Microsoft.UI.Text.FontWeights.SemiBold
+            });
+
+            var browserValues = new[] { "system", "edge" };
+            var browserCombo = new ComboBox
+            {
+                ItemsSource   = new List<string> { R.Get("Browser_System"), "Microsoft Edge" },
+                SelectedIndex = _appSettings.ExternalBrowser == "edge" ? 1 : 0,
+                MinWidth      = 200
+            };
+
+            var edgeProfiles = EdgeService.EnumerateProfiles();
+            var profileCombo = new ComboBox
+            {
+                MinWidth  = 200,
+                IsEnabled = _appSettings.ExternalBrowser == "edge" && edgeProfiles.Count > 0
+            };
+
+            // Edge 未インストール時はプルダウンに「Edge が見つかりません」を表示
+            if (edgeProfiles.Count == 0)
+            {
+                profileCombo.ItemsSource   = new List<string> { R.Get("Browser_EdgeNotFound") };
+                profileCombo.SelectedIndex = 0;
+                profileCombo.IsEnabled     = false;
+            }
+            else
+            {
+                var profileDisplayNames = new List<string>();
+                int selectedProfileIdx = 0;
+                for (int i = 0; i < edgeProfiles.Count; i++)
+                {
+                    var p = edgeProfiles[i];
+                    profileDisplayNames.Add($"{p.DisplayName}  ({p.Directory})");
+                    if (p.Directory == _appSettings.EdgeProfileDirectory)
+                        selectedProfileIdx = i;
+                }
+                profileCombo.ItemsSource   = profileDisplayNames;
+                profileCombo.SelectedIndex = selectedProfileIdx;
+            }
+
+            browserCombo.SelectionChanged += (_, _) =>
+            {
+                var isEdge = browserCombo.SelectedIndex == 1;
+                profileCombo.IsEnabled = isEdge && edgeProfiles.Count > 0;
+            };
+
+            panel.Children.Add(MakeRow(R.Get("Settings_ExternalBrowser"), browserCombo));
+            panel.Children.Add(MakeRow(R.Get("Settings_EdgeProfile"), profileCombo));
+
             var dlg = new ContentDialog
             {
                 Title             = R.Get("AppSettings_Title"),
@@ -198,6 +251,9 @@ namespace XTimelineViewer.Views
                 _appSettings.OpenTimestampInBrowser = openTimestampToggle.IsOn;
                 _appSettings.AutoActivateMinutes   = (int)Math.Clamp(autoActivateBox.Value, 0, 60);
                 _appSettings.ShowAutoActivateLabel = showAutoActivateLabelToggle.IsOn;
+                _appSettings.ExternalBrowser      = browserValues[Math.Max(0, Math.Min(browserCombo.SelectedIndex, browserValues.Length - 1))];
+                if (edgeProfiles.Count > 0 && profileCombo.SelectedIndex >= 0 && profileCombo.SelectedIndex < edgeProfiles.Count)
+                    _appSettings.EdgeProfileDirectory = edgeProfiles[profileCombo.SelectedIndex].Directory;
 
                 var newLang    = langValues[Math.Max(0, Math.Min(langCombo.SelectedIndex, langValues.Length - 1))];
                 var langChanged = newLang != _appSettings.Language;
@@ -368,7 +424,8 @@ namespace XTimelineViewer.Views
                 var url = latestReleaseUrl ?? fallbackUrl;
                 if (PackageContext.IsPackaged)
                 {
-                    _ = Windows.System.Launcher.LaunchUriAsync(new Uri("ms-windows-store://pdp/?ProductId=9P308HB5BLJ1"));
+                    // ms-windows-store:// は LaunchUriByEdgeProfileAsync 内でシステム既定にフォールバックする
+                    await LaunchUriByEdgeProfileAsync(new Uri("ms-windows-store://pdp/?ProductId=9P308HB5BLJ1"));
                 }
                 else if (FindWinget() is not null)
                 {
@@ -377,7 +434,7 @@ namespace XTimelineViewer.Views
                 }
                 else
                 {
-                    _ = Windows.System.Launcher.LaunchUriAsync(new Uri(url));
+                    await LaunchUriByEdgeProfileAsync(new Uri(url));
                 }
             };
 

--- a/Views/MainWindow.Settings.cs
+++ b/Views/MainWindow.Settings.cs
@@ -217,7 +217,8 @@ namespace XTimelineViewer.Views
                 for (int i = 0; i < edgeProfiles.Count; i++)
                 {
                     var p = edgeProfiles[i];
-                    profileDisplayNames.Add($"{p.DisplayName}  ({p.Directory})");
+                    var detail = p.UserName.Length > 0 ? p.UserName : p.Directory;
+                    profileDisplayNames.Add($"{p.DisplayName}  ({detail})");
                     if (p.Directory == _appSettings.EdgeProfileDirectory)
                         selectedProfileIdx = i;
                 }

--- a/Views/MainWindow.Updates.cs
+++ b/Views/MainWindow.Updates.cs
@@ -110,7 +110,7 @@ namespace XTimelineViewer.Views
             var winget = FindWinget();
             if (winget is null)
             {
-                _ = Windows.System.Launcher.LaunchUriAsync(new Uri(releaseUrl));
+                await LaunchUriByEdgeProfileAsync(new Uri(releaseUrl));
                 return;
             }
 

--- a/Views/MainWindow.WebView2.cs
+++ b/Views/MainWindow.WebView2.cs
@@ -321,7 +321,7 @@ namespace XTimelineViewer.Views
                     dlg.SecondaryButtonClick += (s, e) =>
                     {
                         e.Cancel = true;
-                        _ = Windows.System.Launcher.LaunchUriAsync(homepageUri);
+                        _ = LaunchUriByEdgeProfileAsync(homepageUri);
                     };
 
                 var env = await GetOrCreateProfileEnvAsync("default");
@@ -440,11 +440,11 @@ namespace XTimelineViewer.Views
             webView.CoreWebView2.WebMessageReceived += (s, e) =>
                 OnWebViewMessageReceived(webView, e.TryGetWebMessageAsString());
 
-            // 外部リンクをシステム既定ブラウザーで開く
+            // 外部リンクをシステム既定ブラウザーまたは指定 Edge プロファイルで開く
             webView.CoreWebView2.NewWindowRequested += async (s, args) =>
             {
                 args.Handled = true;
-                await Windows.System.Launcher.LaunchUriAsync(new Uri(args.Uri));
+                await LaunchUriByEdgeProfileAsync(new Uri(args.Uri));
             };
 
             webView.CoreWebView2.NavigationStarting += async (s, args) =>
@@ -455,7 +455,7 @@ namespace XTimelineViewer.Views
                     !nav.Host.Equals(origin.Host, StringComparison.OrdinalIgnoreCase))
                 {
                     args.Cancel = true;
-                    await Windows.System.Launcher.LaunchUriAsync(nav);
+                    await LaunchUriByEdgeProfileAsync(nav);
                     return;
                 }
 

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -19,9 +19,9 @@ using Windows.ApplicationModel.DataTransfer;
 using Windows.Graphics;
 using Windows.Storage;
 using Windows.UI;
-using XTimelineViewer.ViewModels;
-
 using XTimelineViewer.Models;
+using XTimelineViewer.Services;
+using XTimelineViewer.ViewModels;
 
 namespace XTimelineViewer.Views
 {
@@ -304,6 +304,29 @@ namespace XTimelineViewer.Views
             if (!Uri.TryCreate(baseUrl,    UriKind.Absolute, out var @base)) return false;
             return string.Equals(cur.Host,         @base.Host,         StringComparison.OrdinalIgnoreCase)
                 && string.Equals(cur.AbsolutePath, @base.AbsolutePath, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// 外部ブラウザー設定に応じて URI を開く。
+        /// Edge プロファイル指定が有効かつ http/https の場合は Edge で開き、
+        /// それ以外はシステム既定に委ねる。
+        /// </summary>
+        private async Task LaunchUriByEdgeProfileAsync(Uri uri)
+        {
+            if (_appSettings.ExternalBrowser == "edge" &&
+                (uri.Scheme == "http" || uri.Scheme == "https"))
+            {
+                var edgePath = EdgeService.FindEdgePath();
+                if (edgePath is not null)
+                {
+                    EdgeService.LaunchInProfile(edgePath, _appSettings.EdgeProfileDirectory, uri);
+                    return;
+                }
+                // Edge が見つからない場合はシステム既定にフォールバック
+                Debug.WriteLine("[Edge] Falling back to system default — Edge not found");
+            }
+
+            await Windows.System.Launcher.LaunchUriAsync(uri);
         }
     }
 }

--- a/XTimelineViewer.Tests/Services/EdgeServiceTests.cs
+++ b/XTimelineViewer.Tests/Services/EdgeServiceTests.cs
@@ -71,17 +71,24 @@ public class EdgeServiceTests : IDisposable
     [Fact]
     public void EdgeProfile_RecordEquality()
     {
-        var a = new EdgeProfile("Default", "Profile 1");
-        var b = new EdgeProfile("Default", "Profile 1");
+        var a = new EdgeProfile("Default", "Profile 1", "user@example.com");
+        var b = new EdgeProfile("Default", "Profile 1", "user@example.com");
         Assert.Equal(a, b);
     }
 
     [Fact]
     public void EdgeProfile_RecordInequality()
     {
-        var a = new EdgeProfile("Default", "Profile 1");
-        var b = new EdgeProfile("Profile 1", "Profile 2");
+        var a = new EdgeProfile("Default", "Profile 1", "user@example.com");
+        var b = new EdgeProfile("Profile 1", "Profile 2", "other@example.com");
         Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void EdgeProfile_UserNameCanBeEmpty()
+    {
+        var p = new EdgeProfile("Profile 2", "プロファイル 3", "");
+        Assert.Equal("", p.UserName);
     }
 
     // ── AppSettings の新規プロパティ ───────────────────────────────────────────

--- a/XTimelineViewer.Tests/Services/EdgeServiceTests.cs
+++ b/XTimelineViewer.Tests/Services/EdgeServiceTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using XTimelineViewer.Services;
+using Xunit;
+
+namespace XTimelineViewer.Tests.Services;
+
+public class EdgeServiceTests : IDisposable
+{
+    private readonly string _tempDir =
+        Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+
+    public EdgeServiceTests() => Directory.CreateDirectory(_tempDir);
+    public void Dispose()     => Directory.Delete(_tempDir, recursive: true);
+
+    private string At(string filename) => Path.Combine(_tempDir, filename);
+
+    // ── FindEdgePath ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void FindEdgePath_ReturnsNullOrValidPath()
+    {
+        var path = EdgeService.FindEdgePath();
+        // Edge がインストールされていれば有効なパス、なければ null
+        if (path is not null)
+            Assert.True(File.Exists(path));
+    }
+
+    // ── EnumerateProfiles ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void EnumerateProfiles_ReturnsListWithoutException()
+    {
+        // Edge がインストールされていなくても例外を投げない
+        var profiles = EdgeService.EnumerateProfiles();
+        Assert.NotNull(profiles);
+    }
+
+    [Fact]
+    public void EnumerateProfiles_WhenEdgeInstalled_ContainsDefault()
+    {
+        // Edge がインストールされている環境でのみ意味のあるテスト
+        var userDataPath = EdgeService.GetUserDataPath();
+        if (!Directory.Exists(userDataPath))
+            return; // skip — Edge not installed
+
+        var profiles = EdgeService.EnumerateProfiles();
+        Assert.True(profiles.Count > 0, "Edge がインストールされていればプロファイルが 1 つ以上あるはず");
+        Assert.Contains(profiles, p => p.Directory == "Default");
+    }
+
+    [Fact]
+    public void EnumerateProfiles_ProfileHasDirectoryAndDisplayName()
+    {
+        var userDataPath = EdgeService.GetUserDataPath();
+        if (!Directory.Exists(userDataPath))
+            return; // skip
+
+        var profiles = EdgeService.EnumerateProfiles();
+        foreach (var p in profiles)
+        {
+            Assert.False(string.IsNullOrEmpty(p.Directory));
+            Assert.False(string.IsNullOrEmpty(p.DisplayName));
+        }
+    }
+
+    // ── EdgeProfile record ────────────────────────────────────────────────────
+
+    [Fact]
+    public void EdgeProfile_RecordEquality()
+    {
+        var a = new EdgeProfile("Default", "Profile 1");
+        var b = new EdgeProfile("Default", "Profile 1");
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void EdgeProfile_RecordInequality()
+    {
+        var a = new EdgeProfile("Default", "Profile 1");
+        var b = new EdgeProfile("Profile 1", "Profile 2");
+        Assert.NotEqual(a, b);
+    }
+
+    // ── AppSettings の新規プロパティ ───────────────────────────────────────────
+
+    [Fact]
+    public void AppSettings_ExternalBrowserDefaults()
+    {
+        var s = new XTimelineViewer.Models.AppSettings();
+        Assert.Equal("system", s.ExternalBrowser);
+        Assert.Equal("",       s.EdgeProfileDirectory);
+    }
+
+    [Fact]
+    public void AppSettings_ExternalBrowser_RoundTrip()
+    {
+        var path = At("settings.json");
+        var original = new XTimelineViewer.Models.AppSettings
+        {
+            ExternalBrowser      = "edge",
+            EdgeProfileDirectory = "Profile 1"
+        };
+
+        SettingsService.SaveSettings(path, original);
+        var loaded = SettingsService.LoadSettings(path);
+
+        Assert.Equal("edge",      loaded.ExternalBrowser);
+        Assert.Equal("Profile 1", loaded.EdgeProfileDirectory);
+    }
+}

--- a/XTimelineViewer.Tests/XTimelineViewer.Tests.csproj
+++ b/XTimelineViewer.Tests/XTimelineViewer.Tests.csproj
@@ -28,6 +28,7 @@
   <ItemGroup>
     <Compile Include="..\Models\Models.cs"             Link="Models\Models.cs" />
     <Compile Include="..\Services\SettingsService.cs" Link="Services\SettingsService.cs" />
+    <Compile Include="..\Services\EdgeService.cs"    Link="Services\EdgeService.cs" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- `Services/EdgeService.cs` を新規作成し、Edge Stable の検出・プロファイル列挙（`Local State` JSON）・プロファイル指定起動を実装
- 全 `LaunchUriAsync` 呼び出しを `LaunchUriByEdgeProfileAsync` ヘルパー経由に統一（`http/https` → Edge プロファイル対象、`ms-windows-store://` 等 → システム既定にフォールバック）
- 設定ダイアログの試験機能セクションに「外部ブラウザー」を追加（システム既定 / Microsoft Edge の ComboBox + Edge プロファイル選択の ComboBox）
- `AppSettings` に `ExternalBrowser`・`EdgeProfileDirectory` プロパティ追加
- `EdgeService` のユニットテスト 8 件追加（全 21 テスト成功）

## Test plan
- [x] 設定ダイアログで「外部ブラウザー」セクションが表示されること
- [x] 「Microsoft Edge」を選択するとプロファイル ComboBox が活性化されること
- [x] 「システム既定」を選択するとプロファイル ComboBox が無効化されること
- [x] Edge + プロファイル指定で保存後、タイムライン内の外部リンクが指定プロファイルの Edge で開くこと
- [x] タイムスタンプリンク・投稿ボタン（ブラウザモード）も Edge プロファイルで開くこと
- [ ] Store リンク（`ms-windows-store://`）はシステム既定で開くこと
- [ ] Edge 未インストール環境で「Edge が見つかりません」と表示されること
- [ ] 設定の保存・復元（ラウンドトリップ）が正常に動作すること
- [x] `dotnet test` で全 21 テスト成功

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)