### PR TITLE
fix: タイムライン設定ダイアログに ScrollViewer を追加 (#147)

### DIFF
--- a/Views/MainWindow.Timeline.cs
+++ b/Views/MainWindow.Timeline.cs
@@ -438,7 +438,11 @@ namespace XTimelineViewer.Views
                 var dlg = new ContentDialog
                 {
                     Title             = R.Get("Timeline_Settings_Title"),
-                    Content           = panel,
+                    Content           = new ScrollViewer
+                    {
+                        Content = panel,
+                        VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                    },
                     PrimaryButtonText = R.Get("Button_Apply"),
                     CloseButtonText   = R.Get("Button_Cancel"),
                     DefaultButton     = ContentDialogButton.Primary,


### PR DESCRIPTION
## Summary
- タイムライン設定 ContentDialog の `Content` を `ScrollViewer` でラップ
- ウィンドウ縮小時に下部の設定項目（定期リロード、削除ボタン等）にアクセスできない問題を修正

Closes #147

## Test plan
- [x] ウィンドウを小さくした状態でタイムライン設定ダイアログを開き、全項目にスクロールでアクセスできる
- [x] 通常サイズではスクロールバーが表示されない（`Auto`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)