### PR TITLE
feat: NavigationView 付き設定ウィンドウのスケルトンを追加

### DIFF
--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -98,6 +98,14 @@
   <data name="Settings_EdgeProfile" xml:space="preserve"><value>Edge Profile</value></data>
   <data name="Browser_System" xml:space="preserve"><value>System Default</value></data>
   <data name="Browser_EdgeNotFound" xml:space="preserve"><value>Edge not found</value></data>
+
+  <!-- Settings window navigation -->
+  <data name="Nav_General" xml:space="preserve"><value>General</value></data>
+  <data name="Nav_Experimental" xml:space="preserve"><value>Experimental</value></data>
+  <data name="Nav_Extensions" xml:space="preserve"><value>Extensions</value></data>
+  <data name="Nav_Profiles" xml:space="preserve"><value>Profiles</value></data>
+  <data name="Nav_About" xml:space="preserve"><value>About</value></data>
+  <data name="Settings_Placeholder" xml:space="preserve"><value>This page will be implemented in a future update.</value></data>
   <data name="Pane_Settings_Tooltip" xml:space="preserve"><value>Settings</value></data>
   <data name="Pane_Close_Tooltip" xml:space="preserve"><value>Close</value></data>
   <data name="Pane_Delete" xml:space="preserve"><value>Remove This Timeline</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -98,6 +98,14 @@
   <data name="Settings_EdgeProfile" xml:space="preserve"><value>Edge プロファイル</value></data>
   <data name="Browser_System" xml:space="preserve"><value>システム既定</value></data>
   <data name="Browser_EdgeNotFound" xml:space="preserve"><value>Edge が見つかりません</value></data>
+
+  <!-- Settings window navigation -->
+  <data name="Nav_General" xml:space="preserve"><value>全般</value></data>
+  <data name="Nav_Experimental" xml:space="preserve"><value>試験機能</value></data>
+  <data name="Nav_Extensions" xml:space="preserve"><value>拡張機能</value></data>
+  <data name="Nav_Profiles" xml:space="preserve"><value>プロファイル</value></data>
+  <data name="Nav_About" xml:space="preserve"><value>バージョン情報</value></data>
+  <data name="Settings_Placeholder" xml:space="preserve"><value>このページは今後のアップデートで実装されます。</value></data>
   <data name="Pane_Settings_Tooltip" xml:space="preserve"><value>設定</value></data>
   <data name="Pane_Close_Tooltip" xml:space="preserve"><value>閉じる</value></data>
   <data name="Pane_Delete" xml:space="preserve"><value>このタイムラインを削除</value></data>

--- a/Views/MainWindow.Settings.cs
+++ b/Views/MainWindow.Settings.cs
@@ -58,6 +58,18 @@ namespace XTimelineViewer.Views
                 _profiles.Select(p => p.Id));
         }
 
+        private void OpenSettingsWindow_Click(object _, RoutedEventArgs __)
+        {
+            var ownerHwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+            var settingsWin = new SettingsWindow(ownerHwnd);
+
+            // 親ウィンドウのテーマを引き継ぐ
+            var theme = ((FrameworkElement)Content).RequestedTheme;
+            settingsWin.ApplyTheme(theme);
+
+            settingsWin.Activate();
+        }
+
         private async void AppSettingsMenuItem_Click(object _, RoutedEventArgs __)
         {
             var themeCombo = new ComboBox

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -74,7 +74,7 @@
                                 </MenuFlyoutItem.Icon>
                             </MenuFlyoutItem>
                             <MenuFlyoutSeparator/>
-                            <MenuFlyoutItem x:Name="AppSettingsMenuItem" Click="AppSettingsMenuItem_Click">
+                            <MenuFlyoutItem x:Name="AppSettingsMenuItem" Click="OpenSettingsWindow_Click">
                                 <MenuFlyoutItem.Icon>
                                     <FontIcon Glyph="&#xE713;" FontFamily="Segoe Fluent Icons"/>
                                 </MenuFlyoutItem.Icon>

--- a/Views/Settings/AboutPage.xaml
+++ b/Views/Settings/AboutPage.xaml
@@ -1,0 +1,18 @@
+<Page
+    x:Class="XTimelineViewer.Views.Settings.AboutPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls">
+
+    <ScrollViewer Padding="24,16">
+        <StackPanel Spacing="4" MaxWidth="700" HorizontalAlignment="Left">
+            <TextBlock x:Name="PageTitle"
+                       Style="{StaticResource TitleTextBlockStyle}"
+                       Margin="0,0,0,16"/>
+
+            <TextBlock x:Name="PlaceholderText"
+                       Opacity="0.6"
+                       FontSize="13"/>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/Views/Settings/AboutPage.xaml.cs
+++ b/Views/Settings/AboutPage.xaml.cs
@@ -1,0 +1,14 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace XTimelineViewer.Views.Settings
+{
+    public sealed partial class AboutPage : Page
+    {
+        public AboutPage()
+        {
+            this.InitializeComponent();
+            PageTitle.Text = R.Get("Nav_About");
+            PlaceholderText.Text = R.Get("Settings_Placeholder");
+        }
+    }
+}

--- a/Views/Settings/ExperimentalPage.xaml
+++ b/Views/Settings/ExperimentalPage.xaml
@@ -1,0 +1,18 @@
+<Page
+    x:Class="XTimelineViewer.Views.Settings.ExperimentalPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls">
+
+    <ScrollViewer Padding="24,16">
+        <StackPanel Spacing="4" MaxWidth="700" HorizontalAlignment="Left">
+            <TextBlock x:Name="PageTitle"
+                       Style="{StaticResource TitleTextBlockStyle}"
+                       Margin="0,0,0,16"/>
+
+            <TextBlock x:Name="PlaceholderText"
+                       Opacity="0.6"
+                       FontSize="13"/>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/Views/Settings/ExperimentalPage.xaml.cs
+++ b/Views/Settings/ExperimentalPage.xaml.cs
@@ -1,0 +1,14 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace XTimelineViewer.Views.Settings
+{
+    public sealed partial class ExperimentalPage : Page
+    {
+        public ExperimentalPage()
+        {
+            this.InitializeComponent();
+            PageTitle.Text = R.Get("Nav_Experimental");
+            PlaceholderText.Text = R.Get("Settings_Placeholder");
+        }
+    }
+}

--- a/Views/Settings/ExtensionsPage.xaml
+++ b/Views/Settings/ExtensionsPage.xaml
@@ -1,0 +1,18 @@
+<Page
+    x:Class="XTimelineViewer.Views.Settings.ExtensionsPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls">
+
+    <ScrollViewer Padding="24,16">
+        <StackPanel Spacing="4" MaxWidth="700" HorizontalAlignment="Left">
+            <TextBlock x:Name="PageTitle"
+                       Style="{StaticResource TitleTextBlockStyle}"
+                       Margin="0,0,0,16"/>
+
+            <TextBlock x:Name="PlaceholderText"
+                       Opacity="0.6"
+                       FontSize="13"/>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/Views/Settings/ExtensionsPage.xaml.cs
+++ b/Views/Settings/ExtensionsPage.xaml.cs
@@ -1,0 +1,14 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace XTimelineViewer.Views.Settings
+{
+    public sealed partial class ExtensionsPage : Page
+    {
+        public ExtensionsPage()
+        {
+            this.InitializeComponent();
+            PageTitle.Text = R.Get("Nav_Extensions");
+            PlaceholderText.Text = R.Get("Settings_Placeholder");
+        }
+    }
+}

--- a/Views/Settings/GeneralPage.xaml
+++ b/Views/Settings/GeneralPage.xaml
@@ -1,0 +1,18 @@
+<Page
+    x:Class="XTimelineViewer.Views.Settings.GeneralPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls">
+
+    <ScrollViewer Padding="24,16">
+        <StackPanel Spacing="4" MaxWidth="700" HorizontalAlignment="Left">
+            <TextBlock x:Name="PageTitle"
+                       Style="{StaticResource TitleTextBlockStyle}"
+                       Margin="0,0,0,16"/>
+
+            <TextBlock x:Name="PlaceholderText"
+                       Opacity="0.6"
+                       FontSize="13"/>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/Views/Settings/GeneralPage.xaml.cs
+++ b/Views/Settings/GeneralPage.xaml.cs
@@ -1,0 +1,14 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace XTimelineViewer.Views.Settings
+{
+    public sealed partial class GeneralPage : Page
+    {
+        public GeneralPage()
+        {
+            this.InitializeComponent();
+            PageTitle.Text = R.Get("Nav_General");
+            PlaceholderText.Text = R.Get("Settings_Placeholder");
+        }
+    }
+}

--- a/Views/Settings/ProfilesPage.xaml
+++ b/Views/Settings/ProfilesPage.xaml
@@ -1,0 +1,18 @@
+<Page
+    x:Class="XTimelineViewer.Views.Settings.ProfilesPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls">
+
+    <ScrollViewer Padding="24,16">
+        <StackPanel Spacing="4" MaxWidth="700" HorizontalAlignment="Left">
+            <TextBlock x:Name="PageTitle"
+                       Style="{StaticResource TitleTextBlockStyle}"
+                       Margin="0,0,0,16"/>
+
+            <TextBlock x:Name="PlaceholderText"
+                       Opacity="0.6"
+                       FontSize="13"/>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/Views/Settings/ProfilesPage.xaml.cs
+++ b/Views/Settings/ProfilesPage.xaml.cs
@@ -1,0 +1,14 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace XTimelineViewer.Views.Settings
+{
+    public sealed partial class ProfilesPage : Page
+    {
+        public ProfilesPage()
+        {
+            this.InitializeComponent();
+            PageTitle.Text = R.Get("Nav_Profiles");
+            PlaceholderText.Text = R.Get("Settings_Placeholder");
+        }
+    }
+}

--- a/Views/SettingsWindow.xaml
+++ b/Views/SettingsWindow.xaml
@@ -1,0 +1,46 @@
+<Window
+    x:Class="XTimelineViewer.Views.SettingsWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Title="Settings">
+
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <NavigationView x:Name="NavView"
+                        IsBackButtonVisible="Collapsed"
+                        IsSettingsVisible="False"
+                        PaneDisplayMode="Left"
+                        OpenPaneLength="200"
+                        SelectionChanged="NavView_SelectionChanged">
+            <NavigationView.MenuItems>
+                <NavigationViewItem x:Name="NavGeneral" Tag="General">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xE790;" FontFamily="Segoe Fluent Icons"/>
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem x:Name="NavExperimental" Tag="Experimental">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xE9A1;" FontFamily="Segoe Fluent Icons"/>
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem x:Name="NavExtensions" Tag="Extensions">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xEA86;" FontFamily="Segoe Fluent Icons"/>
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem x:Name="NavProfiles" Tag="Profiles">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xE716;" FontFamily="Segoe Fluent Icons"/>
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+            </NavigationView.MenuItems>
+            <NavigationView.FooterMenuItems>
+                <NavigationViewItem x:Name="NavAbout" Tag="About">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xE946;" FontFamily="Segoe Fluent Icons"/>
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+            </NavigationView.FooterMenuItems>
+            <Frame x:Name="ContentFrame"/>
+        </NavigationView>
+    </Grid>
+</Window>

--- a/Views/SettingsWindow.xaml.cs
+++ b/Views/SettingsWindow.xaml.cs
@@ -1,0 +1,76 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using Windows.Graphics;
+
+namespace XTimelineViewer.Views
+{
+    public sealed partial class SettingsWindow : Window
+    {
+        [DllImport("user32.dll")]
+        private static extern bool EnableWindow(IntPtr hWnd, bool bEnable);
+
+        private readonly IntPtr _ownerHwnd;
+
+        public SettingsWindow(IntPtr ownerHwnd)
+        {
+            _ownerHwnd = ownerHwnd;
+            this.InitializeComponent();
+
+            // ウィンドウサイズ・アイコン設定
+            AppWindow.Resize(new SizeInt32(900, 620));
+            var iconPath = Path.Combine(AppContext.BaseDirectory, "Assets", "AppIcon.ico");
+            if (File.Exists(iconPath)) AppWindow.SetIcon(iconPath);
+
+            // ナビゲーション項目のテキストを設定
+            RefreshNavText();
+
+            // モーダル化: 親ウィンドウを無効化
+            EnableWindow(_ownerHwnd, false);
+            Closed += (_, _) => EnableWindow(_ownerHwnd, true);
+
+            // 初期ページを選択
+            NavView.SelectedItem = NavGeneral;
+        }
+
+        /// <summary>
+        /// 親ウィンドウのテーマを設定ウィンドウにも適用する。
+        /// </summary>
+        public void ApplyTheme(ElementTheme theme)
+        {
+            ((FrameworkElement)Content).RequestedTheme = theme;
+            MainWindow.ApplyTitleBarTheme(this, theme);
+        }
+
+        private void RefreshNavText()
+        {
+            Title                = R.Get("AppSettings_Title");
+            NavGeneral.Content     = R.Get("Nav_General");
+            NavExperimental.Content = R.Get("Nav_Experimental");
+            NavExtensions.Content  = R.Get("Nav_Extensions");
+            NavProfiles.Content    = R.Get("Nav_Profiles");
+            NavAbout.Content       = R.Get("Nav_About");
+        }
+
+        private void NavView_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
+        {
+            if (args.SelectedItem is not NavigationViewItem item) return;
+            var tag = item.Tag?.ToString();
+
+            var pageType = tag switch
+            {
+                "General"      => typeof(Settings.GeneralPage),
+                "Experimental" => typeof(Settings.ExperimentalPage),
+                "Extensions"   => typeof(Settings.ExtensionsPage),
+                "Profiles"     => typeof(Settings.ProfilesPage),
+                "About"        => typeof(Settings.AboutPage),
+                _              => null,
+            };
+
+            if (pageType is not null)
+                ContentFrame.Navigate(pageType);
+        }
+    }
+}

--- a/XTimelineViewer.csproj
+++ b/XTimelineViewer.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.2.251219" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250602001" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
     <PackageReference Include="System.Security.Permissions" Version="8.0.0" />


### PR DESCRIPTION
## Summary
- NavigationView + Frame パターンで設定ウィンドウ (`SettingsWindow`) を新設
- 全般・試験機能・拡張機能・プロファイル・バージョン情報の 5 ページ構成（プレースホルダー）
- Win32 `EnableWindow` によるモーダル動作を実装
- 親ウィンドウからのテーマ引き継ぎ（タイトルバー含む）
- `CommunityToolkit.WinUI.Controls.SettingsControls` v8.2.251219 を導入
- メニューの「設定」クリックで新しい設定ウィンドウを開くように変更
- ja-JP / en-US の両方にナビゲーション項目のリソースキーを追加

Closes #133

## Test plan
- [x] ビルド成功（x64）
- [x] 設定メニューから SettingsWindow が開く
- [x] 5 つのナビゲーション項目すべてでページ遷移が動作する
- [x] モーダル動作（親ウィンドウが操作不能になる）
- [x] 設定ウィンドウを閉じると親ウィンドウが再び操作可能になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)