### PR TITLE
feat: 全般設定ページに SettingsCard ベースの UI を実装

### DIFF
--- a/Models/Models.cs
+++ b/Models/Models.cs
@@ -22,7 +22,7 @@ namespace XTimelineViewer.Models
         public string? BadgeText      { get; set; }
     }
 
-    internal class AppSettings
+    public class AppSettings
     {
         public bool    SeparateComposeEnv    { get; set; } = false;
         public bool    OpenComposerInBrowser { get; set; } = false;

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -51,6 +51,8 @@
   <data name="Settings_Theme" xml:space="preserve"><value>Theme</value></data>
   <data name="Settings_Language" xml:space="preserve"><value>Language</value></data>
   <data name="Settings_ExportFolder" xml:space="preserve"><value>Export Settings</value></data>
+  <data name="Settings_Theme_Description" xml:space="preserve"><value>Change the app's appearance</value></data>
+  <data name="Settings_Language_Description" xml:space="preserve"><value>Change the display language</value></data>
   <data name="Section_Experimental" xml:space="preserve"><value>Experimental Features</value></data>
   <data name="Section_About" xml:space="preserve"><value>About</value></data>
   <data name="Settings_SeparateCompose" xml:space="preserve"><value>Open Composer in Separate Profile (Deprecated)</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -51,6 +51,8 @@
   <data name="Settings_Theme" xml:space="preserve"><value>テーマ</value></data>
   <data name="Settings_Language" xml:space="preserve"><value>言語</value></data>
   <data name="Settings_ExportFolder" xml:space="preserve"><value>設定ファイルのエクスポート</value></data>
+  <data name="Settings_Theme_Description" xml:space="preserve"><value>アプリの外観を変更します</value></data>
+  <data name="Settings_Language_Description" xml:space="preserve"><value>アプリの表示言語を変更します</value></data>
   <data name="Section_Experimental" xml:space="preserve"><value>試験機能</value></data>
   <data name="Section_About" xml:space="preserve"><value>バージョン情報</value></data>
   <data name="Settings_SeparateCompose" xml:space="preserve"><value>投稿画面を別プロファイルで開く（廃止予定）</value></data>

--- a/Views/MainWindow.Settings.cs
+++ b/Views/MainWindow.Settings.cs
@@ -61,11 +61,25 @@ namespace XTimelineViewer.Views
         private void OpenSettingsWindow_Click(object _, RoutedEventArgs __)
         {
             var ownerHwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
-            var settingsWin = new SettingsWindow(ownerHwnd);
+            var settingsFolder = Path.GetDirectoryName(SettingsFilePath)!;
+            var settingsWin = new SettingsWindow(ownerHwnd, _appSettings, settingsFolder);
 
             // 親ウィンドウのテーマを引き継ぐ
             var theme = ((FrameworkElement)Content).RequestedTheme;
             settingsWin.ApplyTheme(theme);
+
+            // 設定変更を即時反映
+            settingsWin.SettingsChanged += () =>
+            {
+                SaveSettings();
+                ApplySavedTheme();
+
+                // 言語変更の即時反映
+                var locale = _appSettings.Language == "system" ? null : _appSettings.Language;
+                R.Reload(locale);
+                RefreshUIText();
+                settingsWin.RefreshNavText();
+            };
 
             settingsWin.Activate();
         }

--- a/Views/Settings/AboutPage.xaml
+++ b/Views/Settings/AboutPage.xaml
@@ -5,7 +5,7 @@
     xmlns:controls="using:CommunityToolkit.WinUI.Controls">
 
     <ScrollViewer Padding="24,16">
-        <StackPanel Spacing="4" MaxWidth="700" HorizontalAlignment="Left">
+        <StackPanel Spacing="4">
             <TextBlock x:Name="PageTitle"
                        Style="{StaticResource TitleTextBlockStyle}"
                        Margin="0,0,0,16"/>

--- a/Views/Settings/ExperimentalPage.xaml
+++ b/Views/Settings/ExperimentalPage.xaml
@@ -5,7 +5,7 @@
     xmlns:controls="using:CommunityToolkit.WinUI.Controls">
 
     <ScrollViewer Padding="24,16">
-        <StackPanel Spacing="4" MaxWidth="700" HorizontalAlignment="Left">
+        <StackPanel Spacing="4">
             <TextBlock x:Name="PageTitle"
                        Style="{StaticResource TitleTextBlockStyle}"
                        Margin="0,0,0,16"/>

--- a/Views/Settings/ExtensionsPage.xaml
+++ b/Views/Settings/ExtensionsPage.xaml
@@ -5,7 +5,7 @@
     xmlns:controls="using:CommunityToolkit.WinUI.Controls">
 
     <ScrollViewer Padding="24,16">
-        <StackPanel Spacing="4" MaxWidth="700" HorizontalAlignment="Left">
+        <StackPanel Spacing="4">
             <TextBlock x:Name="PageTitle"
                        Style="{StaticResource TitleTextBlockStyle}"
                        Margin="0,0,0,16"/>

--- a/Views/Settings/GeneralPage.xaml
+++ b/Views/Settings/GeneralPage.xaml
@@ -10,9 +10,33 @@
                        Style="{StaticResource TitleTextBlockStyle}"
                        Margin="0,0,0,16"/>
 
-            <TextBlock x:Name="PlaceholderText"
-                       Opacity="0.6"
-                       FontSize="13"/>
+            <!-- Theme -->
+            <controls:SettingsCard x:Name="ThemeCard">
+                <controls:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE771;" FontFamily="Segoe Fluent Icons"/>
+                </controls:SettingsCard.HeaderIcon>
+                <ComboBox x:Name="ThemeCombo"
+                          MinWidth="160"
+                          SelectionChanged="ThemeCombo_SelectionChanged"/>
+            </controls:SettingsCard>
+
+            <!-- Language -->
+            <controls:SettingsCard x:Name="LanguageCard">
+                <controls:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE8C1;" FontFamily="Segoe Fluent Icons"/>
+                </controls:SettingsCard.HeaderIcon>
+                <ComboBox x:Name="LanguageCombo"
+                          MinWidth="160"
+                          SelectionChanged="LanguageCombo_SelectionChanged"/>
+            </controls:SettingsCard>
+
+            <!-- Export Settings Folder -->
+            <controls:SettingsCard x:Name="ExportFolderCard">
+                <controls:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE838;" FontFamily="Segoe Fluent Icons"/>
+                </controls:SettingsCard.HeaderIcon>
+                <Button x:Name="OpenFolderBtn" Click="OpenFolderBtn_Click"/>
+            </controls:SettingsCard>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/Views/Settings/GeneralPage.xaml
+++ b/Views/Settings/GeneralPage.xaml
@@ -5,7 +5,7 @@
     xmlns:controls="using:CommunityToolkit.WinUI.Controls">
 
     <ScrollViewer Padding="24,16">
-        <StackPanel Spacing="4" MaxWidth="700" HorizontalAlignment="Left">
+        <StackPanel Spacing="4">
             <TextBlock x:Name="PageTitle"
                        Style="{StaticResource TitleTextBlockStyle}"
                        Margin="0,0,0,16"/>

--- a/Views/Settings/GeneralPage.xaml.cs
+++ b/Views/Settings/GeneralPage.xaml.cs
@@ -1,14 +1,107 @@
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Navigation;
+using System;
+using System.Collections.Generic;
+using System.IO;
 
 namespace XTimelineViewer.Views.Settings
 {
     public sealed partial class GeneralPage : Page
     {
+        private static readonly string[] ThemeValues = ["Default", "Light", "Dark"];
+        private static readonly string[] LangValues  = ["system", "ja-JP", "en-US"];
+
+        private SettingsWindow? _parent;
+        private bool _isInitializing = true;
+
         public GeneralPage()
         {
             this.InitializeComponent();
+        }
+
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            base.OnNavigatedTo(e);
+            _parent = e.Parameter as SettingsWindow;
+            PopulateUI();
+        }
+
+        private void PopulateUI()
+        {
+            _isInitializing = true;
+
             PageTitle.Text = R.Get("Nav_General");
-            PlaceholderText.Text = R.Get("Settings_Placeholder");
+
+            // Theme
+            ThemeCard.Header      = R.Get("Settings_Theme");
+            ThemeCard.Description = R.Get("Settings_Theme_Description");
+            ThemeCombo.ItemsSource = new List<string>
+            {
+                R.Get("Theme_System"),
+                R.Get("Theme_Light"),
+                R.Get("Theme_Dark"),
+            };
+            ThemeCombo.SelectedIndex = _parent?.Settings.Theme switch
+            {
+                "Light" => 1,
+                "Dark"  => 2,
+                _       => 0,
+            };
+
+            // Language
+            LanguageCard.Header      = R.Get("Settings_Language");
+            LanguageCard.Description = R.Get("Settings_Language_Description");
+            LanguageCombo.ItemsSource = new List<string>
+            {
+                R.Get("Language_System"),
+                R.Get("Language_JA"),
+                R.Get("Language_EN"),
+            };
+            var langIdx = Array.IndexOf(LangValues, _parent?.Settings.Language ?? "system");
+            LanguageCombo.SelectedIndex = langIdx < 0 ? 0 : langIdx;
+
+            // Export Folder
+            ExportFolderCard.Header      = R.Get("Settings_ExportFolder");
+            ExportFolderCard.Description = _parent?.SettingsFolder ?? "";
+            OpenFolderBtn.Content        = R.Get("Button_OpenFolder");
+
+            _isInitializing = false;
+        }
+
+        private void ThemeCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_isInitializing || _parent is null) return;
+
+            var idx = Math.Clamp(ThemeCombo.SelectedIndex, 0, ThemeValues.Length - 1);
+            _parent.Settings.Theme = ThemeValues[idx];
+
+            // テーマは即時反映
+            var theme = idx switch
+            {
+                1 => ElementTheme.Light,
+                2 => ElementTheme.Dark,
+                _ => ElementTheme.Default,
+            };
+            _parent.ApplyTheme(theme);
+            _parent.NotifySettingsChanged();
+        }
+
+        private void LanguageCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_isInitializing || _parent is null) return;
+
+            var idx = Math.Clamp(LanguageCombo.SelectedIndex, 0, LangValues.Length - 1);
+            _parent.Settings.Language = LangValues[idx];
+            _parent.NotifySettingsChanged();
+        }
+
+        private async void OpenFolderBtn_Click(object sender, RoutedEventArgs e)
+        {
+            if (_parent is null) return;
+            var folder = _parent.SettingsFolder;
+            Directory.CreateDirectory(folder);
+            await Windows.System.Launcher.LaunchFolderPathAsync(folder);
         }
     }
 }

--- a/Views/Settings/ProfilesPage.xaml
+++ b/Views/Settings/ProfilesPage.xaml
@@ -5,7 +5,7 @@
     xmlns:controls="using:CommunityToolkit.WinUI.Controls">
 
     <ScrollViewer Padding="24,16">
-        <StackPanel Spacing="4" MaxWidth="700" HorizontalAlignment="Left">
+        <StackPanel Spacing="4">
             <TextBlock x:Name="PageTitle"
                        Style="{StaticResource TitleTextBlockStyle}"
                        Margin="0,0,0,16"/>

--- a/Views/SettingsWindow.xaml.cs
+++ b/Views/SettingsWindow.xaml.cs
@@ -4,6 +4,7 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using Windows.Graphics;
+using XTimelineViewer.Models;
 
 namespace XTimelineViewer.Views
 {
@@ -14,9 +15,22 @@ namespace XTimelineViewer.Views
 
         private readonly IntPtr _ownerHwnd;
 
-        public SettingsWindow(IntPtr ownerHwnd)
+        /// <summary>親ウィンドウから渡されたアプリ設定。ページが直接読み書きする。</summary>
+        internal AppSettings Settings { get; }
+
+        /// <summary>設定ファイルが格納されているフォルダーパス。</summary>
+        internal string SettingsFolder { get; }
+
+        /// <summary>設定が変更されたときに発火する。MainWindow が購読して保存・適用する。</summary>
+        internal event Action? SettingsChanged;
+
+        internal void NotifySettingsChanged() => SettingsChanged?.Invoke();
+
+        public SettingsWindow(IntPtr ownerHwnd, AppSettings settings, string settingsFolder)
         {
             _ownerHwnd = ownerHwnd;
+            Settings = settings;
+            SettingsFolder = settingsFolder;
             this.InitializeComponent();
 
             // ウィンドウサイズ・アイコン設定
@@ -44,9 +58,10 @@ namespace XTimelineViewer.Views
             MainWindow.ApplyTitleBarTheme(this, theme);
         }
 
-        private void RefreshNavText()
+        /// <summary>ナビゲーション項目と各ページのテキストを再設定する。</summary>
+        internal void RefreshNavText()
         {
-            Title                = R.Get("AppSettings_Title");
+            Title                  = R.Get("AppSettings_Title");
             NavGeneral.Content     = R.Get("Nav_General");
             NavExperimental.Content = R.Get("Nav_Experimental");
             NavExtensions.Content  = R.Get("Nav_Extensions");
@@ -70,7 +85,7 @@ namespace XTimelineViewer.Views
             };
 
             if (pageType is not null)
-                ContentFrame.Navigate(pageType);
+                ContentFrame.Navigate(pageType, this);
         }
     }
 }


### PR DESCRIPTION
## Summary
- 全般設定ページ (`GeneralPage`) に SettingsCard ベースの UI を実装
- テーマ選択（ComboBox）・言語選択（ComboBox）・設定フォルダーを開く（Button）の 3 カード構成
- `SettingsWindow` に `AppSettings` 受け渡し基盤を追加（`Settings` プロパティ、`SettingsChanged` イベント）
- テーマ変更は設定ウィンドウと親ウィンドウの両方に即時反映
- 言語変更も即時反映（`R.Reload` + `RefreshUIText`）
- `AppSettings` のアクセシビリティを `internal` → `public` に変更（WinUI XAML コンパイラ要件）

Closes #134

## Test plan
- [x] ビルド成功（x64）
- [x] 全般ページに 3 つの SettingsCard が表示される
- [x] テーマ切り替え（システム/ライト/ダーク）が即時反映される
- [x] 設定ウィンドウと親ウィンドウの両方にテーマが適用される
- [x] 設定フォルダーパスが SettingsCard の Description に表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)