### PR TITLE
feat: 投稿画面にプロファイル選択プルダウンを追加

### DIFF
--- a/Models/Models.cs
+++ b/Models/Models.cs
@@ -44,5 +44,6 @@ namespace XTimelineViewer.Models
         public bool    ShowAutoActivateLabel { get; set; } = false;
         public string  ExternalBrowser       { get; set; } = "system";  // "system" | "edge"
         public string  EdgeProfileDirectory  { get; set; } = "";        // "Default" | "Profile 1" など
+        public string? LastUsedProfileId     { get; set; } = null;      // 投稿画面で最後に使ったプロファイル
     }
 }

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -133,6 +133,9 @@
   <data name="Profiles_BadgeText" xml:space="preserve"><value>Badge Text</value></data>
   <data name="Profiles_DefaultDescription" xml:space="preserve"><value>Default profile</value></data>
 
+  <!-- Compose profile selector -->
+  <data name="Compose_Profile" xml:space="preserve"><value>Post as</value></data>
+
   <!-- Error dialogs -->
   <data name="ExtLoadError_Title" xml:space="preserve"><value>Failed to Load Extensions</value></data>
   <data name="WebViewInitError_Title" xml:space="preserve"><value>Failed to Initialize WebView2</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -133,6 +133,9 @@
   <data name="Profiles_BadgeText" xml:space="preserve"><value>バッジテキスト</value></data>
   <data name="Profiles_DefaultDescription" xml:space="preserve"><value>既定のプロファイル</value></data>
 
+  <!-- Compose profile selector -->
+  <data name="Compose_Profile" xml:space="preserve"><value>投稿アカウント</value></data>
+
   <!-- Error dialogs -->
   <data name="ExtLoadError_Title" xml:space="preserve"><value>拡張機能の読み込みに失敗しました</value></data>
   <data name="WebViewInitError_Title" xml:space="preserve"><value>WebView2 の初期化に失敗しました</value></data>

--- a/Views/MainWindow.Post.cs
+++ b/Views/MainWindow.Post.cs
@@ -1,23 +1,12 @@
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.Linq;
-using System.Net.Http;
-using System.Net.NetworkInformation;
-using System.Reflection;
-using System.Text.Json;
 using System.Threading.Tasks;
-using System.IO;
-using System.Runtime.InteropServices;
 using Microsoft.Web.WebView2.Core;
-using Windows.ApplicationModel.DataTransfer;
-using Windows.Graphics;
-using Windows.Storage;
 using Windows.UI;
 
 using XTimelineViewer.Models;
@@ -36,18 +25,140 @@ namespace XTimelineViewer.Views
 
         private async Task OpenPostDialogAsync(WebView2? senderWebView = null)
         {
+            // ── プロファイルセレクターの構築 ──
+            var selectedProfileId = ResolveComposeProfileId();
+
+            var profileCombo = BuildProfileComboBox(selectedProfileId);
             var webView = new WebView2 { Width = 500, MinHeight = 520 };
+            var rootPanel = new StackPanel { Spacing = 8 };
+            rootPanel.Children.Add(profileCombo);
+            rootPanel.Children.Add(webView);
 
             var dlg = new ContentDialog
             {
-                Content         = webView,
+                Content         = rootPanel,
                 CloseButtonText = R.Get("Button_Close"),
                 XamlRoot        = Content.XamlRoot,
             };
 
-            var env = _appSettings.SeparateComposeEnv
-                ? await GetOrCreateComposeEnvAsync()
-                : await GetOrCreateProfileEnvAsync("default");
+            // ── WebView2 初期化 ──
+            await InitComposeWebView(webView, selectedProfileId, dlg);
+
+            // ── プロファイル切り替え ──
+            profileCombo.SelectionChanged += async (s, args) =>
+            {
+                if (profileCombo.SelectedItem is not ComboBoxItem item) return;
+                var newProfileId = item.Tag as string ?? "default";
+                if (newProfileId == selectedProfileId) return;
+                selectedProfileId = newProfileId;
+
+                // 古い WebView2 を破棄して新しいものに差し替え
+                var oldWebView = webView;
+                webView = new WebView2 { Width = 500, MinHeight = 520 };
+                rootPanel.Children.Remove(oldWebView);
+                rootPanel.Children.Add(webView);
+                try { oldWebView.Close(); } catch { }
+
+                await InitComposeWebView(webView, selectedProfileId, dlg);
+            };
+
+            // WebView2 の Win32 HWND は XAML Popup より常に前面に描画されるため、
+            // ダイアログ表示中はタイムライン WebView2 を非表示にして Z-order 問題を回避する
+            foreach (var wv in _webViews)
+                wv.Visibility = Visibility.Collapsed;
+            try
+            {
+                await ShowDialogAsync(dlg);
+            }
+            finally
+            {
+                foreach (var wv in _webViews)
+                    wv.Visibility = Visibility.Visible;
+
+                // 選択プロファイルを保存
+                if (_appSettings.LastUsedProfileId != selectedProfileId)
+                {
+                    _appSettings.LastUsedProfileId = selectedProfileId;
+                    SaveSettings();
+                }
+
+                // ダイアログを閉じた後、キーボードフォーカスを WebView2 に戻す
+                var target = senderWebView ?? _webViews.FirstOrDefault();
+                if (target is not null &&
+                    _webViewToPane.TryGetValue(target, out var pane) &&
+                    _paneToSetFocus.TryGetValue(pane, out var setFocus))
+                {
+                    setFocus();
+                }
+            }
+        }
+
+        /// <summary>投稿に使用するプロファイル ID を決定する。</summary>
+        private string ResolveComposeProfileId()
+        {
+            // 前回使用したプロファイルが存在すればそれを使う
+            if (_appSettings.LastUsedProfileId is { } last &&
+                _profiles.Any(p => p.Id == last))
+                return last;
+
+            // 名前付きプロファイルがあれば最初のものを使う
+            var named = _profiles.FirstOrDefault(p => p.Id != "default");
+            if (named is not null) return named.Id;
+
+            return "default";
+        }
+
+        /// <summary>プロファイル選択 ComboBox を構築する。</summary>
+        private ComboBox BuildProfileComboBox(string selectedProfileId)
+        {
+            var combo = new ComboBox
+            {
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                Header = R.Get("Compose_Profile"),
+            };
+
+            int selectedIndex = 0;
+            for (int i = 0; i < _profiles.Count; i++)
+            {
+                var profile = _profiles[i];
+                var color = GetProfileColor(profile, profile.Id);
+                var item = new ComboBoxItem
+                {
+                    Tag     = profile.Id,
+                    Content = new StackPanel
+                    {
+                        Orientation = Orientation.Horizontal,
+                        Spacing     = 8,
+                        Children =
+                        {
+                            new Border
+                            {
+                                Width        = 12,
+                                Height       = 12,
+                                CornerRadius = new CornerRadius(2),
+                                Background   = new SolidColorBrush(color),
+                                VerticalAlignment = VerticalAlignment.Center,
+                            },
+                            new TextBlock
+                            {
+                                Text              = profile.Name,
+                                VerticalAlignment = VerticalAlignment.Center,
+                            },
+                        },
+                    },
+                };
+                combo.Items.Add(item);
+                if (profile.Id == selectedProfileId) selectedIndex = i;
+            }
+
+            combo.SelectedIndex = selectedIndex;
+            return combo;
+        }
+
+        /// <summary>投稿用 WebView2 を初期化して compose/post へナビゲートする。</summary>
+        private async Task InitComposeWebView(WebView2 webView, string profileId, ContentDialog dlg)
+        {
+            var env = await GetOrCreateProfileEnvAsync(profileId);
             await webView.EnsureCoreWebView2Async(env);
 
             // テーマを適用
@@ -90,29 +201,6 @@ namespace XTimelineViewer.Views
             };
 
             webView.Source = new Uri("https://x.com/compose/post");
-
-            // WebView2 の Win32 HWND は XAML Popup より常に前面に描画されるため、
-            // ダイアログ表示中はタイムライン WebView2 を非表示にして Z-order 問題を回避する
-            foreach (var wv in _webViews)
-                wv.Visibility = Visibility.Collapsed;
-            try
-            {
-                await ShowDialogAsync(dlg);
-            }
-            finally
-            {
-                foreach (var wv in _webViews)
-                    wv.Visibility = Visibility.Visible;
-
-                // ダイアログを閉じた後、キーボードフォーカスを WebView2 に戻す
-                var target = senderWebView ?? _webViews.FirstOrDefault();
-                if (target is not null &&
-                    _webViewToPane.TryGetValue(target, out var pane) &&
-                    _paneToSetFocus.TryGetValue(pane, out var setFocus))
-                {
-                    setFocus();
-                }
-            }
         }
 
         // ── Keyboard shortcuts ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- 投稿ダイアログ（ContentDialog）にプロファイル選択 ComboBox を常時表示
- 各プロファイルをバッジ色 + 名前で表示し、選択したプロファイルの WebView2 env で `x.com/compose/post` を開く
- プロファイル切り替え時は WebView2 を再作成して新しい env で初期化
- 前回使用したプロファイルを `AppSettings.LastUsedProfileId` に保存し、次回の初期選択に反映
- 廃止済みの `SeparateComposeEnv` 分岐を除去

## Test plan
- [x] 投稿ボタン → プロファイル選択プルダウンが表示される
- [x] プルダウンを切り替えると、そのプロファイルのログインセッションで投稿画面が読み込まれる
- [x] ダイアログを閉じて再度開くと、前回選択したプロファイルが初期選択されている
- [x] プロファイルが1つ（default のみ）でもプルダウンは表示される

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)