### PR TITLE
chore: 拡張機能カードのリンクボタンを削除

### DIFF
--- a/Views/Settings/ExtensionsPage.xaml.cs
+++ b/Views/Settings/ExtensionsPage.xaml.cs
@@ -116,22 +116,7 @@ namespace XTimelineViewer.Views.Settings
                 buttonsPanel.Children.Add(settingsBtn);
             }
 
-            if (ext.HomepageUrl is not null && Uri.TryCreate(ext.HomepageUrl, UriKind.Absolute, out var homepageUri))
-            {
-                var isStore = homepageUri.Host.Contains("chromewebstore.google.com");
-                var linkBtn = new HyperlinkButton
-                {
-                    Content = isStore ? R.Get("ExtSettings_StoreLink") : R.Get("ExtSettings_Homepage"),
-                };
-                linkBtn.Click += async (_, _) =>
-                {
-                    if (_parent?.LaunchUriAsync is not null)
-                        await _parent.LaunchUriAsync(homepageUri);
-                    else
-                        await Windows.System.Launcher.LaunchUriAsync(homepageUri);
-                };
-                buttonsPanel.Children.Add(linkBtn);
-            }
+            // 拡張機能カードのリンクボタン（Chrome Web Store 等）は場所をとるため削除
 
             if (buttonsPanel.Children.Count > 0)
                 card.Content = buttonsPanel;


### PR DESCRIPTION
## Summary
設定 → 拡張機能 の各カードにある **Chrome Web Store / ホームページへのリンクボタン**を削除する。場所をとるため。

## 変更点
- `ExtensionsPage.xaml.cs` の拡張機能カードからリンクボタン（`HyperlinkButton`）の生成を削除
- 拡張機能の **設定ボタン**（`ExtSettings_OpenSettings`）は残す
- `ExtSettings_StoreLink` / `ExtSettings_Homepage` リソースは拡張機能オプションダイアログ（`MainWindow.WebView2.cs`）で引き続き使うため残置

## テスト手順
1. 設定 → 拡張機能 を開く
2. 各拡張機能カードに **リンクボタンが表示されない**ことを確認
3. 設定ボタン（オプションページがある拡張機能のみ）は従来どおり動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)