### PR TITLE
fix: 起動時の堅牢性を改善 (winget バリデーション対策)

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -21,8 +21,40 @@ namespace XTimelineViewer
 
         public App()
         {
-            SetProcessDpiAwarenessContext(-4);
+            try
+            {
+                SetProcessDpiAwarenessContext(-4);
+            }
+            catch (Exception ex)
+            {
+                // ヘッドレス VM など DPI API が利用できない環境でもクラッシュしない
+                Debug.WriteLine($"[App] SetProcessDpiAwarenessContext failed: {ex.Message}");
+            }
             this.InitializeComponent();
+
+            // UI スレッドの未処理例外でプロセスが即死するのを防ぐ。
+            // winget バリデーション VM など特殊環境でのサイレントクラッシュを診断しやすくする。
+            this.UnhandledException += (sender, e) =>
+            {
+                Debug.WriteLine($"[App] UnhandledException: {e.Exception}");
+                LogUnhandledException(e.Exception);
+                e.Handled = true;
+            };
+        }
+
+        private static void LogUnhandledException(Exception ex)
+        {
+            try
+            {
+                var dir = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                    "XTimelineViewer");
+                Directory.CreateDirectory(dir);
+                File.AppendAllText(
+                    Path.Combine(dir, "error.log"),
+                    $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] UnhandledException\n{ex}\n\n");
+            }
+            catch { /* ログ書き込み失敗は無視 */ }
         }
 
         protected override void OnLaunched(LaunchActivatedEventArgs args)

--- a/XTimelineViewer.csproj
+++ b/XTimelineViewer.csproj
@@ -7,7 +7,7 @@
     <Platforms>x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
     <PlatformTarget>x64</PlatformTarget>
-    <Version>1.4.2</Version>
+    <Version>1.4.3</Version>
     <ApplicationIcon>Assets\AppIcon.ico</ApplicationIcon>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
## Summary
- `SetProcessDpiAwarenessContext(-4)` を try/catch で保護し、ヘッドレス VM でも安全に起動
- `App.UnhandledException` ハンドラを追加し、UI スレッドの未処理例外によるサイレントクラッシュを防止・ログ記録
- バージョンを 1.4.3 にバンプ（winget-pkgs への再申請用）

## Background
winget-pkgs の PR で `Validation-Installation-Error` が頻発していた (#131)。マニフェスト構成は正しく（ZIP portable として v1.2.5〜v1.4.0 はマージ済み）、バリデーション VM 上での起動時クラッシュが原因と推定。ZIP ポータブル配布を維持する方針のため、アプリ側の起動堅牢性を改善する。

## Test plan
- [ ] デバッグ実行で正常に起動・終了することを確認
- [ ] リリースタグ作成後、winget-releaser が生成する PR のバリデーション結果を確認

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)