### PR TITLE
fix: バッジ色が起動ごとに変わる問題を修正

### DIFF
--- a/Views/MainWindow.Profiles.cs
+++ b/Views/MainWindow.Profiles.cs
@@ -82,11 +82,22 @@ namespace XTimelineViewer.Views
             Color.FromArgb(255,  63,  81, 181),  // indigo
         ];
 
-        private static Color GetProfileColor(string profileId)
+        // string.GetHashCode() は .NET (Core) ではプロセスごとにランダム化されるため、
+        // 起動のたびに同じ profileId が別の色になる問題があった (#160)。
+        // FNV-1a 風の決定的ハッシュで安定したインデックスを返す。
+        internal static int StableIndex(string s, int modulo)
         {
-            var hash = Math.Abs(profileId.GetHashCode());
-            return ProfileBadgeColors[hash % ProfileBadgeColors.Length];
+            if (modulo <= 0) return 0;
+            unchecked
+            {
+                int hash = 17;
+                foreach (char c in s) hash = hash * 31 + c;
+                return (int)((uint)hash % (uint)modulo);
+            }
         }
+
+        private static Color GetProfileColor(string profileId)
+            => ProfileBadgeColors[StableIndex(profileId, ProfileBadgeColors.Length)];
 
         private Color GetProfileColor(ProfileConfig? profile, string profileId)
         {

--- a/Views/Settings/ProfilesPage.xaml.cs
+++ b/Views/Settings/ProfilesPage.xaml.cs
@@ -47,8 +47,9 @@ namespace XTimelineViewer.Views.Settings
         private CommunityToolkit.WinUI.Controls.SettingsExpander BuildProfileCard(
             ProfileConfig profile, Color[] colors)
         {
+            // string.GetHashCode() の非決定性により起動ごとに色が変わる問題を回避 (#160)
             var colorIdx = profile.BadgeColorIndex
-                ?? (Math.Abs(profile.Id.GetHashCode()) % Math.Max(colors.Length, 1));
+                ?? MainWindow.StableIndex(profile.Id, Math.Max(colors.Length, 1));
             if (colorIdx < 0 || colorIdx >= colors.Length) colorIdx = 0;
 
             var badgeColor = colors.Length > 0 ? colors[colorIdx] : Color.FromArgb(255, 128, 128, 128);


### PR DESCRIPTION
## Summary
- `string.GetHashCode()` は .NET Core でプロセスごとにランダム化されるため、起動のたびにバッジ色が変わっていた
- FNV-1a 風の決定的ハッシュ (`StableIndex`) に置き換え、起動をまたいでも同じ色が割り当てられるようにした
- `MainWindow.Profiles.cs` と `ProfilesPage.xaml.cs` の両方を修正

## Test plan
- [x] デバッグ実行を3回行い、バッジ色が変わらないことを確認済み

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)