### PR TITLE
feat: 試験機能ページに SettingsCard ベースの UI を実装

### DIFF
--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -56,9 +56,16 @@
   <data name="Section_Experimental" xml:space="preserve"><value>Experimental Features</value></data>
   <data name="Section_About" xml:space="preserve"><value>About</value></data>
   <data name="Settings_SeparateCompose" xml:space="preserve"><value>Open Composer in Separate Profile (Deprecated)</value></data>
+  <data name="Settings_SeparateCompose_Description" xml:space="preserve"><value>This feature has been deprecated</value></data>
   <data name="Settings_OpenComposerInBrowser" xml:space="preserve"><value>Open Composer in External Browser</value></data>
+  <data name="Settings_OpenComposerInBrowser_Description" xml:space="preserve"><value>Open new posts in an external browser instead of the built-in composer</value></data>
   <data name="Settings_OpenTimestampInBrowser" xml:space="preserve"><value>Open Timestamp Links in External Browser</value></data>
+  <data name="Settings_OpenTimestampInBrowser_Description" xml:space="preserve"><value>Open timestamp links in an external browser instead of navigating in the timeline</value></data>
   <data name="Settings_AutoActivate" xml:space="preserve"><value>Auto-activate Home Timeline (min, 0 to disable)</value></data>
+  <data name="Settings_AutoActivate_Description" xml:space="preserve"><value>Periodically bring the Home timeline to the foreground</value></data>
+  <data name="Settings_ShowAutoActivateLabel_Description" xml:space="preserve"><value>Show the auto-activate countdown timer in the toolbar</value></data>
+  <data name="Settings_ExternalBrowser_Description" xml:space="preserve"><value>Choose which browser to use for opening external links</value></data>
+  <data name="Settings_EdgeProfile_Description" xml:space="preserve"><value>Select the Edge profile to use when opening links</value></data>
 
   <!-- Language selector items -->
   <data name="Language_System" xml:space="preserve"><value>System Language</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -56,9 +56,16 @@
   <data name="Section_Experimental" xml:space="preserve"><value>試験機能</value></data>
   <data name="Section_About" xml:space="preserve"><value>バージョン情報</value></data>
   <data name="Settings_SeparateCompose" xml:space="preserve"><value>投稿画面を別プロファイルで開く（廃止予定）</value></data>
+  <data name="Settings_SeparateCompose_Description" xml:space="preserve"><value>この機能は廃止予定です</value></data>
   <data name="Settings_OpenComposerInBrowser" xml:space="preserve"><value>新規投稿を外部ブラウザーで開く</value></data>
+  <data name="Settings_OpenComposerInBrowser_Description" xml:space="preserve"><value>内蔵のコンポーザーの代わりに外部ブラウザーで新規投稿を開きます</value></data>
   <data name="Settings_OpenTimestampInBrowser" xml:space="preserve"><value>タイムスタンプリンクを外部ブラウザーで開く</value></data>
+  <data name="Settings_OpenTimestampInBrowser_Description" xml:space="preserve"><value>タイムライン内で移動せず、外部ブラウザーでタイムスタンプリンクを開きます</value></data>
   <data name="Settings_AutoActivate" xml:space="preserve"><value>ホームタイムラインを定期的にアクティブ化（分、0 で無効）</value></data>
+  <data name="Settings_AutoActivate_Description" xml:space="preserve"><value>定期的にホームタイムラインを前面に表示します</value></data>
+  <data name="Settings_ShowAutoActivateLabel_Description" xml:space="preserve"><value>ツールバーに自動アクティブ化のカウントダウンタイマーを表示します</value></data>
+  <data name="Settings_ExternalBrowser_Description" xml:space="preserve"><value>外部リンクを開くブラウザーを選択します</value></data>
+  <data name="Settings_EdgeProfile_Description" xml:space="preserve"><value>リンクを開く際に使用する Edge プロファイルを選択します</value></data>
 
   <!-- Language selector items -->
   <data name="Language_System" xml:space="preserve"><value>システム言語</value></data>

--- a/Views/MainWindow.Settings.cs
+++ b/Views/MainWindow.Settings.cs
@@ -73,6 +73,14 @@ namespace XTimelineViewer.Views
             {
                 SaveSettings();
                 ApplySavedTheme();
+                ApplyAutoActivateTimer();
+
+                // WebView のタイムスタンプ設定を即時反映
+                var tsFlag = _appSettings.OpenTimestampInBrowser ? "true" : "false";
+                foreach (var wv in _webViews)
+                    if (wv.CoreWebView2 is not null)
+                        _ = wv.CoreWebView2.ExecuteScriptAsync(
+                            $"window._xtvOpenTimestampInBrowser = {tsFlag};");
 
                 // 言語変更の即時反映
                 var locale = _appSettings.Language == "system" ? null : _appSettings.Language;

--- a/Views/Settings/ExperimentalPage.xaml
+++ b/Views/Settings/ExperimentalPage.xaml
@@ -10,9 +10,78 @@
                        Style="{StaticResource TitleTextBlockStyle}"
                        Margin="0,0,0,16"/>
 
-            <TextBlock x:Name="PlaceholderText"
-                       Opacity="0.6"
-                       FontSize="13"/>
+            <!-- Open Composer in Separate Profile (Deprecated) -->
+            <controls:SettingsCard x:Name="SeparateComposeCard" IsEnabled="False">
+                <controls:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE8A7;" FontFamily="Segoe Fluent Icons"/>
+                </controls:SettingsCard.HeaderIcon>
+                <ToggleSwitch x:Name="SeparateComposeToggle" IsOn="False" IsEnabled="False"/>
+            </controls:SettingsCard>
+
+            <!-- Open Composer in External Browser -->
+            <controls:SettingsCard x:Name="OpenComposerCard">
+                <controls:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE70F;" FontFamily="Segoe Fluent Icons"/>
+                </controls:SettingsCard.HeaderIcon>
+                <ToggleSwitch x:Name="OpenComposerToggle"
+                              Toggled="OpenComposerToggle_Toggled"/>
+            </controls:SettingsCard>
+
+            <!-- Open Timestamp Links in External Browser -->
+            <controls:SettingsCard x:Name="OpenTimestampCard">
+                <controls:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE71B;" FontFamily="Segoe Fluent Icons"/>
+                </controls:SettingsCard.HeaderIcon>
+                <ToggleSwitch x:Name="OpenTimestampToggle"
+                              Toggled="OpenTimestampToggle_Toggled"/>
+            </controls:SettingsCard>
+
+            <!-- Auto-Activate Home Timeline -->
+            <controls:SettingsCard x:Name="AutoActivateCard">
+                <controls:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE787;" FontFamily="Segoe Fluent Icons"/>
+                </controls:SettingsCard.HeaderIcon>
+                <NumberBox x:Name="AutoActivateBox"
+                           Minimum="0" Maximum="60"
+                           SmallChange="1" LargeChange="5"
+                           SpinButtonPlacementMode="Inline"
+                           Width="160"
+                           ValueChanged="AutoActivateBox_ValueChanged"/>
+            </controls:SettingsCard>
+
+            <!-- Show Auto-Activate Status in Toolbar -->
+            <controls:SettingsCard x:Name="ShowAutoActivateLabelCard">
+                <controls:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE7B3;" FontFamily="Segoe Fluent Icons"/>
+                </controls:SettingsCard.HeaderIcon>
+                <ToggleSwitch x:Name="ShowAutoActivateLabelToggle"
+                              Toggled="ShowAutoActivateLabelToggle_Toggled"/>
+            </controls:SettingsCard>
+
+            <!-- External Browser Section Header -->
+            <TextBlock x:Name="ExternalBrowserHeader"
+                       Style="{StaticResource BodyStrongTextBlockStyle}"
+                       Margin="0,20,0,4"/>
+
+            <!-- Browser Selection -->
+            <controls:SettingsCard x:Name="BrowserCard">
+                <controls:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE774;" FontFamily="Segoe Fluent Icons"/>
+                </controls:SettingsCard.HeaderIcon>
+                <ComboBox x:Name="BrowserCombo"
+                          MinWidth="200"
+                          SelectionChanged="BrowserCombo_SelectionChanged"/>
+            </controls:SettingsCard>
+
+            <!-- Edge Profile -->
+            <controls:SettingsCard x:Name="EdgeProfileCard">
+                <controls:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE716;" FontFamily="Segoe Fluent Icons"/>
+                </controls:SettingsCard.HeaderIcon>
+                <ComboBox x:Name="EdgeProfileCombo"
+                          MinWidth="200"
+                          SelectionChanged="EdgeProfileCombo_SelectionChanged"/>
+            </controls:SettingsCard>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/Views/Settings/ExperimentalPage.xaml.cs
+++ b/Views/Settings/ExperimentalPage.xaml.cs
@@ -1,14 +1,159 @@
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Navigation;
+using System;
+using System.Collections.Generic;
+using XTimelineViewer.Services;
 
 namespace XTimelineViewer.Views.Settings
 {
     public sealed partial class ExperimentalPage : Page
     {
+        private static readonly string[] BrowserValues = ["system", "edge"];
+
+        private SettingsWindow? _parent;
+        private bool _isInitializing = true;
+        private List<EdgeProfile> _edgeProfiles = [];
+
         public ExperimentalPage()
         {
             this.InitializeComponent();
+        }
+
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            base.OnNavigatedTo(e);
+            _parent = e.Parameter as SettingsWindow;
+            PopulateUI();
+        }
+
+        private void PopulateUI()
+        {
+            _isInitializing = true;
+            var s = _parent?.Settings;
+
             PageTitle.Text = R.Get("Nav_Experimental");
-            PlaceholderText.Text = R.Get("Settings_Placeholder");
+
+            // Separate Compose (Deprecated)
+            SeparateComposeCard.Header      = R.Get("Settings_SeparateCompose");
+            SeparateComposeCard.Description = R.Get("Settings_SeparateCompose_Description");
+
+            // Open Composer in Browser
+            OpenComposerCard.Header      = R.Get("Settings_OpenComposerInBrowser");
+            OpenComposerCard.Description = R.Get("Settings_OpenComposerInBrowser_Description");
+            OpenComposerToggle.OnContent  = R.Get("Toggle_On");
+            OpenComposerToggle.OffContent = R.Get("Toggle_Off");
+            OpenComposerToggle.IsOn       = s?.OpenComposerInBrowser ?? false;
+
+            // Open Timestamp in Browser
+            OpenTimestampCard.Header      = R.Get("Settings_OpenTimestampInBrowser");
+            OpenTimestampCard.Description = R.Get("Settings_OpenTimestampInBrowser_Description");
+            OpenTimestampToggle.OnContent  = R.Get("Toggle_On");
+            OpenTimestampToggle.OffContent = R.Get("Toggle_Off");
+            OpenTimestampToggle.IsOn       = s?.OpenTimestampInBrowser ?? false;
+
+            // Auto-Activate
+            AutoActivateCard.Header      = R.Get("Settings_AutoActivate");
+            AutoActivateCard.Description = R.Get("Settings_AutoActivate_Description");
+            AutoActivateBox.Value        = s?.AutoActivateMinutes ?? 0;
+
+            // Show Auto-Activate Label
+            ShowAutoActivateLabelCard.Header      = R.Get("Settings_ShowAutoActivateLabel");
+            ShowAutoActivateLabelCard.Description = R.Get("Settings_ShowAutoActivateLabel_Description");
+            ShowAutoActivateLabelToggle.OnContent  = R.Get("Toggle_On");
+            ShowAutoActivateLabelToggle.OffContent = R.Get("Toggle_Off");
+            ShowAutoActivateLabelToggle.IsOn       = s?.ShowAutoActivateLabel ?? false;
+
+            // External Browser Section
+            ExternalBrowserHeader.Text = R.Get("Section_ExternalBrowser");
+
+            BrowserCard.Header      = R.Get("Settings_ExternalBrowser");
+            BrowserCard.Description = R.Get("Settings_ExternalBrowser_Description");
+            BrowserCombo.ItemsSource = new List<string> { R.Get("Browser_System"), "Microsoft Edge" };
+            BrowserCombo.SelectedIndex = s?.ExternalBrowser == "edge" ? 1 : 0;
+
+            // Edge Profile
+            EdgeProfileCard.Header      = R.Get("Settings_EdgeProfile");
+            EdgeProfileCard.Description = R.Get("Settings_EdgeProfile_Description");
+            _edgeProfiles = EdgeService.EnumerateProfiles();
+
+            if (_edgeProfiles.Count == 0)
+            {
+                EdgeProfileCombo.ItemsSource   = new List<string> { R.Get("Browser_EdgeNotFound") };
+                EdgeProfileCombo.SelectedIndex = 0;
+                EdgeProfileCombo.IsEnabled     = false;
+            }
+            else
+            {
+                var names = new List<string>();
+                int selectedIdx = 0;
+                for (int i = 0; i < _edgeProfiles.Count; i++)
+                {
+                    var p = _edgeProfiles[i];
+                    var detail = p.UserName.Length > 0 ? p.UserName : p.Directory;
+                    names.Add($"{p.DisplayName}  ({detail})");
+                    if (p.Directory == s?.EdgeProfileDirectory)
+                        selectedIdx = i;
+                }
+                EdgeProfileCombo.ItemsSource   = names;
+                EdgeProfileCombo.SelectedIndex = selectedIdx;
+                EdgeProfileCombo.IsEnabled     = s?.ExternalBrowser == "edge";
+            }
+
+            _isInitializing = false;
+        }
+
+        private void OpenComposerToggle_Toggled(object sender, RoutedEventArgs e)
+        {
+            if (_isInitializing || _parent is null) return;
+            _parent.Settings.OpenComposerInBrowser = OpenComposerToggle.IsOn;
+            _parent.NotifySettingsChanged();
+        }
+
+        private void OpenTimestampToggle_Toggled(object sender, RoutedEventArgs e)
+        {
+            if (_isInitializing || _parent is null) return;
+            _parent.Settings.OpenTimestampInBrowser = OpenTimestampToggle.IsOn;
+            _parent.NotifySettingsChanged();
+        }
+
+        private void AutoActivateBox_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+        {
+            if (_isInitializing || _parent is null) return;
+            _parent.Settings.AutoActivateMinutes = (int)Math.Clamp(args.NewValue, 0, 60);
+            _parent.NotifySettingsChanged();
+        }
+
+        private void ShowAutoActivateLabelToggle_Toggled(object sender, RoutedEventArgs e)
+        {
+            if (_isInitializing || _parent is null) return;
+            _parent.Settings.ShowAutoActivateLabel = ShowAutoActivateLabelToggle.IsOn;
+            _parent.NotifySettingsChanged();
+        }
+
+        private void BrowserCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_isInitializing || _parent is null) return;
+
+            var idx = Math.Clamp(BrowserCombo.SelectedIndex, 0, BrowserValues.Length - 1);
+            _parent.Settings.ExternalBrowser = BrowserValues[idx];
+
+            // Edge プロファイル ComboBox の有効/無効を切り替え
+            var isEdge = idx == 1;
+            EdgeProfileCombo.IsEnabled = isEdge && _edgeProfiles.Count > 0;
+
+            _parent.NotifySettingsChanged();
+        }
+
+        private void EdgeProfileCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_isInitializing || _parent is null) return;
+
+            var idx = EdgeProfileCombo.SelectedIndex;
+            if (_edgeProfiles.Count > 0 && idx >= 0 && idx < _edgeProfiles.Count)
+                _parent.Settings.EdgeProfileDirectory = _edgeProfiles[idx].Directory;
+
+            _parent.NotifySettingsChanged();
         }
     }
 }


### PR DESCRIPTION
## Summary
- 試験機能ページ (`ExperimentalPage`) に SettingsCard ベースの UI を実装
- 旧ダイアログから 7 項目を移植:
  - 投稿画面を別プロファイルで開く（廃止予定、無効化状態）
  - 新規投稿を外部ブラウザーで開く（ToggleSwitch）
  - タイムスタンプリンクを外部ブラウザーで開く（ToggleSwitch）
  - ホームタイムライン定期アクティブ化（NumberBox）
  - ツールバーに自動アクティブ化の状態を表示（ToggleSwitch）
  - 外部ブラウザー選択（ComboBox）
  - Edge プロファイル選択（ComboBox）
- MainWindow の SettingsChanged ハンドラに `ApplyAutoActivateTimer()` と WebView タイムスタンプ設定の即時反映を追加
- 各 SettingsCard に Description テキストのリソースキーを追加（ja/en）

Closes #135

## Test plan
- [x] ビルド成功（x64）
- [x] 全ての ToggleSwitch/NumberBox/ComboBox が AppSettings を正しく読み書きする
- [x] Edge プロファイル ComboBox がブラウザー選択と連動して有効/無効を切り替える
- [ ] 設定変更が即時保存・反映される（AutoActivateTimer、WebView タイムスタンプ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)