### PR TITLE
feat: 拡張機能ページに SettingsCard ベースの UI を実装 (#136)

### DIFF
--- a/Models/Models.cs
+++ b/Models/Models.cs
@@ -2,6 +2,15 @@ using System;
 
 namespace XTimelineViewer.Models
 {
+    internal record ExtensionInfo(
+        string Name,
+        string DirectoryPath,
+        string? IconPath,
+        string? OptionsPage,
+        string? HomepageUrl,
+        string? ExtensionId
+    );
+
     internal class TimelineConfig
     {
         public string Url                { get; set; } = "";

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -148,6 +148,9 @@
   <data name="ExtSettings_Format" xml:space="preserve"><value>{0} Settings</value></data>
   <data name="ExtSettings_Homepage" xml:space="preserve"><value>Open Homepage</value></data>
   <data name="ExtSettings_StoreLink" xml:space="preserve"><value>Open in Chrome Web Store</value></data>
+  <data name="ExtSettings_OpenSettings" xml:space="preserve"><value>Open Settings</value></data>
+  <data name="Extensions_Empty" xml:space="preserve"><value>No extensions installed</value></data>
+  <data name="Extensions_Empty_Description" xml:space="preserve"><value>Place extension folders in the "extensions" directory to add them.</value></data>
 
   <!-- Update check -->
   <data name="CheckUpdate_Btn" xml:space="preserve"><value>Check for Updates</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -148,6 +148,9 @@
   <data name="ExtSettings_Format" xml:space="preserve"><value>{0} の設定</value></data>
   <data name="ExtSettings_Homepage" xml:space="preserve"><value>ホームページを開く</value></data>
   <data name="ExtSettings_StoreLink" xml:space="preserve"><value>Chrome Web Store で開く</value></data>
+  <data name="ExtSettings_OpenSettings" xml:space="preserve"><value>設定を開く</value></data>
+  <data name="Extensions_Empty" xml:space="preserve"><value>拡張機能がインストールされていません</value></data>
+  <data name="Extensions_Empty_Description" xml:space="preserve"><value>"extensions" フォルダーに拡張機能を配置してください。</value></data>
 
   <!-- Update check -->
   <data name="CheckUpdate_Btn" xml:space="preserve"><value>更新を確認</value></data>

--- a/Views/MainWindow.Settings.cs
+++ b/Views/MainWindow.Settings.cs
@@ -64,6 +64,12 @@ namespace XTimelineViewer.Views
             var settingsFolder = Path.GetDirectoryName(SettingsFilePath)!;
             var settingsWin = new SettingsWindow(ownerHwnd, _appSettings, settingsFolder);
 
+            // 拡張機能情報とコールバックを設定
+            settingsWin.Extensions = _loadedExtensions;
+            settingsWin.OpenExtensionSettingsAsync = (info, xamlRoot) =>
+                ShowExtensionSettingsDialogAsync(info, xamlRoot, LaunchUriByEdgeProfileAsync);
+            settingsWin.LaunchUriAsync = LaunchUriByEdgeProfileAsync;
+
             // 親ウィンドウのテーマを引き継ぐ
             var theme = ((FrameworkElement)Content).RequestedTheme;
             settingsWin.ApplyTheme(theme);

--- a/Views/MainWindow.WebView2.cs
+++ b/Views/MainWindow.WebView2.cs
@@ -236,24 +236,25 @@ namespace XTimelineViewer.Views
             }
         }
 
-        private void AddExtensionButton(CoreWebView2BrowserExtension ext, string extDir)
+        internal static ExtensionInfo ReadExtensionManifest(string extDir, string? extensionId = null, string? nameOverride = null)
         {
-            // マニフェストから名前、options_ui.page、アイコン、homepage_url を取得
-            string name          = ext.Name;
-            string? optPage      = null;
-            string? iconPath     = null;
-            string? homepageUrl  = null;
+            string name     = nameOverride ?? Path.GetFileName(extDir);
+            string? optPage     = null;
+            string? iconPath    = null;
+            string? homepageUrl = null;
             var manifestPath = Path.Combine(extDir, "manifest.json");
             if (File.Exists(manifestPath))
             {
                 using var doc = JsonDocument.Parse(File.ReadAllText(manifestPath));
                 var root = doc.RootElement;
+                if (root.TryGetProperty("name", out var nameProp) && nameOverride is null)
+                    name = nameProp.GetString() ?? name;
                 if (root.TryGetProperty("options_ui", out var optUi) &&
                     optUi.TryGetProperty("page", out var page))
                     optPage = page.GetString();
                 if (root.TryGetProperty("icons", out var icons))
                 {
-                    foreach (var size in new[] { "16", "32", "48", "128" })
+                    foreach (var size in new[] { "48", "32", "128", "16" })
                     {
                         if (icons.TryGetProperty(size, out var iconProp))
                         {
@@ -268,22 +269,27 @@ namespace XTimelineViewer.Views
                 }
                 if (root.TryGetProperty("homepage_url", out var hp))
                     homepageUrl = hp.GetString();
-
-                // homepage_url がない場合、Chrome Web Store 拡張なら store URL を構成する
                 if (homepageUrl is null &&
                     root.TryGetProperty("update_url", out var updateUrl) &&
                     updateUrl.GetString()?.Contains("clients2.google.com") == true)
                 {
-                    // ext.Id は WebView2 内部 ID のため、フォルダー名（元の CWS ID）を使う
                     homepageUrl = $"https://chromewebstore.google.com/detail/{Path.GetFileName(extDir)}";
                 }
             }
-            if (optPage is null) return; // options_ui がない拡張は追加しない
+            return new ExtensionInfo(name, extDir, iconPath, optPage, homepageUrl, extensionId);
+        }
 
-            object btnContent = iconPath is not null
+        private void AddExtensionButton(CoreWebView2BrowserExtension ext, string extDir)
+        {
+            var info = ReadExtensionManifest(extDir, ext.Id, ext.Name);
+            _loadedExtensions.Add(info);
+
+            if (info.OptionsPage is null) return;
+
+            object btnContent = info.IconPath is not null
                 ? new Image
                 {
-                    Source = new Microsoft.UI.Xaml.Media.Imaging.BitmapImage(new Uri(iconPath)),
+                    Source = new Microsoft.UI.Xaml.Media.Imaging.BitmapImage(new Uri(info.IconPath)),
                     Width = 20, Height = 20
                 }
                 : (object)"🧩";
@@ -295,67 +301,72 @@ namespace XTimelineViewer.Views
                 Height  = 32,
                 Padding = new Thickness(0),
             };
-            ToolTipService.SetToolTip(btn, string.Format(R.Get("ExtSettings_Format"), name));
+            ToolTipService.SetToolTip(btn, string.Format(R.Get("ExtSettings_Format"), info.Name));
 
-            var optPageUrl = $"chrome-extension://{ext.Id}/{optPage}";
             btn.Click += async (_, _) =>
             {
-                var optWebView = new WebView2 { Width = 480, MinHeight = 200 };
-
-                Uri.TryCreate(homepageUrl, UriKind.Absolute, out var homepageUri);
-                var linkText = homepageUri?.Host.Contains("chromewebstore.google.com") == true
-                    ? R.Get("ExtSettings_StoreLink")
-                    : R.Get("ExtSettings_Homepage");
-
-                var dlg = new ContentDialog
-                {
-                    Title                = string.Format(R.Get("ExtSettings_Format"), name),
-                    Content              = optWebView,
-                    SecondaryButtonText  = homepageUri is not null ? linkText : null,
-                    CloseButtonText      = R.Get("Button_Close"),
-                    XamlRoot             = Content.XamlRoot
-                };
-
-                // SecondaryButton クリックでブラウザーを開き、ダイアログは閉じない
-                if (homepageUri is not null)
-                    dlg.SecondaryButtonClick += (s, e) =>
-                    {
-                        e.Cancel = true;
-                        _ = LaunchUriByEdgeProfileAsync(homepageUri);
-                    };
-
-                var env = await GetOrCreateProfileEnvAsync("default");
-                await optWebView.EnsureCoreWebView2Async(env);
-                var isDark = ((FrameworkElement)Content).ActualTheme == ElementTheme.Dark;
-                optWebView.CoreWebView2.Profile.PreferredColorScheme = isDark
-                    ? CoreWebView2PreferredColorScheme.Dark
-                    : CoreWebView2PreferredColorScheme.Light;
-                // 拡張機能ページが prefers-color-scheme 未対応の場合に備え、
-                // WebView2 背景色を合わせ、ページ読み込み後に CSS を注入する
-                if (isDark)
-                {
-                    optWebView.DefaultBackgroundColor = Windows.UI.Color.FromArgb(255, 32, 32, 32);
-                    optWebView.CoreWebView2.NavigationCompleted += async (s, e) =>
-                    {
-                        await optWebView.CoreWebView2.ExecuteScriptAsync("""
-                            if (!window.matchMedia('(prefers-color-scheme: dark)').matches ||
-                                getComputedStyle(document.body).backgroundColor === 'rgb(255, 255, 255)') {
-                                document.documentElement.style.cssText += 'background:#202020!important;color:#e0e0e0!important';
-                                document.body.style.cssText += 'background:#202020!important;color:#e0e0e0!important';
-                                document.querySelectorAll('input,select,textarea,button').forEach(el => {
-                                    el.style.cssText += 'background:#333!important;color:#e0e0e0!important;border-color:#555!important';
-                                });
-                            }
-                        """);
-                    };
-                }
-                optWebView.Source = new Uri(optPageUrl);
-                await ShowDialogAsync(dlg);
+                await ShowExtensionSettingsDialogAsync(info, Content.XamlRoot, LaunchUriByEdgeProfileAsync);
             };
 
             // 設定ボタン（末尾）の左隣に挿入
             int insertIdx = Math.Max(0, RightToolbar.Children.Count - 1);
             RightToolbar.Children.Insert(insertIdx, btn);
+        }
+
+        internal async Task ShowExtensionSettingsDialogAsync(
+            ExtensionInfo info, Microsoft.UI.Xaml.XamlRoot xamlRoot, Func<Uri, Task> launchUri)
+        {
+            if (info.OptionsPage is null || info.ExtensionId is null) return;
+
+            var optWebView = new WebView2 { Width = 480, MinHeight = 200 };
+
+            Uri.TryCreate(info.HomepageUrl, UriKind.Absolute, out var homepageUri);
+            var linkText = homepageUri?.Host.Contains("chromewebstore.google.com") == true
+                ? R.Get("ExtSettings_StoreLink")
+                : R.Get("ExtSettings_Homepage");
+
+            var dlg = new ContentDialog
+            {
+                Title                = string.Format(R.Get("ExtSettings_Format"), info.Name),
+                Content              = optWebView,
+                SecondaryButtonText  = homepageUri is not null ? linkText : null,
+                CloseButtonText      = R.Get("Button_Close"),
+                XamlRoot             = xamlRoot
+            };
+
+            if (homepageUri is not null)
+                dlg.SecondaryButtonClick += (s, e) =>
+                {
+                    e.Cancel = true;
+                    _ = launchUri(homepageUri);
+                };
+
+            var env = await GetOrCreateProfileEnvAsync("default");
+            await optWebView.EnsureCoreWebView2Async(env);
+            var isDark = xamlRoot.Content is FrameworkElement fe
+                && fe.ActualTheme == ElementTheme.Dark;
+            optWebView.CoreWebView2.Profile.PreferredColorScheme = isDark
+                ? CoreWebView2PreferredColorScheme.Dark
+                : CoreWebView2PreferredColorScheme.Light;
+            if (isDark)
+            {
+                optWebView.DefaultBackgroundColor = Windows.UI.Color.FromArgb(255, 32, 32, 32);
+                optWebView.CoreWebView2.NavigationCompleted += async (s, e) =>
+                {
+                    await optWebView.CoreWebView2.ExecuteScriptAsync("""
+                        if (!window.matchMedia('(prefers-color-scheme: dark)').matches ||
+                            getComputedStyle(document.body).backgroundColor === 'rgb(255, 255, 255)') {
+                            document.documentElement.style.cssText += 'background:#202020!important;color:#e0e0e0!important';
+                            document.body.style.cssText += 'background:#202020!important;color:#e0e0e0!important';
+                            document.querySelectorAll('input,select,textarea,button').forEach(el => {
+                                el.style.cssText += 'background:#333!important;color:#e0e0e0!important;border-color:#555!important';
+                            });
+                        }
+                    """);
+                };
+            }
+            optWebView.Source = new Uri($"chrome-extension://{info.ExtensionId}/{info.OptionsPage}");
+            await ShowDialogAsync(dlg);
         }
 
         private static readonly string LogFilePath = Path.Combine(

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -61,7 +61,7 @@ namespace XTimelineViewer.Views
             return newPath;
         }
 
-        private static string GetExtensionsDir()
+        internal static string GetExtensionsDir()
         {
             var sourceDir = Path.Combine(AppContext.BaseDirectory, "extensions");
             if (!PackageContext.IsPackaged) return sourceDir;
@@ -97,6 +97,7 @@ namespace XTimelineViewer.Views
         private readonly List<Action> _headerRefreshers = [];
         private readonly List<WebView2> _webViews = [];
         private bool _extensionsLoaded = false;
+        private readonly List<ExtensionInfo> _loadedExtensions = [];
         private readonly Dictionary<string, CoreWebView2Environment> _profileEnvs = [];
         private CoreWebView2Environment? _composeEnv;
         private List<ProfileConfig> _profiles = [];

--- a/Views/Settings/ExtensionsPage.xaml
+++ b/Views/Settings/ExtensionsPage.xaml
@@ -5,14 +5,12 @@
     xmlns:controls="using:CommunityToolkit.WinUI.Controls">
 
     <ScrollViewer Padding="24,16">
-        <StackPanel Spacing="4">
+        <StackPanel x:Name="RootPanel" Spacing="4">
             <TextBlock x:Name="PageTitle"
                        Style="{StaticResource TitleTextBlockStyle}"
                        Margin="0,0,0,16"/>
 
-            <TextBlock x:Name="PlaceholderText"
-                       Opacity="0.6"
-                       FontSize="13"/>
+            <!-- 拡張機能カードはコードビハインドで動的に追加 -->
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/Views/Settings/ExtensionsPage.xaml.cs
+++ b/Views/Settings/ExtensionsPage.xaml.cs
@@ -1,14 +1,142 @@
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media.Imaging;
+using Microsoft.UI.Xaml.Navigation;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using XTimelineViewer.Models;
 
 namespace XTimelineViewer.Views.Settings
 {
     public sealed partial class ExtensionsPage : Page
     {
+        private SettingsWindow? _parent;
+
         public ExtensionsPage()
         {
             this.InitializeComponent();
+        }
+
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            base.OnNavigatedTo(e);
+            _parent = e.Parameter as SettingsWindow;
+            PopulateUI();
+        }
+
+        private void PopulateUI()
+        {
             PageTitle.Text = R.Get("Nav_Extensions");
-            PlaceholderText.Text = R.Get("Settings_Placeholder");
+
+            var extensions = _parent?.Extensions ?? [];
+
+            if (extensions.Count == 0)
+            {
+                var emptyCard = new CommunityToolkit.WinUI.Controls.SettingsCard
+                {
+                    Header      = R.Get("Extensions_Empty"),
+                    Description = R.Get("Extensions_Empty_Description"),
+                    IsEnabled   = false,
+                };
+                emptyCard.HeaderIcon = new FontIcon
+                {
+                    Glyph      = "",
+                    FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Segoe Fluent Icons")
+                };
+                RootPanel.Children.Add(emptyCard);
+                return;
+            }
+
+            foreach (var ext in extensions)
+            {
+                AddExtensionCard(ext);
+            }
+        }
+
+        private void AddExtensionCard(ExtensionInfo ext)
+        {
+            var card = new CommunityToolkit.WinUI.Controls.SettingsCard
+            {
+                Header      = ext.Name,
+                Description = Path.GetFileName(ext.DirectoryPath),
+                IsClickEnabled = ext.OptionsPage is not null && ext.ExtensionId is not null,
+            };
+
+            if (ext.IconPath is not null)
+            {
+                card.HeaderIcon = new ImageIcon
+                {
+                    Source = new BitmapImage(new Uri(ext.IconPath)),
+                    Width  = 24,
+                    Height = 24,
+                };
+            }
+            else
+            {
+                card.HeaderIcon = new FontIcon
+                {
+                    Glyph      = "",
+                    FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Segoe Fluent Icons")
+                };
+            }
+
+            if (card.IsClickEnabled)
+            {
+                card.ActionIcon = new FontIcon
+                {
+                    Glyph      = "",
+                    FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Segoe Fluent Icons"),
+                    FontSize   = 14,
+                };
+                card.Click += async (_, _) =>
+                {
+                    if (_parent?.OpenExtensionSettingsAsync is not null && XamlRoot is not null)
+                        await _parent.OpenExtensionSettingsAsync(ext, XamlRoot);
+                };
+            }
+
+            var buttonsPanel = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Spacing     = 8,
+            };
+
+            if (ext.OptionsPage is not null && ext.ExtensionId is not null)
+            {
+                var settingsBtn = new Button
+                {
+                    Content = R.Get("ExtSettings_OpenSettings"),
+                };
+                settingsBtn.Click += async (_, _) =>
+                {
+                    if (_parent?.OpenExtensionSettingsAsync is not null && XamlRoot is not null)
+                        await _parent.OpenExtensionSettingsAsync(ext, XamlRoot);
+                };
+                buttonsPanel.Children.Add(settingsBtn);
+            }
+
+            if (ext.HomepageUrl is not null && Uri.TryCreate(ext.HomepageUrl, UriKind.Absolute, out var homepageUri))
+            {
+                var isStore = homepageUri.Host.Contains("chromewebstore.google.com");
+                var linkBtn = new HyperlinkButton
+                {
+                    Content = isStore ? R.Get("ExtSettings_StoreLink") : R.Get("ExtSettings_Homepage"),
+                };
+                linkBtn.Click += async (_, _) =>
+                {
+                    if (_parent?.LaunchUriAsync is not null)
+                        await _parent.LaunchUriAsync(homepageUri);
+                    else
+                        await Windows.System.Launcher.LaunchUriAsync(homepageUri);
+                };
+                buttonsPanel.Children.Add(linkBtn);
+            }
+
+            if (buttonsPanel.Children.Count > 0)
+                card.Content = buttonsPanel;
+
+            RootPanel.Children.Add(card);
         }
     }
 }

--- a/Views/SettingsWindow.xaml.cs
+++ b/Views/SettingsWindow.xaml.cs
@@ -1,8 +1,10 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using Windows.Graphics;
 using XTimelineViewer.Models;
 
@@ -25,6 +27,15 @@ namespace XTimelineViewer.Views
         internal event Action? SettingsChanged;
 
         internal void NotifySettingsChanged() => SettingsChanged?.Invoke();
+
+        /// <summary>ロード済み拡張機能の一覧。MainWindow が設定する。</summary>
+        internal List<ExtensionInfo> Extensions { get; set; } = [];
+
+        /// <summary>拡張機能の設定ダイアログを開くコールバック。MainWindow が提供する。</summary>
+        internal Func<ExtensionInfo, Microsoft.UI.Xaml.XamlRoot, Task>? OpenExtensionSettingsAsync { get; set; }
+
+        /// <summary>外部ブラウザー設定に従って URI を開くコールバック。MainWindow が提供する。</summary>
+        internal Func<Uri, Task>? LaunchUriAsync { get; set; }
 
         public SettingsWindow(IntPtr ownerHwnd, AppSettings settings, string settingsFolder)
         {


### PR DESCRIPTION
## Summary
- `ExtensionInfo` レコードを `Models/Models.cs` に追加し、拡張機能のマニフェスト読み取りロジックを `ReadExtensionManifest` として共通化
- `ExtensionsPage` にインストール済み拡張機能を SettingsCard で一覧表示（名前・アイコン・設定ボタン・Chrome Web Store リンク）
- 拡張機能の設定ダイアログ表示ロジックを `ShowExtensionSettingsDialogAsync` に抽出し、ツールバーボタンと設定ページの両方から呼び出し可能に
- `SettingsWindow` に `Extensions`/`OpenExtensionSettingsAsync`/`LaunchUriAsync` プロパティを追加し、MainWindow からコールバック経由で連携

Closes #136

## Test plan
- [x] 拡張機能がインストールされている状態で「拡張機能」ページを開き、SettingsCard が表示されることを確認
- [ ] 拡張機能がない状態で空状態カードが表示されることを確認
- [x] SettingsCard の「設定を開く」ボタンをクリックして設定ダイアログが開くことを確認
- [x] Chrome Web Store リンクが外部ブラウザーで開くことを確認
- [x] ツールバーの拡張機能ボタンが引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)