### PR TITLE
refactor: プロファイル作成フローを共通化・モーダル化 (#157)

### DIFF
--- a/Services/ProfileService.cs
+++ b/Services/ProfileService.cs
@@ -1,0 +1,26 @@
+using System;
+using System.IO;
+
+namespace XTimelineViewer.Services
+{
+    /// <summary>
+    /// プロファイル関連のパス算出など、UI 非依存のヘルパー。
+    /// </summary>
+    internal static class ProfileService
+    {
+        /// <summary>
+        /// 名前付きプロファイルの WebView2 ユーザーデータ保存先ディレクトリ。
+        /// MSIX パッケージ環境では LocalFolder 配下、unpackaged では LocalApplicationData 配下。
+        /// （旧 AddProfileWindow / MainWindow の重複実装を共通化 — #157）
+        /// </summary>
+        public static string GetProfilesDataDir()
+        {
+            if (PackageContext.IsPackaged)
+                return Path.Combine(
+                    Windows.Storage.ApplicationData.Current.LocalFolder.Path, "profiles");
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "XTimelineViewer", "profiles");
+        }
+    }
+}

--- a/Services/WindowModal.cs
+++ b/Services/WindowModal.cs
@@ -1,0 +1,25 @@
+using Microsoft.UI.Xaml;
+using System;
+using System.Runtime.InteropServices;
+
+namespace XTimelineViewer.Services
+{
+    /// <summary>
+    /// 子ウィンドウを親に対して擬似モーダルで開くヘルパー (#157)。
+    /// WinUI 3 には Window のモーダル表示が無いため、親を EnableWindow(false) で
+    /// 無効化し、子が閉じたら必ず復帰させる（例外時もロックが残らない）。
+    /// </summary>
+    internal static class WindowModal
+    {
+        [DllImport("user32.dll")]
+        private static extern bool EnableWindow(IntPtr hWnd, bool bEnable);
+
+        public static void RunModal(Window owner, Window modal)
+        {
+            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(owner);
+            EnableWindow(hwnd, false);
+            modal.Closed += (_, _) => EnableWindow(hwnd, true);
+            modal.Activate();
+        }
+    }
+}

--- a/Views/AddProfileWindow.xaml
+++ b/Views/AddProfileWindow.xaml
@@ -2,6 +2,7 @@
     x:Class="XTimelineViewer.Views.AddProfileWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:XTimelineViewer.Views.Controls"
     Title="Add Profile">
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" Padding="0">
@@ -10,38 +11,8 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <!-- Phase 1: Login -->
-        <Grid x:Name="LoginPhase" Grid.Row="0">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="*"/>
-            </Grid.RowDefinitions>
-            <TextBlock x:Name="LoginHintText"
-                       Grid.Row="0"
-                       Margin="16,12"
-                       FontSize="14"
-                       Opacity="0.7"/>
-            <WebView2 x:Name="LoginWebView"
-                      Grid.Row="1"
-                      xmlns="using:Microsoft.UI.Xaml.Controls"/>
-        </Grid>
-
-        <!-- Phase 2: Confirm -->
-        <StackPanel x:Name="ConfirmPhase"
-                    Grid.Row="0"
-                    Visibility="Collapsed"
-                    VerticalAlignment="Center"
-                    HorizontalAlignment="Center"
-                    Spacing="16"
-                    Padding="32">
-            <TextBlock x:Name="DetectedText"
-                       FontSize="16"
-                       FontWeight="SemiBold"
-                       HorizontalAlignment="Center"/>
-            <TextBox x:Name="ProfileNameBox"
-                     Width="280"
-                     HorizontalAlignment="Center"/>
-        </StackPanel>
+        <!-- ログイン～プロファイル作成フロー（#157 で共通化） -->
+        <controls:ProfileLoginControl x:Name="LoginControl" Grid.Row="0"/>
 
         <!-- Footer -->
         <StackPanel Grid.Row="1"

--- a/Views/AddProfileWindow.xaml.cs
+++ b/Views/AddProfileWindow.xaml.cs
@@ -1,111 +1,49 @@
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Automation;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.Web.WebView2.Core;
 using System;
 using System.Diagnostics;
-using System.IO;
-using System.Threading.Tasks;
 using Windows.Graphics;
-
 using XTimelineViewer.Models;
+using XTimelineViewer.Services;
 
 namespace XTimelineViewer.Views
 {
     public sealed partial class AddProfileWindow : Window
     {
-        private readonly string _profileId = Guid.NewGuid().ToString("N");
+        // 生成は ShowModal 経由のみ。呼び出し元に関わらずモーダルを型で保証する (#157)。
+        private event EventHandler<ProfileConfig>? ProfileCreated;
 
-        public event EventHandler<ProfileConfig>? ProfileCreated;
-
-        public AddProfileWindow()
+        private AddProfileWindow()
         {
             this.InitializeComponent();
             AppWindow.Resize(new SizeInt32(500, 700));
             Title = R.Get("AddProfile_Title");
-            LoginHintText.Text = R.Get("AddProfile_LoginHint");
             CancelBtn.Content = R.Get("Button_Cancel");
             CreateBtn.Content = R.Get("AddProfile_CreateBtn");
-            ProfileNameBox.PlaceholderText = R.Get("AddProfile_FallbackLabel");
-            AutomationProperties.SetName(ProfileNameBox, R.Get("AddProfile_FallbackLabel"));
-            AutomationProperties.SetName(LoginWebView,   R.Get("AddProfile_LoginHint"));
-            _ = InitAsync();
+
+            // ログイン検出で作成ボタンを表示する。実処理は共通コントロールが担う (#157)。
+            LoginControl.LoginDetected += _ => CreateBtn.Visibility = Visibility.Visible;
+            _ = LoginControl.InitializeAsync();
         }
 
-        private static string GetProfilesDataDir()
+        /// <summary>
+        /// owner に対してモーダルでプロファイル作成ウィンドウを開く (#157)。
+        /// テーマ・タイトルバー・モーダル化・コールバック配線をすべてここに集約し、
+        /// 呼び出し元（設定画面・メニュー・将来のオンボーディング）はこの 1 行で済む。
+        /// </summary>
+        public static void ShowModal(Window owner, Action<ProfileConfig> onCreated)
         {
-            if (PackageContext.IsPackaged)
-                return Path.Combine(
-                    Windows.Storage.ApplicationData.Current.LocalFolder.Path, "profiles");
-            return Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "XTimelineViewer", "profiles");
-        }
-
-        private async Task InitAsync()
-        {
-            var folder = Path.Combine(GetProfilesDataDir(), _profileId);
-            Directory.CreateDirectory(folder);
-            var options = new CoreWebView2EnvironmentOptions { AreBrowserExtensionsEnabled = false };
-            var env = await CoreWebView2Environment.CreateWithOptionsAsync("", folder, options);
-            await LoginWebView.EnsureCoreWebView2Async(env);
-
-            // ウィンドウテーマを WebView2 にも反映する
-            LoginWebView.CoreWebView2.Profile.PreferredColorScheme =
-                ((FrameworkElement)Content).ActualTheme switch
-                {
-                    ElementTheme.Light => CoreWebView2PreferredColorScheme.Light,
-                    ElementTheme.Dark  => CoreWebView2PreferredColorScheme.Dark,
-                    _                  => CoreWebView2PreferredColorScheme.Auto,
-                };
-
-            LoginWebView.Source = new Uri("https://x.com/i/flow/login");
-
-            LoginWebView.CoreWebView2.NavigationCompleted += async (s, e) =>
-            {
-                if (!e.IsSuccess) return;
-                if (!Uri.TryCreate(LoginWebView.CoreWebView2.Source, UriKind.Absolute, out var uri)) return;
-                if (!uri.AbsolutePath.TrimEnd('/').Equals("/home", StringComparison.OrdinalIgnoreCase)) return;
-
-                var screenName = await TryGetScreenNameAsync();
-                ShowConfirmPhase(screenName);
-            };
-        }
-
-        private async Task<string?> TryGetScreenNameAsync()
-        {
-            var result = await LoginWebView.CoreWebView2.ExecuteScriptAsync(
-                "document.querySelector('[data-testid=\"AppTabBar_Profile_Link\"]')?.href?.split('/').pop() ?? null");
-            return result?.Trim('"') is { Length: > 0 } name && name != "null" ? name : null;
-        }
-
-        private void ShowConfirmPhase(string? screenName)
-        {
-            LoginPhase.Visibility = Visibility.Collapsed;
-            ConfirmPhase.Visibility = Visibility.Visible;
-            CreateBtn.Visibility = Visibility.Visible;
-
-            if (screenName is not null)
-            {
-                DetectedText.Text = string.Format(R.Get("AddProfile_Detected"), $"@{screenName}");
-                ProfileNameBox.Text = screenName;
-            }
-            else
-            {
-                DetectedText.Text = "";
-            }
+            var win = new AddProfileWindow();
+            var theme = ((FrameworkElement)owner.Content).ActualTheme;
+            ((FrameworkElement)win.Content).RequestedTheme = theme;
+            MainWindow.ApplyTitleBarTheme(win, theme);
+            win.ProfileCreated += (_, profile) => onCreated(profile);
+            WindowModal.RunModal(owner, win);
         }
 
         private void CreateBtn_Click(object sender, RoutedEventArgs e)
         {
-            var name = ProfileNameBox.Text.Trim();
-            if (string.IsNullOrEmpty(name)) return;
-
-            var profile = new ProfileConfig
-            {
-                Id = _profileId,
-                Name = name,
-            };
+            var profile = LoginControl.BuildProfile();
+            if (profile is null) return;
             Debug.WriteLine($"[Profile] Created: Id={profile.Id}, Name={profile.Name}");
             ProfileCreated?.Invoke(this, profile);
             Close();
@@ -113,7 +51,7 @@ namespace XTimelineViewer.Views
 
         private void CancelBtn_Click(object sender, RoutedEventArgs e)
         {
-            Debug.WriteLine($"[Profile] Cancelled: Id={_profileId} (will be cleaned up on next launch)");
+            Debug.WriteLine($"[Profile] Cancelled: Id={LoginControl.ProfileId} (will be cleaned up on next launch)");
             Close();
         }
     }

--- a/Views/Controls/ProfileLoginControl.xaml
+++ b/Views/Controls/ProfileLoginControl.xaml
@@ -1,0 +1,39 @@
+<UserControl
+    x:Class="XTimelineViewer.Views.Controls.ProfileLoginControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Grid>
+        <!-- Phase 1: Login -->
+        <Grid x:Name="LoginPhase">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+            <TextBlock x:Name="LoginHintText"
+                       Grid.Row="0"
+                       Margin="16,12"
+                       FontSize="14"
+                       Opacity="0.7"/>
+            <WebView2 x:Name="LoginWebView"
+                      Grid.Row="1"
+                      xmlns="using:Microsoft.UI.Xaml.Controls"/>
+        </Grid>
+
+        <!-- Phase 2: Confirm -->
+        <StackPanel x:Name="ConfirmPhase"
+                    Visibility="Collapsed"
+                    VerticalAlignment="Center"
+                    HorizontalAlignment="Center"
+                    Spacing="16"
+                    Padding="32">
+            <TextBlock x:Name="DetectedText"
+                       FontSize="16"
+                       FontWeight="SemiBold"
+                       HorizontalAlignment="Center"/>
+            <TextBox x:Name="ProfileNameBox"
+                     Width="280"
+                     HorizontalAlignment="Center"/>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/Views/Controls/ProfileLoginControl.xaml.cs
+++ b/Views/Controls/ProfileLoginControl.xaml.cs
@@ -1,0 +1,104 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.Web.WebView2.Core;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using XTimelineViewer.Models;
+using XTimelineViewer.Services;
+
+namespace XTimelineViewer.Views.Controls
+{
+    /// <summary>
+    /// X にログインして ProfileConfig を生成する、再利用可能なログインフロー (#157)。
+    /// 新規プロファイル作成（AddProfileWindow）とオンボーディング（#4）で共有する。
+    /// ボタン類はホスト側に持たせ、本コントロールはログイン～名前入力のみを担う。
+    /// </summary>
+    public sealed partial class ProfileLoginControl : UserControl
+    {
+        private readonly string _profileId = Guid.NewGuid().ToString("N");
+
+        /// <summary>このコントロールが扱う新規プロファイルの ID。</summary>
+        public string ProfileId => _profileId;
+
+        /// <summary>
+        /// ログインが完了し /home に到達したときに発火する。引数は検出したスクリーンネーム（取得できなければ null）。
+        /// ホストはこれを受けて「作成」ボタンを表示するなどの反応をする。
+        /// </summary>
+        public event Action<string?>? LoginDetected;
+
+        public ProfileLoginControl()
+        {
+            this.InitializeComponent();
+            LoginHintText.Text = R.Get("AddProfile_LoginHint");
+            ProfileNameBox.PlaceholderText = R.Get("AddProfile_FallbackLabel");
+            AutomationProperties.SetName(ProfileNameBox, R.Get("AddProfile_FallbackLabel"));
+            AutomationProperties.SetName(LoginWebView, R.Get("AddProfile_LoginHint"));
+        }
+
+        /// <summary>
+        /// WebView2 環境を作成し、X のログインページを表示する。
+        /// テーマは親から伝播した this.ActualTheme を使う（ホストが RequestedTheme を設定すれば追従）。
+        /// </summary>
+        public async Task InitializeAsync()
+        {
+            var folder = Path.Combine(ProfileService.GetProfilesDataDir(), _profileId);
+            Directory.CreateDirectory(folder);
+            var options = new CoreWebView2EnvironmentOptions { AreBrowserExtensionsEnabled = false };
+            var env = await CoreWebView2Environment.CreateWithOptionsAsync("", folder, options);
+            await LoginWebView.EnsureCoreWebView2Async(env);
+
+            LoginWebView.CoreWebView2.Profile.PreferredColorScheme = this.ActualTheme switch
+            {
+                ElementTheme.Light => CoreWebView2PreferredColorScheme.Light,
+                ElementTheme.Dark  => CoreWebView2PreferredColorScheme.Dark,
+                _                  => CoreWebView2PreferredColorScheme.Auto,
+            };
+
+            LoginWebView.Source = new Uri("https://x.com/i/flow/login");
+
+            LoginWebView.CoreWebView2.NavigationCompleted += async (s, e) =>
+            {
+                if (!e.IsSuccess) return;
+                if (!Uri.TryCreate(LoginWebView.CoreWebView2.Source, UriKind.Absolute, out var uri)) return;
+                if (!uri.AbsolutePath.TrimEnd('/').Equals("/home", StringComparison.OrdinalIgnoreCase)) return;
+
+                var screenName = await TryGetScreenNameAsync();
+                ShowConfirmPhase(screenName);
+                LoginDetected?.Invoke(screenName);
+            };
+        }
+
+        private async Task<string?> TryGetScreenNameAsync()
+        {
+            var result = await LoginWebView.CoreWebView2.ExecuteScriptAsync(
+                "document.querySelector('[data-testid=\"AppTabBar_Profile_Link\"]')?.href?.split('/').pop() ?? null");
+            return result?.Trim('"') is { Length: > 0 } name && name != "null" ? name : null;
+        }
+
+        private void ShowConfirmPhase(string? screenName)
+        {
+            LoginPhase.Visibility = Visibility.Collapsed;
+            ConfirmPhase.Visibility = Visibility.Visible;
+
+            if (screenName is not null)
+            {
+                DetectedText.Text = string.Format(R.Get("AddProfile_Detected"), $"@{screenName}");
+                ProfileNameBox.Text = screenName;
+            }
+            else
+            {
+                DetectedText.Text = "";
+            }
+        }
+
+        /// <summary>入力された名前で ProfileConfig を生成する。名前が空なら null を返す。</summary>
+        public ProfileConfig? BuildProfile()
+        {
+            var name = ProfileNameBox.Text.Trim();
+            if (string.IsNullOrEmpty(name)) return null;
+            return new ProfileConfig { Id = _profileId, Name = name };
+        }
+    }
+}

--- a/Views/MainWindow.Profiles.cs
+++ b/Views/MainWindow.Profiles.cs
@@ -122,5 +122,16 @@ namespace XTimelineViewer.Views
                 }
             };
         }
+
+        // メニューから新規プロファイル作成ウィンドウをモーダルで開く (#157)
+        private void NewProfileMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            AddProfileWindow.ShowModal(this, profile =>
+            {
+                _profiles.Add(profile);
+                SaveProfiles();
+                RefreshAllProfileBadges();
+            });
+        }
     }
 }

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -47,6 +47,11 @@
                     <FontIcon Glyph="&#xE700;" FontFamily="Segoe Fluent Icons" FontSize="14"/>
                     <Button.Flyout>
                         <MenuFlyout>
+                            <MenuFlyoutItem x:Name="NewProfileMenuItem" Click="NewProfileMenuItem_Click">
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon Glyph="&#xE8FA;" FontFamily="Segoe Fluent Icons"/>
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
                             <MenuFlyoutSubItem x:Name="AddTimelineSubMenu">
                                 <MenuFlyoutSubItem.Icon>
                                     <FontIcon Glyph="&#xE710;" FontFamily="Segoe Fluent Icons"/>

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -194,15 +194,8 @@ namespace XTimelineViewer.Views
             })();
             """;
 
-        private static string GetProfilesDataDir()
-        {
-            if (PackageContext.IsPackaged)
-                return Path.Combine(
-                    Windows.Storage.ApplicationData.Current.LocalFolder.Path, "profiles");
-            return Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "XTimelineViewer", "profiles");
-        }
+        // プロファイルデータの保存先は ProfileService に共通化済み (#157)
+        private static string GetProfilesDataDir() => ProfileService.GetProfilesDataDir();
 
         private async Task<CoreWebView2Environment> GetOrCreateProfileEnvAsync(string profileId)
         {
@@ -278,6 +271,7 @@ namespace XTimelineViewer.Views
             UpdateThemeRadioState();
             AppSettingsMenuItem.Text = R.Get("Menu_Settings");
 
+            NewProfileMenuItem.Text           = R.Get("Menu_NewProfile");
             AddTimelineSubMenu.Text           = R.Get("Menu_AddTimeline");
             AddHomeTimelineItem.Text          = R.Get("Timeline_Home");
             AddNotificationsTimelineItem.Text = R.Get("Timeline_Notifications");

--- a/Views/Settings/ProfilesPage.xaml.cs
+++ b/Views/Settings/ProfilesPage.xaml.cs
@@ -190,23 +190,13 @@ namespace XTimelineViewer.Views.Settings
         {
             if (_parent is null) return;
 
-            var win = new AddProfileWindow();
-            var childTheme = ((FrameworkElement)_parent.Content).ActualTheme;
-            ((FrameworkElement)win.Content).RequestedTheme = childTheme;
-            MainWindow.ApplyTitleBarTheme(win, childTheme);
-
-            // AddProfileWindow を SettingsWindow に対してモーダル化
-            _parent.SetEnabled(false);
-            win.Closed += (_, _) => _parent.SetEnabled(true);
-
-            win.ProfileCreated += (_, profile) =>
+            // モーダル化・テーマ適用は ShowModal に集約済み (#157)
+            AddProfileWindow.ShowModal(_parent, profile =>
             {
                 _parent.Profiles.Add(profile);
                 _parent.OnProfileCreated?.Invoke(profile);
                 PopulateUI();
-            };
-
-            win.Activate();
+            });
         }
     }
 }

--- a/Views/SettingsWindow.xaml.cs
+++ b/Views/SettingsWindow.xaml.cs
@@ -134,13 +134,6 @@ namespace XTimelineViewer.Views
             }
         }
 
-        /// <summary>設定ウィンドウの有効/無効を切り替える（子ウィンドウのモーダル化用）。</summary>
-        internal void SetEnabled(bool enabled)
-        {
-            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
-            EnableWindow(hwnd, enabled);
-        }
-
         private void NavView_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
         {
             if (args.SelectedItem is not NavigationViewItem item) return;


### PR DESCRIPTION
## Summary
オンボーディング（#4）の土台として、新規プロファイル作成フローを整理する。**機能の本質は変えず**、再利用可能・一貫したモーダル動線にリファクタした。

## 変更点

### 1. ログインフローの共通化
- **`ProfileLoginControl`（UserControl）** を新規抽出。X ログイン → `/home` 検出 → スクリーンネーム取得 → `ProfileConfig` 生成をカプセル化。`LoginDetected` イベントと `BuildProfile()` を公開
- `AddProfileWindow` はこのコントロール + Cancel/Create 枠の薄いホストに
- → オンボーディング（#4）の Step2 はこのコントロールを再利用するだけで済む

### 2. パスの重複解消
- `GetProfilesDataDir()` が `AddProfileWindow` と `MainWindow` で重複していたのを **`ProfileService`** に集約

### 3. メニューからの作成を追加
- メニュー（≡）の**最上部**に「新規プロファイルの作成」を追加。従来の 設定 → プロファイル 経由に加え、メニューからも直接作成できる

### 4. モーダルを型で保証
- `AddProfileWindow` のコンストラクタを private 化し、静的 **`ShowModal(owner, onCreated)`** だけ公開 → 非モーダルで開く事故を防止
- モーダル化を **`WindowModal.RunModal(owner, modal)`**（`Services/WindowModal.cs`）に共通化。owner 非依存で、将来の `OnboardingWindow` も再利用可
- 不要になった `SettingsWindow.SetEnabled` を削除

設計指針は #4 にも記録済み。

## テスト手順（要手動確認）
1. **メニュー（≡）最上部に「新規プロファイルの作成」** が表示される
2. クリック → 作成ウィンドウが開き、**メインウィンドウが無効化（モーダル）**される
3. X ログイン → `/home` 到達で確認フェーズ・@ハンドル検出・作成ボタン表示
4. 「プロファイルを作成」→ メインのタイムラインヘッダーにバッジ反映
5. ウィンドウを閉じる → **メインウィンドウが操作可能に復帰**
6. **設定 → プロファイル → 新規作成** でも、設定ウィンドウが無効化され、閉じると復帰（モーダル一致）
7. キャンセル・テーマ反映（ライト/ダーク）が従来どおり
8. 既存プロファイルの削除・編集にリグレッションがない

## 関連
- #4 オンボーディング（このコントロール／モーダルパターンを再利用）
- #156 投稿プロファイル選択

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)