### PR TITLE
chore: 拡張機能カードのリンクアイコンを削除（IsClickEnabled）

### DIFF
--- a/Views/Settings/ExtensionsPage.xaml.cs
+++ b/Views/Settings/ExtensionsPage.xaml.cs
@@ -60,7 +60,8 @@ namespace XTimelineViewer.Views.Settings
             {
                 Header      = ext.Name,
                 Description = Path.GetFileName(ext.DirectoryPath),
-                IsClickEnabled = ext.OptionsPage is not null && ext.ExtensionId is not null,
+                // 右端のリンクアイコンと「設定を開く」ボタンの機能が重複していたため、
+                // 明示的なボタンを残してカード自体のクリック化は廃止
             };
 
             if (ext.IconPath is not null)
@@ -78,21 +79,6 @@ namespace XTimelineViewer.Views.Settings
                 {
                     Glyph      = "",
                     FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Segoe Fluent Icons")
-                };
-            }
-
-            if (card.IsClickEnabled)
-            {
-                card.ActionIcon = new FontIcon
-                {
-                    Glyph      = "",
-                    FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Segoe Fluent Icons"),
-                    FontSize   = 14,
-                };
-                card.Click += async (_, _) =>
-                {
-                    if (_parent?.OpenExtensionSettingsAsync is not null && XamlRoot is not null)
-                        await _parent.OpenExtensionSettingsAsync(ext, XamlRoot);
                 };
             }
 


### PR DESCRIPTION
## Summary
#159 で「設定を開く」ボタンを残してリンク類を削除したが、`SettingsCard` 自体の `IsClickEnabled` による右端のリンクアイコン（`ActionIcon` の「↗」）が残っており、「設定を開く」ボタンと機能が重複していた。明示的なボタンを残し、カード自体のクリック化を廃止する。

（本変更は #159 のレビュー中に対応した修正だが push 漏れがあり、独立 PR として再投入する。）

## 変更点
- `ExtensionsPage.xaml.cs`:
  - `SettingsCard.IsClickEnabled = ...` を削除
  - `card.IsClickEnabled` 分岐内の `ActionIcon` / `Click` ハンドラ生成を削除
- 「設定を開く」ボタン（`ExtSettings_OpenSettings`）はそのまま残る

## テスト手順
1. 設定 → 拡張機能 を開く
2. 各カードに **右端のリンクアイコン（「↗」）が表示されない**ことを確認
3. 「設定を開く」ボタンは従来どおり動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)