### PR TITLE
feat: About ダイアログを設定ウィンドウの About ページへ移行 (#138)

### DIFF
--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -175,5 +175,5 @@
   <data name="About_Repository" xml:space="preserve"><value>GitHub Repository</value></data>
   <data name="About_Acknowledgements" xml:space="preserve"><value>Acknowledgements</value></data>
   <data name="About_License" xml:space="preserve"><value>License</value></data>
-  <data name="About_Components" xml:space="preserve"><value>Components</value></data>
+  <data name="About_Components" xml:space="preserve"><value>Components Used</value></data>
 </root>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -175,5 +175,5 @@
   <data name="About_Repository" xml:space="preserve"><value>GitHub リポジトリ</value></data>
   <data name="About_Acknowledgements" xml:space="preserve"><value>謝辞</value></data>
   <data name="About_License" xml:space="preserve"><value>ライセンス</value></data>
-  <data name="About_Components" xml:space="preserve"><value>コンポーネント</value></data>
+  <data name="About_Components" xml:space="preserve"><value>利用しているコンポーネント</value></data>
 </root>

--- a/Views/MainWindow.Settings.cs
+++ b/Views/MainWindow.Settings.cs
@@ -102,6 +102,34 @@ namespace XTimelineViewer.Views
             };
             settingsWin.OnProfileCreated = _ => { SaveProfiles(); RefreshAllProfileBadges(); };
 
+            // About ページ情報とコールバックを設定
+            string edgeVer;
+            try
+            {
+                edgeVer = CoreWebView2Environment.GetAvailableBrowserVersionString();
+            }
+            catch
+            {
+                edgeVer = _profileEnvs.Values.FirstOrDefault()?.BrowserVersionString
+                          ?? R.Get("Version_Unknown");
+            }
+            settingsWin.EdgeVersion = edgeVer;
+            settingsWin.HasWinget = !PackageContext.IsPackaged && FindWinget() is not null;
+            settingsWin.FetchLatestReleaseAsync = FetchLatestReleaseAsync;
+            settingsWin.CheckIsUpdateAvailable = IsUpdateAvailable;
+            settingsWin.SaveSettingsOnly = SaveSettings;
+            settingsWin.UpdateMenuBadge = UpdateMenuUpdateBadge;
+            settingsWin.ExitAndRunWingetUpdate = () =>
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName        = "cmd.exe",
+                    Arguments       = "/c timeout /t 2 /nobreak > nul && winget upgrade daruyanagi.XTimelineViewer",
+                    UseShellExecute = true,
+                });
+                Application.Current.Exit();
+            };
+
             // 親ウィンドウのテーマを引き継ぐ
             var theme = ((FrameworkElement)Content).RequestedTheme;
             settingsWin.ApplyTheme(theme);
@@ -358,248 +386,7 @@ namespace XTimelineViewer.Views
             }
         }
 
-        private async void AboutMenuItem_Click(object _, RoutedEventArgs __)
-        {
-            var currentVersion = Assembly.GetExecutingAssembly().GetName().Version!;
-            var versionStr     = currentVersion.ToString(3);
-
-            var edgeChannel = R.Get("EdgeChannel_Runtime");
-            string edgeVersion;
-            try
-            {
-                edgeVersion = CoreWebView2Environment.GetAvailableBrowserVersionString();
-            }
-            catch
-            {
-                edgeVersion = _profileEnvs.Values.FirstOrDefault()?.BrowserVersionString
-                              ?? R.Get("Version_Unknown");
-            }
-            var versionInfoText = $"XTimelineViewer v{versionStr}\r\n{edgeChannel} {edgeVersion}";
-
-            var issueBody = Uri.EscapeDataString(
-                $"- {R.Get("IssueLabel_AppVersion")}: v{versionStr}\n" +
-                $"- {R.Get("IssueLabel_EdgeVersion")}: {edgeChannel} {edgeVersion}\n" +
-                $"- {R.Get("IssueLabel_Symptoms")}:\n");
-            var issueUrl    = $"https://github.com/daruyanagi/XTimelineViewer/issues/new?labels=bug&title=&body={issueBody}";
-            var repoUrl     = "https://github.com/daruyanagi/XTimelineViewer";
-            var fallbackUrl = repoUrl + "/releases/latest";
-
-            // ── Header ────────────────────────────────────────────────────────
-            var iconPath = Path.Combine(AppContext.BaseDirectory, "Assets", "StoreLogo.png");
-
-            var textStack = new StackPanel { Spacing = 3, VerticalAlignment = VerticalAlignment.Center };
-            textStack.Children.Add(new TextBlock
-            {
-                Text       = "XTimelineViewer",
-                FontSize   = 20,
-                FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
-            });
-            textStack.Children.Add(new TextBlock { Text = $"v{versionStr}", FontSize = 13, Opacity = 0.7 });
-            textStack.Children.Add(new TextBlock { Text = R.Get("About_Copyright"), FontSize = 12, Opacity = 0.6 });
-
-            var titleRow = new StackPanel
-            {
-                Orientation = Orientation.Horizontal,
-                Spacing     = 12,
-                Margin      = new Thickness(0, 0, 0, 8),
-            };
-            if (File.Exists(iconPath))
-                titleRow.Children.Add(new Microsoft.UI.Xaml.Controls.Image
-                {
-                    Source            = new Microsoft.UI.Xaml.Media.Imaging.BitmapImage(new Uri(iconPath)),
-                    Width             = 48,
-                    Height            = 48,
-                    VerticalAlignment = VerticalAlignment.Top,
-                });
-            titleRow.Children.Add(textStack);
-
-            var copyBtn = new Button
-            {
-                Content = new StackPanel
-                {
-                    Orientation = Orientation.Horizontal,
-                    Spacing     = 6,
-                    Children    =
-                    {
-                        new FontIcon { Glyph = "", FontFamily = new FontFamily("Segoe Fluent Icons"), FontSize = 14 },
-                        new TextBlock { Text = R.Get("Button_Copy") },
-                    }
-                },
-                Margin = new Thickness(0, 4, 8, 0),
-            };
-            copyBtn.Click += (_, _) =>
-            {
-                var dp = new DataPackage();
-                dp.SetText(versionInfoText);
-                Clipboard.SetContent(dp);
-            };
-
-            // ── Update check ─────────────────────────────────────────────────
-            string? latestReleaseUrl = null;
-
-            var statusText = new TextBlock { FontSize = 13, Margin = new Thickness(0, 6, 0, 0), Visibility = Visibility.Collapsed };
-
-            bool hasWinget = !PackageContext.IsPackaged && FindWinget() is not null;
-            var updateBtnLabel = PackageContext.IsPackaged
-                ? R.Get("CheckUpdate_Download_Store")
-                : hasWinget
-                    ? R.Get("CheckUpdate_Download_Winget")
-                    : R.Get("CheckUpdate_Download_GitHub");
-            var updateBtn = new Button { Content = updateBtnLabel, Margin = new Thickness(0, 4, 0, 0), Visibility = Visibility.Collapsed };
-
-            // キャッシュがあれば初期表示
-            if (_appSettings.CachedLatestVersion is { } cached
-                && Version.TryParse(cached.TrimStart('v'), out var cachedVersion)
-                && IsUpdateAvailable(currentVersion, cachedVersion))
-            {
-                latestReleaseUrl = $"{repoUrl}/releases/tag/{cached}";
-                statusText.Text       = string.Format(R.Get("CheckUpdate_Available"), cached);
-                statusText.Visibility = Visibility.Visible;
-                updateBtn.Visibility  = Visibility.Visible;
-            }
-
-            var checkBtn = new Button { Content = R.Get("CheckUpdate_Btn"), Margin = new Thickness(0, 4, 0, 0) };
-            checkBtn.Click += async (_, _) =>
-            {
-                checkBtn.IsEnabled    = false;
-                statusText.Text       = R.Get("CheckUpdate_Checking");
-                statusText.Visibility = Visibility.Visible;
-                updateBtn.Visibility  = Visibility.Collapsed;
-                try
-                {
-                    var (latest, tag, freshUrl) = await FetchLatestReleaseAsync();
-                    latestReleaseUrl = freshUrl;
-                    _appSettings.LastUpdateCheck = DateTime.UtcNow.ToString("O");
-                    if (IsUpdateAvailable(currentVersion, latest))
-                    {
-                        _appSettings.CachedLatestVersion = tag;
-                        statusText.Text      = string.Format(R.Get("CheckUpdate_Available"), tag);
-                        updateBtn.Visibility = Visibility.Visible;
-                    }
-                    else
-                    {
-                        _appSettings.CachedLatestVersion = null;
-                        statusText.Text = R.Get("CheckUpdate_Latest");
-                    }
-                    SaveSettings();
-                    UpdateMenuUpdateBadge();
-                }
-                catch
-                {
-                    statusText.Text = R.Get("CheckUpdate_Error");
-                }
-                finally
-                {
-                    checkBtn.IsEnabled = true;
-                }
-            };
-
-            ContentDialog dlg = null!;
-
-            updateBtn.Click += async (_, _) =>
-            {
-                var url = latestReleaseUrl ?? fallbackUrl;
-                if (PackageContext.IsPackaged)
-                {
-                    // ms-windows-store:// は LaunchUriByEdgeProfileAsync 内でシステム既定にフォールバックする
-                    await LaunchUriByEdgeProfileAsync(new Uri("ms-windows-store://pdp/?ProductId=9P308HB5BLJ1"));
-                }
-                else if (FindWinget() is not null)
-                {
-                    dlg.Hide();
-                    await SelfUpdateViaWingetAsync(url);
-                }
-                else
-                {
-                    await LaunchUriByEdgeProfileAsync(new Uri(url));
-                }
-            };
-
-            var updateRow = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
-            updateRow.Children.Add(copyBtn);
-            updateRow.Children.Add(checkBtn);
-
-            var header = new StackPanel { Spacing = 0, Margin = new Thickness(0, 0, 0, 4) };
-            header.Children.Add(titleRow);
-            header.Children.Add(updateRow);
-            header.Children.Add(statusText);
-            header.Children.Add(updateBtn);
-
-            // ── Section helper ────────────────────────────────────────────────
-            static StackPanel MakeSection(string title)
-            {
-                var s = new StackPanel { Spacing = 4, Margin = new Thickness(0, 12, 0, 0) };
-                s.Children.Add(new NavigationViewItemSeparator { Margin = new Thickness(0, 0, 0, 8) });
-                s.Children.Add(new TextBlock
-                {
-                    Text       = title,
-                    FontSize   = 12,
-                    FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
-                    Opacity    = 0.8,
-                    Margin     = new Thickness(0, 0, 0, 4),
-                });
-                return s;
-            }
-
-            HyperlinkButton MakeLink(string text, string url) => new HyperlinkButton
-            {
-                NavigateUri = new Uri(url),
-                Padding     = new Thickness(0),
-                Content     = new StackPanel
-                {
-                    Orientation       = Orientation.Horizontal,
-                    Spacing           = 4,
-                    VerticalAlignment = VerticalAlignment.Center,
-                    Children          =
-                    {
-                        new TextBlock { Text = text, VerticalAlignment = VerticalAlignment.Center },
-                        new FontIcon
-                        {
-                            Glyph             = "",
-                            FontFamily        = new FontFamily("Segoe Fluent Icons"),
-                            FontSize          = 10,
-                            Opacity           = 0.6,
-                            VerticalAlignment = VerticalAlignment.Center,
-                        },
-                    }
-                },
-            };
-
-            var linksSection = MakeSection(R.Get("About_Links"));
-            linksSection.Children.Add(MakeLink(R.Get("About_Repository"), repoUrl));
-            linksSection.Children.Add(MakeLink(R.Get("Button_ReportIssue"), issueUrl));
-
-            var acksSection = MakeSection(R.Get("About_Acknowledgements"));
-            acksSection.Children.Add(MakeLink("TwitterTimelineLoader",
-                "https://chromewebstore.google.com/detail/twittertimelineloader/ipmgjpmedafkmmadinmeoannpofakpbh"));
-
-            var licenseSection = MakeSection(R.Get("About_License"));
-            licenseSection.Children.Add(new TextBlock { Text = "MIT License", IsTextSelectionEnabled = true, FontSize = 13 });
-
-            var componentsSection = MakeSection(R.Get("About_Components"));
-            componentsSection.Children.Add(new TextBlock
-            {
-                Text                   = $"{edgeChannel}  {edgeVersion}",
-                IsTextSelectionEnabled = true,
-                FontSize               = 13,
-                Opacity                = 0.8,
-            });
-
-            var panel = new StackPanel { MinWidth = 320 };
-            panel.Children.Add(header);
-            panel.Children.Add(linksSection);
-            panel.Children.Add(acksSection);
-            panel.Children.Add(licenseSection);
-            panel.Children.Add(componentsSection);
-
-            dlg = new ContentDialog
-            {
-                Title           = R.Get("About_Title"),
-                Content         = panel,
-                CloseButtonText = R.Get("Button_Close"),
-                XamlRoot        = Content.XamlRoot,
-            };
-            await ShowDialogAsync(dlg);
-        }
+        private void AboutMenuItem_Click(object _, RoutedEventArgs __)
+            => OpenSettingsWindow("About");
     }
 }

--- a/Views/MainWindow.Updates.cs
+++ b/Views/MainWindow.Updates.cs
@@ -1,26 +1,13 @@
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Automation;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Media;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Net.NetworkInformation;
 using System.Reflection;
 using System.Text.Json;
 using System.Threading.Tasks;
-using System.IO;
-using System.Runtime.InteropServices;
-using Microsoft.Web.WebView2.Core;
-using Windows.ApplicationModel.DataTransfer;
-using Windows.Graphics;
-using Windows.Storage;
-using Windows.UI;
-
-using XTimelineViewer.Models;
 
 namespace XTimelineViewer.Views
 {
@@ -88,39 +75,6 @@ namespace XTimelineViewer.Views
                 ?.Split(';', StringSplitOptions.RemoveEmptyEntries)
                 .Select(d => Path.Combine(d, "winget.exe"))
                 .FirstOrDefault(File.Exists);
-        }
-
-        private async Task SelfUpdateViaWingetAsync(string releaseUrl)
-        {
-            var confirmDlg = new ContentDialog
-            {
-                Title             = R.Get("CheckUpdate_WingetTitle"),
-                Content           = new TextBlock
-                {
-                    Text         = R.Get("CheckUpdate_WingetBody"),
-                    TextWrapping = TextWrapping.Wrap,
-                },
-                PrimaryButtonText = R.Get("CheckUpdate_WingetConfirm"),
-                CloseButtonText   = R.Get("Button_Cancel"),
-                XamlRoot          = Content.XamlRoot,
-            };
-
-            if (await ShowDialogAsync(confirmDlg) != ContentDialogResult.Primary) return;
-
-            var winget = FindWinget();
-            if (winget is null)
-            {
-                await LaunchUriByEdgeProfileAsync(new Uri(releaseUrl));
-                return;
-            }
-
-            Process.Start(new ProcessStartInfo
-            {
-                FileName        = "cmd.exe",
-                Arguments       = "/c timeout /t 2 /nobreak > nul && winget upgrade daruyanagi.XTimelineViewer",
-                UseShellExecute = true,
-            });
-            Application.Current.Exit();
         }
     }
 }

--- a/Views/Settings/AboutPage.xaml
+++ b/Views/Settings/AboutPage.xaml
@@ -5,14 +5,12 @@
     xmlns:controls="using:CommunityToolkit.WinUI.Controls">
 
     <ScrollViewer Padding="24,16">
-        <StackPanel Spacing="4">
+        <StackPanel x:Name="RootPanel" Spacing="4">
             <TextBlock x:Name="PageTitle"
                        Style="{StaticResource TitleTextBlockStyle}"
                        Margin="0,0,0,16"/>
 
-            <TextBlock x:Name="PlaceholderText"
-                       Opacity="0.6"
-                       FontSize="13"/>
+            <!-- アプリ情報・更新・リンク等はコードビハインドで動的に追加 -->
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/Views/Settings/AboutPage.xaml.cs
+++ b/Views/Settings/AboutPage.xaml.cs
@@ -1,14 +1,332 @@
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Media.Imaging;
+using Microsoft.UI.Xaml.Navigation;
+using System;
+using System.IO;
+using System.Reflection;
+using Windows.ApplicationModel.DataTransfer;
 
 namespace XTimelineViewer.Views.Settings
 {
     public sealed partial class AboutPage : Page
     {
+        private SettingsWindow? _parent;
+
         public AboutPage()
         {
             this.InitializeComponent();
+        }
+
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            base.OnNavigatedTo(e);
+            _parent = e.Parameter as SettingsWindow;
+            PopulateUI();
+        }
+
+        private void PopulateUI()
+        {
             PageTitle.Text = R.Get("Nav_About");
-            PlaceholderText.Text = R.Get("Settings_Placeholder");
+
+            var currentVersion = Assembly.GetExecutingAssembly().GetName().Version!;
+            var versionStr = currentVersion.ToString(3);
+            var edgeChannel = R.Get("EdgeChannel_Runtime");
+            var edgeVersion = _parent?.EdgeVersion ?? R.Get("Version_Unknown");
+            var versionInfoText = $"XTimelineViewer v{versionStr}\r\n{edgeChannel} {edgeVersion}";
+
+            var repoUrl = "https://github.com/daruyanagi/XTimelineViewer";
+            var fallbackUrl = repoUrl + "/releases/latest";
+
+            // ── 1. アプリ情報ヘッダー ────────────────────────────────────────
+            BuildHeaderCard(versionStr, versionInfoText);
+
+            // ── 2. 更新を確認 ────────────────────────────────────────────────
+            BuildUpdateSection(currentVersion, repoUrl, fallbackUrl);
+
+            // ── 3. ライセンス ────────────────────────────────────────────────
+            var licenseCard = new CommunityToolkit.WinUI.Controls.SettingsCard
+            {
+                Header     = R.Get("About_License"),
+                HeaderIcon = new FontIcon
+                {
+                    Glyph      = "",
+                    FontFamily = new FontFamily("Segoe Fluent Icons"),
+                },
+                Content = new TextBlock
+                {
+                    Text     = "MIT License",
+                    FontSize = 13,
+                    Opacity  = 0.8,
+                    IsTextSelectionEnabled = true,
+                },
+            };
+            RootPanel.Children.Add(licenseCard);
+
+            // ── 4. 利用しているコンポーネント ────────────────────────────────
+            BuildComponentsExpander(edgeChannel, edgeVersion);
+        }
+
+        private void BuildHeaderCard(string versionStr, string versionInfoText)
+        {
+            var iconPath = Path.Combine(AppContext.BaseDirectory, "Assets", "StoreLogo.png");
+
+            var textStack = new StackPanel { Spacing = 3, VerticalAlignment = VerticalAlignment.Center };
+            textStack.Children.Add(new TextBlock
+            {
+                Text       = "XTimelineViewer",
+                FontSize   = 20,
+                FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+            });
+            textStack.Children.Add(new TextBlock { Text = $"v{versionStr}", FontSize = 13, Opacity = 0.7 });
+            textStack.Children.Add(new TextBlock { Text = R.Get("About_Copyright"), FontSize = 12, Opacity = 0.6 });
+
+            var titleRow = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Spacing     = 12,
+            };
+            if (File.Exists(iconPath))
+                titleRow.Children.Add(new Image
+                {
+                    Source            = new BitmapImage(new Uri(iconPath)),
+                    Width             = 48,
+                    Height            = 48,
+                    VerticalAlignment = VerticalAlignment.Top,
+                });
+            titleRow.Children.Add(textStack);
+
+            var copyBtn = new Button
+            {
+                Content = new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    Spacing     = 6,
+                    Children    =
+                    {
+                        new FontIcon
+                        {
+                            Glyph      = "",
+                            FontFamily = new FontFamily("Segoe Fluent Icons"),
+                            FontSize   = 14,
+                        },
+                        new TextBlock { Text = R.Get("Button_Copy") },
+                    }
+                },
+            };
+            copyBtn.Click += (_, _) =>
+            {
+                var dp = new DataPackage();
+                dp.SetText(versionInfoText);
+                Clipboard.SetContent(dp);
+            };
+
+            var headerCard = new CommunityToolkit.WinUI.Controls.SettingsCard
+            {
+                Header  = titleRow,
+                Content = copyBtn,
+            };
+            RootPanel.Children.Add(headerCard);
+        }
+
+        private void BuildUpdateSection(Version currentVersion, string repoUrl, string fallbackUrl)
+        {
+            if (_parent is null) return;
+
+            string? latestReleaseUrl = null;
+            var settings = _parent.Settings;
+
+            var statusText = new TextBlock
+            {
+                FontSize   = 13,
+                Margin     = new Thickness(0, 4, 0, 0),
+                Visibility = Visibility.Collapsed,
+            };
+
+            bool hasWinget = _parent.HasWinget;
+            var updateBtnLabel = PackageContext.IsPackaged
+                ? R.Get("CheckUpdate_Download_Store")
+                : hasWinget
+                    ? R.Get("CheckUpdate_Download_Winget")
+                    : R.Get("CheckUpdate_Download_GitHub");
+            var updateBtn = new Button
+            {
+                Content    = updateBtnLabel,
+                Margin     = new Thickness(0, 4, 0, 0),
+                Visibility = Visibility.Collapsed,
+            };
+
+            // キャッシュがあれば初期表示
+            if (settings.CachedLatestVersion is { } cached
+                && Version.TryParse(cached.TrimStart('v'), out var cachedVersion)
+                && (_parent.CheckIsUpdateAvailable?.Invoke(currentVersion, cachedVersion) ?? false))
+            {
+                latestReleaseUrl      = $"{repoUrl}/releases/tag/{cached}";
+                statusText.Text       = string.Format(R.Get("CheckUpdate_Available"), cached);
+                statusText.Visibility = Visibility.Visible;
+                updateBtn.Visibility  = Visibility.Visible;
+            }
+
+            var checkBtn = new Button { Content = R.Get("CheckUpdate_Btn") };
+            checkBtn.Click += async (_, _) =>
+            {
+                checkBtn.IsEnabled    = false;
+                statusText.Text       = R.Get("CheckUpdate_Checking");
+                statusText.Visibility = Visibility.Visible;
+                updateBtn.Visibility  = Visibility.Collapsed;
+                try
+                {
+                    if (_parent.FetchLatestReleaseAsync is null) return;
+                    var (latest, tag, freshUrl) = await _parent.FetchLatestReleaseAsync();
+                    latestReleaseUrl = freshUrl;
+                    settings.LastUpdateCheck = DateTime.UtcNow.ToString("O");
+                    if (_parent.CheckIsUpdateAvailable?.Invoke(currentVersion, latest) ?? false)
+                    {
+                        settings.CachedLatestVersion = tag;
+                        statusText.Text      = string.Format(R.Get("CheckUpdate_Available"), tag);
+                        updateBtn.Visibility = Visibility.Visible;
+                    }
+                    else
+                    {
+                        settings.CachedLatestVersion = null;
+                        statusText.Text = R.Get("CheckUpdate_Latest");
+                    }
+                    _parent.SaveSettingsOnly?.Invoke();
+                    _parent.UpdateMenuBadge?.Invoke();
+                }
+                catch
+                {
+                    statusText.Text = R.Get("CheckUpdate_Error");
+                }
+                finally
+                {
+                    checkBtn.IsEnabled = true;
+                }
+            };
+
+            updateBtn.Click += async (_, _) =>
+            {
+                var url = latestReleaseUrl ?? fallbackUrl;
+                if (PackageContext.IsPackaged)
+                {
+                    if (_parent.LaunchUriAsync is not null)
+                        await _parent.LaunchUriAsync(new Uri("ms-windows-store://pdp/?ProductId=9P308HB5BLJ1"));
+                }
+                else if (hasWinget)
+                {
+                    var confirmDlg = new ContentDialog
+                    {
+                        Title             = R.Get("CheckUpdate_WingetTitle"),
+                        Content           = new TextBlock
+                        {
+                            Text         = R.Get("CheckUpdate_WingetBody"),
+                            TextWrapping = TextWrapping.Wrap,
+                        },
+                        PrimaryButtonText = R.Get("CheckUpdate_WingetConfirm"),
+                        CloseButtonText   = R.Get("Button_Cancel"),
+                        XamlRoot          = XamlRoot,
+                        RequestedTheme    = ((FrameworkElement)_parent.Content).ActualTheme,
+                    };
+                    if (await confirmDlg.ShowAsync() != ContentDialogResult.Primary) return;
+                    _parent.ExitAndRunWingetUpdate?.Invoke();
+                }
+                else
+                {
+                    if (_parent.LaunchUriAsync is not null)
+                        await _parent.LaunchUriAsync(new Uri(url));
+                }
+            };
+
+            var updateCard = new CommunityToolkit.WinUI.Controls.SettingsCard
+            {
+                Header     = R.Get("CheckUpdate_Btn"),
+                HeaderIcon = new FontIcon
+                {
+                    Glyph      = "",
+                    FontFamily = new FontFamily("Segoe Fluent Icons"),
+                },
+            };
+
+            var updateContent = new StackPanel { Spacing = 4 };
+            updateContent.Children.Add(checkBtn);
+            updateContent.Children.Add(statusText);
+            updateContent.Children.Add(updateBtn);
+            updateCard.Content = updateContent;
+
+            RootPanel.Children.Add(updateCard);
+        }
+
+        private void BuildComponentsExpander(string edgeChannel, string edgeVersion)
+        {
+            var expander = new CommunityToolkit.WinUI.Controls.SettingsExpander
+            {
+                Header     = R.Get("About_Components"),
+                HeaderIcon = new FontIcon
+                {
+                    Glyph      = "",
+                    FontFamily = new FontFamily("Segoe Fluent Icons"),
+                },
+            };
+
+            // WebView2
+            var webView2Card = new CommunityToolkit.WinUI.Controls.SettingsCard
+            {
+                Header = edgeChannel,
+                Content = new TextBlock
+                {
+                    Text     = edgeVersion,
+                    FontSize = 13,
+                    Opacity  = 0.8,
+                    IsTextSelectionEnabled = true,
+                },
+            };
+            expander.Items.Add(webView2Card);
+
+            // TwitterTimelineLoader
+            var ttlLinkBtn = new HyperlinkButton
+            {
+                Padding = new Thickness(0),
+                Content = new StackPanel
+                {
+                    Orientation       = Orientation.Horizontal,
+                    Spacing           = 4,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Children          =
+                    {
+                        new TextBlock
+                        {
+                            Text              = "Chrome Web Store",
+                            VerticalAlignment = VerticalAlignment.Center,
+                        },
+                        new FontIcon
+                        {
+                            Glyph             = "",
+                            FontFamily        = new FontFamily("Segoe Fluent Icons"),
+                            FontSize          = 10,
+                            Opacity           = 0.6,
+                            VerticalAlignment = VerticalAlignment.Center,
+                        },
+                    }
+                },
+            };
+            ttlLinkBtn.Click += async (_, _) =>
+            {
+                var uri = new Uri("https://chromewebstore.google.com/detail/twittertimelineloader/ipmgjpmedafkmmadinmeoannpofakpbh");
+                if (_parent?.LaunchUriAsync is not null)
+                    await _parent.LaunchUriAsync(uri);
+                else
+                    await Windows.System.Launcher.LaunchUriAsync(uri);
+            };
+
+            var ttlCard = new CommunityToolkit.WinUI.Controls.SettingsCard
+            {
+                Header  = "TwitterTimelineLoader",
+                Content = ttlLinkBtn,
+            };
+            expander.Items.Add(ttlCard);
+
+            RootPanel.Children.Add(expander);
         }
     }
 }

--- a/Views/SettingsWindow.xaml.cs
+++ b/Views/SettingsWindow.xaml.cs
@@ -57,6 +57,27 @@ namespace XTimelineViewer.Views
         /// <summary>指定プロファイルが使用しているタイムライン数を返す。</summary>
         internal Func<string, int>? GetTimelineCount { get; set; }
 
+        /// <summary>WebView2 ランタイムバージョン文字列。MainWindow が設定する。</summary>
+        internal string EdgeVersion { get; set; } = "";
+
+        /// <summary>winget が利用可能かどうか（unpackaged のみ意味がある）。</summary>
+        internal bool HasWinget { get; set; }
+
+        /// <summary>最新リリース情報を取得するコールバック。</summary>
+        internal Func<Task<(Version version, string tag, string releaseUrl)>>? FetchLatestReleaseAsync { get; set; }
+
+        /// <summary>バージョン比較で更新が利用可能かを判定するコールバック。</summary>
+        internal Func<Version, Version, bool>? CheckIsUpdateAvailable { get; set; }
+
+        /// <summary>設定のみ保存する（テーマ適用等はしない）コールバック。</summary>
+        internal Action? SaveSettingsOnly { get; set; }
+
+        /// <summary>メニューの更新バッジを更新するコールバック。</summary>
+        internal Action? UpdateMenuBadge { get; set; }
+
+        /// <summary>アプリを終了して winget でアップデートを開始するコールバック。</summary>
+        internal Action? ExitAndRunWingetUpdate { get; set; }
+
         public SettingsWindow(IntPtr ownerHwnd, AppSettings settings, string settingsFolder)
         {
             _ownerHwnd = ownerHwnd;


### PR DESCRIPTION
## Summary
- `AboutMenuItem_Click` の ContentDialog (~240行) を `Settings/AboutPage` に移行し、SettingsCard/SettingsExpander ベースの UI に再構築
- `AboutMenuItem_Click` → `OpenSettingsWindow("About")` へリダイレクト化
- `SelfUpdateViaWingetAsync` を削除し、About ページ内で winget 更新確認ダイアログを処理
- `SettingsWindow` に更新関連コールバック群（`FetchLatestReleaseAsync`, `CheckIsUpdateAvailable`, `SaveSettingsOnly`, `UpdateMenuBadge`, `ExitAndRunWingetUpdate`, `EdgeVersion`, `HasWinget`）を追加

### About ページ構成
1. **アプリ情報ヘッダー** — アイコン・名前・バージョン・コピーライト・コピーボタン
2. **更新を確認** — チェックボタン、ステータス表示、更新ボタン（Store/winget/GitHub 自動判定）
3. **ライセンス** — MIT License
4. **利用しているコンポーネント** — SettingsExpander で開閉
   - WebView2 ランタイム（バージョン表示）
   - TwitterTimelineLoader（Chrome Web Store リンク）

Closes #138

## Test plan
- [x] メニュー → About で設定ウィンドウが「About」ページ選択状態で開く
- [x] アプリアイコン・名前・バージョン・コピーライトが正しく表示される
- [x] コピーボタンでバージョン情報がクリップボードにコピーされる
- [x] 「更新を確認」ボタンで GitHub API からバージョンチェックが動作する
- [x] キャッシュ済みの更新がある場合、初期表示で更新ボタンが表示される
- [x] ライセンスカードに「MIT License」が表示される
- [x] 「利用しているコンポーネント」が SettingsExpander で開閉できる
- [x] WebView2 ランタイムのバージョンが表示される
- [x] TwitterTimelineLoader の Chrome Web Store リンクが動作する
- [x] 日本語/英語の切り替えで About ページのテキストが正しく反映される

🤖 Generated with [Claude Code](https://claude.com/claude-code)