### PR TITLE
feat: 初回起動時のオンボーディングエクスペリエンス

### DIFF
--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -133,6 +133,16 @@
   <data name="Profiles_BadgeText" xml:space="preserve"><value>Badge Text</value></data>
   <data name="Profiles_DefaultDescription" xml:space="preserve"><value>Default profile</value></data>
 
+  <!-- Onboarding (#4) -->
+  <data name="Onboarding_WelcomeTitle" xml:space="preserve"><value>Welcome to XTimelineViewer</value></data>
+  <data name="Onboarding_WelcomeBody" xml:space="preserve"><value>Display multiple X timelines side by side. Let's start by signing in to your X account and creating a profile.</value></data>
+  <data name="Onboarding_LoginTitle" xml:space="preserve"><value>Sign in to X</value></data>
+  <data name="Onboarding_StartBtn" xml:space="preserve"><value>Get Started</value></data>
+  <data name="Onboarding_DoneBtn" xml:space="preserve"><value>Done</value></data>
+  <data name="Onboarding_CompleteTitle" xml:space="preserve"><value>You're all set!</value></data>
+  <data name="Onboarding_CompleteBody" xml:space="preserve"><value>Added {0}'s Home timeline. You can add more timelines and profiles from the menu.</value></data>
+  <data name="Button_Skip" xml:space="preserve"><value>Skip and exit</value></data>
+
   <!-- Compose profile selector -->
   <data name="Compose_Profile" xml:space="preserve"><value>Post as</value></data>
 

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -133,6 +133,16 @@
   <data name="Profiles_BadgeText" xml:space="preserve"><value>バッジテキスト</value></data>
   <data name="Profiles_DefaultDescription" xml:space="preserve"><value>既定のプロファイル</value></data>
 
+  <!-- Onboarding (#4) -->
+  <data name="Onboarding_WelcomeTitle" xml:space="preserve"><value>XTimelineViewer へようこそ</value></data>
+  <data name="Onboarding_WelcomeBody" xml:space="preserve"><value>X のタイムラインを並べて表示するアプリです。まず X アカウントにログインしてプロファイルを作成しましょう。</value></data>
+  <data name="Onboarding_LoginTitle" xml:space="preserve"><value>X にサインイン</value></data>
+  <data name="Onboarding_StartBtn" xml:space="preserve"><value>始める</value></data>
+  <data name="Onboarding_DoneBtn" xml:space="preserve"><value>完了</value></data>
+  <data name="Onboarding_CompleteTitle" xml:space="preserve"><value>準備完了！</value></data>
+  <data name="Onboarding_CompleteBody" xml:space="preserve"><value>{0} のホームタイムラインを追加しました。メニューからタイムラインやプロファイルを追加できます。</value></data>
+  <data name="Button_Skip" xml:space="preserve"><value>スキップしてアプリを終了</value></data>
+
   <!-- Compose profile selector -->
   <data name="Compose_Profile" xml:space="preserve"><value>投稿アカウント</value></data>
 

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -41,5 +41,21 @@ namespace XTimelineViewer.ViewModels
         /// <summary>空状態ヒントの Visibility。タイムラインがなければ Visible。</summary>
         public Visibility DropHintBorderVisibility
             => HasTimelines ? Visibility.Collapsed : Visibility.Visible;
+
+        // ── 名前付きプロファイルの有無 ──────────────────────────────────────────────
+
+        private bool _hasNamedProfiles;
+
+        /// <summary>名前付きプロファイルが1件以上存在するとき true。投稿ボタンの有効/無効に使う。</summary>
+        public bool HasNamedProfiles
+        {
+            get => _hasNamedProfiles;
+            set
+            {
+                if (_hasNamedProfiles == value) return;
+                _hasNamedProfiles = value;
+                NotifyPropertyChanged();
+            }
+        }
     }
 }

--- a/Views/Controls/ProfileLoginControl.xaml.cs
+++ b/Views/Controls/ProfileLoginControl.xaml.cs
@@ -93,6 +93,12 @@ namespace XTimelineViewer.Views.Controls
             }
         }
 
+        /// <summary>WebView2 を明示的に閉じて環境を解放する。</summary>
+        public void CloseWebView()
+        {
+            try { LoginWebView.Close(); } catch { }
+        }
+
         /// <summary>入力された名前で ProfileConfig を生成する。名前が空なら null を返す。</summary>
         public ProfileConfig? BuildProfile()
         {

--- a/Views/MainWindow.Onboarding.cs
+++ b/Views/MainWindow.Onboarding.cs
@@ -25,20 +25,28 @@ namespace XTimelineViewer.Views
                 if (((FrameworkElement)Content).IsLoaded) tcs.TrySetResult();
                 await tcs.Task;
 
-                OnboardingWindow.ShowModal(this, profile =>
-                {
-                    _profiles.Add(profile);
-                    SaveProfiles();
-                    RefreshAllProfileBadges();
-                    UpdateHasNamedProfiles();
-
-                    // ホームタイムラインを自動追加
-                    AddTimeline(new TimelineConfig
+                ProfileConfig? createdProfile = null;
+                OnboardingWindow.ShowModal(this,
+                    onCreated: profile =>
                     {
-                        Url       = HomeTimelineUrl,
-                        ProfileId = profile.Id,
+                        createdProfile = profile;
+                        _profiles.Add(profile);
+                        SaveProfiles();
+                        RefreshAllProfileBadges();
+                        UpdateHasNamedProfiles();
+                    },
+                    onClosed: () =>
+                    {
+                        // ウィンドウが閉じて WebView2 env が解放された後にタイムラインを追加
+                        if (createdProfile is not null)
+                        {
+                            AddTimeline(new TimelineConfig
+                            {
+                                Url       = HomeTimelineUrl,
+                                ProfileId = createdProfile.Id,
+                            });
+                        }
                     });
-                });
             }
         }
 

--- a/Views/MainWindow.Onboarding.cs
+++ b/Views/MainWindow.Onboarding.cs
@@ -1,0 +1,53 @@
+using Microsoft.UI.Xaml;
+using System.Linq;
+using System.Threading.Tasks;
+
+using XTimelineViewer.Models;
+
+namespace XTimelineViewer.Views
+{
+    public sealed partial class MainWindow : Window
+    {
+        /// <summary>
+        /// 起動時の初期化フロー。タイムライン復元後、名前付きプロファイルがなければ
+        /// オンボーディングをモーダル表示する (#4)。
+        /// </summary>
+        private async Task InitializeAsync()
+        {
+            await RestoreTimelinesAsync();
+            UpdateHasNamedProfiles();
+
+            if (!HasNamedProfiles())
+            {
+                // XamlRoot が利用可能になるまで待つ（Content.Loaded は Activate() 後に発火）
+                var tcs = new TaskCompletionSource();
+                ((FrameworkElement)Content).Loaded += (_, _) => tcs.TrySetResult();
+                if (((FrameworkElement)Content).IsLoaded) tcs.TrySetResult();
+                await tcs.Task;
+
+                OnboardingWindow.ShowModal(this, profile =>
+                {
+                    _profiles.Add(profile);
+                    SaveProfiles();
+                    RefreshAllProfileBadges();
+                    UpdateHasNamedProfiles();
+
+                    // ホームタイムラインを自動追加
+                    AddTimeline(new TimelineConfig
+                    {
+                        Url       = HomeTimelineUrl,
+                        ProfileId = profile.Id,
+                    });
+                });
+            }
+        }
+
+        /// <summary>名前付きプロファイルが1つ以上あるか。</summary>
+        private bool HasNamedProfiles()
+            => _profiles.Any(p => p.Id != "default");
+
+        /// <summary>ViewModel.HasNamedProfiles を現在のプロファイル状態で更新する。</summary>
+        private void UpdateHasNamedProfiles()
+            => ViewModel.HasNamedProfiles = HasNamedProfiles();
+    }
+}

--- a/Views/MainWindow.Profiles.cs
+++ b/Views/MainWindow.Profiles.cs
@@ -142,6 +142,7 @@ namespace XTimelineViewer.Views
                 _profiles.Add(profile);
                 SaveProfiles();
                 RefreshAllProfileBadges();
+                UpdateHasNamedProfiles();
             });
         }
     }

--- a/Views/MainWindow.Settings.cs
+++ b/Views/MainWindow.Settings.cs
@@ -85,8 +85,9 @@ namespace XTimelineViewer.Views
                 }
                 await SaveTimelinesAsync();
                 RefreshAllProfileBadges();
+                UpdateHasNamedProfiles();
             };
-            settingsWin.OnProfileCreated = _ => { SaveProfiles(); RefreshAllProfileBadges(); };
+            settingsWin.OnProfileCreated = _ => { SaveProfiles(); RefreshAllProfileBadges(); UpdateHasNamedProfiles(); };
 
             // About ページ情報とコールバックを設定
             string edgeVer;

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -23,6 +23,7 @@
                     Padding="12,0"
                     FontSize="14"
                     Style="{StaticResource AccentButtonStyle}"
+                    IsEnabled="{x:Bind ViewModel.HasNamedProfiles, Mode=OneWay}"
                     Click="PostBtn_Click">
                 <Button.KeyboardAccelerators>
                     <KeyboardAccelerator Key="N" Modifiers="Control"/>

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -249,7 +249,7 @@ namespace XTimelineViewer.Views
             ApplySavedTheme();
             ApplyAutoActivateTimer();
             UpdateMenuUpdateBadge();
-            _ = RestoreTimelinesAsync();
+            _ = InitializeAsync();
             _ = CheckForUpdatesInBackgroundAsync();
         }
 

--- a/Views/OnboardingWindow.xaml
+++ b/Views/OnboardingWindow.xaml
@@ -1,0 +1,71 @@
+<Window
+    x:Class="XTimelineViewer.Views.OnboardingWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:XTimelineViewer.Views.Controls"
+    Title="Onboarding">
+
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" Padding="0">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Step 1: Welcome -->
+        <StackPanel x:Name="WelcomeStep" Grid.Row="0"
+                    VerticalAlignment="Center"
+                    HorizontalAlignment="Center"
+                    Spacing="16"
+                    Padding="48">
+            <FontIcon Glyph="&#xE80F;" FontFamily="Segoe Fluent Icons"
+                      FontSize="48" HorizontalAlignment="Center"
+                      Foreground="{ThemeResource AccentFillColorDefaultBrush}"/>
+            <TextBlock x:Name="WelcomeTitle"
+                       FontSize="24" FontWeight="SemiBold"
+                       HorizontalAlignment="Center"
+                       TextWrapping="Wrap" TextAlignment="Center"/>
+            <TextBlock x:Name="WelcomeBody"
+                       FontSize="14" Opacity="0.8"
+                       HorizontalAlignment="Center"
+                       MaxWidth="380"
+                       TextWrapping="Wrap" TextAlignment="Center"/>
+        </StackPanel>
+
+        <!-- Step 2: Login (ProfileLoginControl) -->
+        <controls:ProfileLoginControl x:Name="LoginControl" Grid.Row="0"
+                                       Visibility="Collapsed"/>
+
+        <!-- Step 3: Complete -->
+        <StackPanel x:Name="CompleteStep" Grid.Row="0"
+                    Visibility="Collapsed"
+                    VerticalAlignment="Center"
+                    HorizontalAlignment="Center"
+                    Spacing="16"
+                    Padding="48">
+            <FontIcon Glyph="&#xE73E;" FontFamily="Segoe Fluent Icons"
+                      FontSize="48" HorizontalAlignment="Center"
+                      Foreground="{ThemeResource SystemFillColorSuccessBrush}"/>
+            <TextBlock x:Name="CompleteTitle"
+                       FontSize="24" FontWeight="SemiBold"
+                       HorizontalAlignment="Center"
+                       TextWrapping="Wrap" TextAlignment="Center"/>
+            <TextBlock x:Name="CompleteBody"
+                       FontSize="14" Opacity="0.8"
+                       HorizontalAlignment="Center"
+                       MaxWidth="380"
+                       TextWrapping="Wrap" TextAlignment="Center"/>
+        </StackPanel>
+
+        <!-- Footer -->
+        <StackPanel Grid.Row="1"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Spacing="8"
+                    Padding="16,12">
+            <Button x:Name="SkipBtn" Click="SkipBtn_Click"/>
+            <Button x:Name="PrimaryBtn"
+                    Style="{StaticResource AccentButtonStyle}"
+                    Click="PrimaryBtn_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Views/OnboardingWindow.xaml.cs
+++ b/Views/OnboardingWindow.xaml.cs
@@ -39,16 +39,17 @@ namespace XTimelineViewer.Views
 
         /// <summary>
         /// owner に対してモーダルでオンボーディングを開く。
-        /// プロファイル作成完了時に onCreated が呼ばれる。
-        /// スキップ時は onCreated は呼ばれない。
+        /// onCreated: プロファイル作成時（ウィンドウはまだ開いている）。プロファイル保存等に使う。
+        /// onClosed: ウィンドウが閉じた後。WebView2 env が解放されるため、タイムライン追加はここで行う。
         /// </summary>
-        public static void ShowModal(Window owner, Action<ProfileConfig> onCreated)
+        public static void ShowModal(Window owner, Action<ProfileConfig> onCreated, Action? onClosed = null)
         {
             var win = new OnboardingWindow();
             var theme = ((FrameworkElement)owner.Content).ActualTheme;
             ((FrameworkElement)win.Content).RequestedTheme = theme;
             MainWindow.ApplyTitleBarTheme(win, theme);
             win.ProfileCreated += (_, profile) => onCreated(profile);
+            win.Closed += (_, _) => onClosed?.Invoke();
             WindowModal.RunModal(owner, win);
         }
 
@@ -104,6 +105,9 @@ namespace XTimelineViewer.Views
         {
             _currentStep = Step.Complete;
 
+            // WebView2 env を解放し、ウィンドウを閉じた後に MainWindow が
+            // 同じプロファイルの env を新規作成できるようにする
+            LoginControl.CloseWebView();
             LoginControl.Visibility  = Visibility.Collapsed;
             CompleteStep.Visibility  = Visibility.Visible;
 

--- a/Views/OnboardingWindow.xaml.cs
+++ b/Views/OnboardingWindow.xaml.cs
@@ -1,0 +1,119 @@
+using Microsoft.UI.Xaml;
+using System;
+using System.Diagnostics;
+using Windows.Graphics;
+using XTimelineViewer.Models;
+using XTimelineViewer.Services;
+
+namespace XTimelineViewer.Views
+{
+    /// <summary>
+    /// 初回起動時のオンボーディングウィザード (#4)。
+    /// Step1: ようこそ → Step2: X ログイン (ProfileLoginControl) → Step3: 完了
+    /// ShowModal パターンで MainWindow に対してモーダル表示する。
+    /// </summary>
+    public sealed partial class OnboardingWindow : Window
+    {
+        private enum Step { Welcome, Login, Complete }
+        private Step _currentStep = Step.Welcome;
+        private event EventHandler<ProfileConfig>? ProfileCreated;
+
+        private OnboardingWindow()
+        {
+            this.InitializeComponent();
+            AppWindow.Resize(new SizeInt32(520, 680));
+
+            // Step 1 テキスト
+            WelcomeTitle.Text = R.Get("Onboarding_WelcomeTitle");
+            WelcomeBody.Text  = R.Get("Onboarding_WelcomeBody");
+            SkipBtn.Content   = R.Get("Button_Skip");
+            PrimaryBtn.Content = R.Get("Onboarding_StartBtn");
+
+            // Step 2: ログイン検出で作成ボタンを有効化
+            LoginControl.LoginDetected += _ =>
+            {
+                PrimaryBtn.Content   = R.Get("AddProfile_CreateBtn");
+                PrimaryBtn.IsEnabled = true;
+            };
+        }
+
+        /// <summary>
+        /// owner に対してモーダルでオンボーディングを開く。
+        /// プロファイル作成完了時に onCreated が呼ばれる。
+        /// スキップ時は onCreated は呼ばれない。
+        /// </summary>
+        public static void ShowModal(Window owner, Action<ProfileConfig> onCreated)
+        {
+            var win = new OnboardingWindow();
+            var theme = ((FrameworkElement)owner.Content).ActualTheme;
+            ((FrameworkElement)win.Content).RequestedTheme = theme;
+            MainWindow.ApplyTitleBarTheme(win, theme);
+            win.ProfileCreated += (_, profile) => onCreated(profile);
+            WindowModal.RunModal(owner, win);
+        }
+
+        private void PrimaryBtn_Click(object sender, RoutedEventArgs e)
+        {
+            switch (_currentStep)
+            {
+                case Step.Welcome:
+                    GoToLogin();
+                    break;
+                case Step.Login:
+                    TryCreateProfile();
+                    break;
+                case Step.Complete:
+                    Close();
+                    break;
+            }
+        }
+
+        private void SkipBtn_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
+            Microsoft.UI.Xaml.Application.Current.Exit();
+        }
+
+        private void GoToLogin()
+        {
+            _currentStep = Step.Login;
+
+            WelcomeStep.Visibility   = Visibility.Collapsed;
+            LoginControl.Visibility  = Visibility.Visible;
+
+            Title = R.Get("Onboarding_LoginTitle");
+            PrimaryBtn.Content   = R.Get("Onboarding_DoneBtn");
+            PrimaryBtn.IsEnabled = false; // ログイン検出まで無効
+            SkipBtn.Content      = R.Get("Button_Skip");
+
+            _ = LoginControl.InitializeAsync();
+        }
+
+        private void TryCreateProfile()
+        {
+            var profile = LoginControl.BuildProfile();
+            if (profile is null) return;
+
+            Debug.WriteLine($"[Onboarding] Profile created: Id={profile.Id}, Name={profile.Name}");
+            ProfileCreated?.Invoke(this, profile);
+
+            GoToComplete(profile.Name);
+        }
+
+        private void GoToComplete(string profileName)
+        {
+            _currentStep = Step.Complete;
+
+            LoginControl.Visibility  = Visibility.Collapsed;
+            CompleteStep.Visibility  = Visibility.Visible;
+
+            Title = R.Get("Onboarding_CompleteTitle");
+            CompleteTitle.Text = R.Get("Onboarding_CompleteTitle");
+            CompleteBody.Text  = string.Format(R.Get("Onboarding_CompleteBody"), profileName);
+
+            PrimaryBtn.Content   = R.Get("Button_Close");
+            PrimaryBtn.IsEnabled = true;
+            SkipBtn.Visibility   = Visibility.Collapsed;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 名前付きプロファイルが存在しない状態で起動すると、モーダルのオンボーディングウィザードを表示
  - **Step1**: ようこそ画面（アプリ概要 + 「始める」/「スキップしてアプリを終了」）
  - **Step2**: X ログイン（`ProfileLoginControl` を再利用、ログイン検出で自動進行）
  - **Step3**: 完了画面（プロファイル名表示 + ホームタイムライン自動追加）
- スキップ時はアプリを終了（名前付きプロファイルなしでは使えないため）
- `OnboardingWindow` は `AddProfileWindow` と同じ `ShowModal` パターンを採用
- 投稿ボタンを `ViewModel.HasNamedProfiles` にバインドし、名前付きプロファイル0件時は無効化
- プロファイル追加/削除時に `HasNamedProfiles` を更新

## Test plan
- [x] 名前付きプロファイルをすべて削除して再起動 → オンボーディングが表示される
- [x] Step1「始める」→ Step2 X ログイン → `/home` 到達で「プロファイルを作成」表示
- [x] プロファイル作成 → Step3 完了画面 → ホームタイムラインが自動追加されている
- [x] 「スキップしてアプリを終了」→ アプリが終了する
- [x] 名前付きプロファイルがある状態 → オンボーディングなしで通常起動、投稿ボタン有効
- [x] 名前付きプロファイル0件 → 投稿ボタン無効

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)