### PR TITLE
fix: msstore publish の -i にディレクトリを渡すよう修正 (#150)

### DIFF
--- a/.github/workflows/store.yml
+++ b/.github/workflows/store.yml
@@ -131,9 +131,14 @@ jobs:
           if ($LASTEXITCODE -ne 0) { Write-Error "makeappx bundle failed"; exit 1 }
 
           # .msixupload は正規バンドルを内包した zip。Store はこの形式を期待する。
-          $uploadPath = "$PWD\XTimelineViewer_$env:MSIX_VERSION.msixupload"
+          # msstore-cli の -i/--inputDirectory はディレクトリを取るため、
+          # .msixupload は専用ディレクトリに 1 つだけ置く（CLI が候補を一意に選べるように）。
+          $uploadDir = "$PWD\store_upload"
+          New-Item -ItemType Directory -Force -Path $uploadDir | Out-Null
+          $uploadPath = "$uploadDir\XTimelineViewer_$env:MSIX_VERSION.msixupload"
           Compress-Archive -Path $bundlePath -DestinationPath $uploadPath -Force
           echo "MSIXUPLOAD_PATH=$uploadPath" >> $env:GITHUB_ENV
+          echo "MSIXUPLOAD_DIR=$uploadDir" >> $env:GITHUB_ENV
           Write-Host "Created: $uploadPath"
 
       # バンドル内に期待バージョンが含まれるか検証する。
@@ -170,9 +175,10 @@ jobs:
         run: msstore submission delete "${{ env.STORE_APP_ID }}" --no-confirm
         continue-on-error: true
 
-      # -i にはディレクトリではなく .msixupload ファイルそのものを渡す (#150)。
+      # msstore-cli (apppublisher@v1.1 同梱版) の -i/--inputDirectory は
+      # .msixupload を含むディレクトリを取る。専用ディレクトリには .msixupload が 1 つだけ (#150)。
       - name: Publish to Microsoft Store
-        run: msstore publish . -i "${{ env.MSIXUPLOAD_PATH }}" -id "${{ env.STORE_APP_ID }}"
+        run: msstore publish . -i "${{ env.MSIXUPLOAD_DIR }}" -id "${{ env.STORE_APP_ID }}"
 
       # publish の戻り値が成功でも、Store のサーバー側前処理でパッケージが
       # サイレント破棄されることがある（旧実装の症状）。最終提出に期待バージョンが


### PR DESCRIPTION
## Summary
手動トリガーで実行した初回 run（[27099455891](https://github.com/daruyanagi/XTimelineViewer/actions/runs/27099455891)）で判明した publish ステップの失敗を修正する。

## 原因
`apppublisher@v1.1` 同梱の msstore-cli では `-i` が **`--inputDirectory`（ディレクトリ）** を取る。公式ドキュメント最新版の `--inputFile`（ファイル）と乖離しており、`.msixupload` ファイルを直接渡したため `Input directory does not exist.` で失敗した。

## 変更点
- `.msixupload` を専用ディレクトリ `store_upload\` に 1 つだけ生成（CLI が候補を一意に選べるように）
- `-i` にそのディレクトリを渡す

## 前回 run の到達点（本修正前）
| ステップ | 結果 |
|---|---|
| Build x64 / arm64 MSIX | ✅ |
| Create MSIX bundle (makeappx) | ✅ |
| Verify bundle version | ✅ |
| Configure msstore-cli | ✅ |
| **Publish to Microsoft Store** | ❌ Input directory does not exist |

ビルド〜バンドル〜検証〜認証は成功済み。本 PR で publish 引数のみ修正。

## Test plan
- [ ] マージ後 `gh workflow run store.yml -f tag=v1.4.3` で publish と提出後検証まで通ることを確認

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)