### PR TITLE
feat: default プロファイルの初期化機能を実装 (#86)

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -4,6 +4,8 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text.Json;
+using XTimelineViewer.Models;
+using XTimelineViewer.Services;
 using XTimelineViewer.Views;
 
 namespace XTimelineViewer
@@ -59,6 +61,10 @@ namespace XTimelineViewer
 
         protected override void OnLaunched(LaunchActivatedEventArgs args)
         {
+            // WebView2 が未初期化のうちに default プロファイルの初期化保留を処理する (#86)。
+            // 実行中はブラウザプロセスがフォルダをロックするため、起動直後のここで削除する。
+            ResetDefaultProfileIfPending();
+
             var lang = ReadLanguageSetting();
 
             if (lang != null && PackageContext.IsPackaged)
@@ -69,16 +75,45 @@ namespace XTimelineViewer
             _window.Activate();
         }
 
+        private static string GetSettingsFilePath() =>
+            PackageContext.IsPackaged
+                ? Path.Combine(Windows.Storage.ApplicationData.Current.LocalFolder.Path, "settings.json")
+                : Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                    "XTimelineViewer", "settings.json");
+
+        // 初期化保留フラグが立っていれば、default の WebView2 データフォルダを削除する (#86)。
+        private static void ResetDefaultProfileIfPending()
+        {
+            try
+            {
+                var settingsPath = GetSettingsFilePath();
+                if (!File.Exists(settingsPath)) return;
+
+                var settings = SettingsService.LoadSettings(settingsPath);
+                if (!settings.ResetDefaultProfilePending) return;
+
+                var dataPath = settings.DefaultProfileDataPath;
+                if (!string.IsNullOrEmpty(dataPath) && Directory.Exists(dataPath))
+                {
+                    Directory.Delete(dataPath, recursive: true);
+                    Debug.WriteLine($"[App] Default profile data deleted: {dataPath}");
+                }
+
+                settings.ResetDefaultProfilePending = false;
+                SettingsService.SaveSettings(settingsPath, settings);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[App] ResetDefaultProfileIfPending FAILED: {ex.Message}");
+            }
+        }
+
         private static string? ReadLanguageSetting()
         {
             try
             {
-                var settingsPath = PackageContext.IsPackaged
-                    ? Path.Combine(Windows.Storage.ApplicationData.Current.LocalFolder.Path, "settings.json")
-                    : Path.Combine(
-                        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                        "XTimelineViewer", "settings.json");
-
+                var settingsPath = GetSettingsFilePath();
                 if (!File.Exists(settingsPath)) return null;
 
                 using var doc = JsonDocument.Parse(File.ReadAllText(settingsPath));

--- a/Models/Models.cs
+++ b/Models/Models.cs
@@ -44,5 +44,7 @@ namespace XTimelineViewer.Models
         public bool    ShowAutoActivateLabel { get; set; } = false;
         public string  ExternalBrowser       { get; set; } = "system";  // "system" | "edge"
         public string  EdgeProfileDirectory  { get; set; } = "";        // "Default" | "Profile 1" など
+        public bool    ResetDefaultProfilePending { get; set; } = false; // 次回起動時に default を初期化 (#86)
+        public string? DefaultProfileDataPath     { get; set; } = null;  // default の実 WebView2 データパス (#86)
     }
 }

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -125,6 +125,8 @@
   <data name="Profile_ResetConfirmTitle" xml:space="preserve"><value>Reset Profile</value></data>
   <data name="Profile_ResetConfirmBody" xml:space="preserve"><value>All cookies and login data will be deleted. Timelines using this profile will be removed, and data will be cleared on next launch.</value></data>
   <data name="Profile_ResetConfirm" xml:space="preserve"><value>Reset</value></data>
+  <data name="Profile_ResetCancel" xml:space="preserve"><value>Cancel reset</value></data>
+  <data name="Profile_ResetPendingInfo" xml:space="preserve"><value>Will be reset on next launch. Please restart the app.</value></data>
   <data name="Profile_DeleteConfirmTitle" xml:space="preserve"><value>Delete Profile</value></data>
   <data name="Profile_DeleteConfirmBody" xml:space="preserve"><value>{0} timeline(s) using this profile will also be removed.</value></data>
   <data name="Profile_DeleteConfirm" xml:space="preserve"><value>Delete</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -125,6 +125,8 @@
   <data name="Profile_ResetConfirmTitle" xml:space="preserve"><value>プロファイルの初期化</value></data>
   <data name="Profile_ResetConfirmBody" xml:space="preserve"><value>Cookie やログイン情報がすべて削除されます。このプロファイルを使用しているタイムラインは削除され、次回起動時にデータが消去されます。</value></data>
   <data name="Profile_ResetConfirm" xml:space="preserve"><value>初期化する</value></data>
+  <data name="Profile_ResetCancel" xml:space="preserve"><value>初期化を取り消す</value></data>
+  <data name="Profile_ResetPendingInfo" xml:space="preserve"><value>次回起動時に初期化されます。アプリを再起動してください。</value></data>
   <data name="Profile_DeleteConfirmTitle" xml:space="preserve"><value>プロファイルの削除</value></data>
   <data name="Profile_DeleteConfirmBody" xml:space="preserve"><value>このプロファイルを使用している {0} 個のタイムラインも削除されます。</value></data>
   <data name="Profile_DeleteConfirm" xml:space="preserve"><value>削除する</value></data>

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -217,6 +217,16 @@ namespace XTimelineViewer.Views
                 "", userDataFolder, options);
             _profileEnvs[profileId] = env;
             Debug.WriteLine($"[Profile] Env created: profileId={profileId}, UserDataFolder={env.UserDataFolder}");
+
+            // default の実データフォルダパスを記録しておく。
+            // userDataFolder="" のときランタイムが決めた exe 相対パスになるため、
+            // 初期化（#86）時に正確な削除対象を知るために保存する。
+            if (profileId == "default" &&
+                _appSettings.DefaultProfileDataPath != env.UserDataFolder)
+            {
+                _appSettings.DefaultProfileDataPath = env.UserDataFolder;
+                SaveSettings();
+            }
             return env;
         }
 

--- a/Views/Settings/ProfilesPage.xaml.cs
+++ b/Views/Settings/ProfilesPage.xaml.cs
@@ -149,12 +149,47 @@ namespace XTimelineViewer.Views.Settings
             // ── アクションボタン（初期化/削除）──
             if (profile.Id == "default")
             {
-                var resetBtn = new Button
+                // 初期化は重大な処理のため、フラグ方式で再起動まで実削除を遅延させ、
+                // それまで取り消せるようにする (#86)。
+                bool pending = _parent?.Settings.ResetDefaultProfilePending ?? false;
+                if (pending)
                 {
-                    Content   = R.Get("Profile_Reset"),
-                    IsEnabled = false,
-                };
-                expander.Content = resetBtn;
+                    expander.Description = R.Get("Profile_ResetPendingInfo");
+                    var cancelBtn = new Button { Content = R.Get("Profile_ResetCancel") };
+                    cancelBtn.Click += (_, _) =>
+                    {
+                        if (_parent is null) return;
+                        _parent.Settings.ResetDefaultProfilePending = false;
+                        _parent.SaveSettingsOnly?.Invoke();
+                        PopulateUI();
+                    };
+                    expander.Content = cancelBtn;
+                }
+                else
+                {
+                    var resetBtn = new Button { Content = R.Get("Profile_Reset") };
+                    resetBtn.Click += async (_, _) =>
+                    {
+                        var dlg = new ContentDialog
+                        {
+                            Title             = R.Get("Profile_ResetConfirmTitle"),
+                            Content           = R.Get("Profile_ResetConfirmBody"),
+                            PrimaryButtonText = R.Get("Profile_ResetConfirm"),
+                            CloseButtonText   = R.Get("Button_Cancel"),
+                            DefaultButton     = ContentDialogButton.Close,
+                            XamlRoot          = XamlRoot,
+                            RequestedTheme    = ((FrameworkElement)_parent!.Content).ActualTheme,
+                        };
+                        if (await dlg.ShowAsync() == ContentDialogResult.Primary)
+                        {
+                            if (_parent is null) return;
+                            _parent.Settings.ResetDefaultProfilePending = true;
+                            _parent.SaveSettingsOnly?.Invoke();
+                            PopulateUI();
+                        }
+                    };
+                    expander.Content = resetBtn;
+                }
             }
             else
             {


### PR DESCRIPTION
## Summary
default プロファイルの「初期化」ボタン（グレーアウト中だった）を有効化する。WebView2 が実行中にデータフォルダをロックする問題を**フラグ方式**で回避し、重大処理ゆえ**再起動までは取り消せる**設計にした。

## 仕組み
1. 初期化ボタン → リスク周知の確認ダイアログ → OK で `ResetDefaultProfilePending` フラグを立てて保存（**この時点では何も削除しない**）
2. UI が「初期化を取り消す」＋「次回起動時に初期化されます」に変化
3. 再起動前なら取り消し可能（フラグを下ろす）
4. 次回起動時、`App.OnLaunched` 冒頭（WebView2 未初期化＝ロックなし）でデータフォルダを削除しフラグをクリア

default の実データパスは `CoreWebView2Environment.UserDataFolder` から取得して `DefaultProfileDataPath` に保存しておく。

## 変更ファイル
- `Models/Models.cs` — `ResetDefaultProfilePending` / `DefaultProfileDataPath` 追加
- `Views/MainWindow.xaml.cs` — default env 作成時に実データパスを記録
- `App.xaml.cs` — 起動時の削除処理（try/catch で保護）
- `Views/Settings/ProfilesPage.xaml.cs` — ボタン有効化・確認ダイアログ・取り消し
- `Strings/{ja-JP,en-US}/Resources.resw` — `Profile_ResetCancel` / `Profile_ResetPendingInfo` 追加（既存 `Profile_Reset*` は再利用）

## テスト手順（要手動確認）
1. **設定 → プロファイル → default の「初期化」** をクリック → 確認ダイアログにリスク（Cookie・ログイン情報が消える旨）が表示されることを確認
2. **「初期化する」** → ボタンが「初期化を取り消す」に変わり、説明が「次回起動時に初期化されます」に変化することを確認（**この時点ではまだ X ログインは生きている**）
3. **「初期化を取り消す」** をクリック → 元の「初期化」ボタンに戻ることを確認（キャンセル余地）
4. 再度 **「初期化する」** → **アプリを再起動** → default プロファイルの X ログイン・データが消えており、再ログインが必要になっていることを確認
5. 再起動後、設定画面でボタンが「初期化」に戻っている（フラグがクリアされた）ことを確認
6. **言語を en-US** に切り替え、同じフローで英語表示（"Reset" / "Cancel reset" / "Will be reset on next launch..."）を確認
7. 非 default プロファイルの「削除」ボタンが従来どおり動作する（リグレッションなし）ことを確認

## 補足
- 自動再起動はしない方針（ユーザーが任意のタイミングで再起動でき、それまで取り消せる）
- データパス未保存（default env を一度も作っていない）の場合は削除をスキップ。初期化したい状況では必ず記録済みのため問題なし

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)