### PR TITLE
feat: プロファイル機能を正式機能に昇格 (#90)

### DIFF
--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -83,7 +83,7 @@
 
   <!-- Timeline pane settings dialog -->
   <data name="Timeline_Settings_Title" xml:space="preserve"><value>Settings</value></data>
-  <data name="Timeline_Profile" xml:space="preserve"><value>Profile (Experimental)</value></data>
+  <data name="Timeline_Profile" xml:space="preserve"><value>Profile</value></data>
   <data name="Timeline_Width" xml:space="preserve"><value>Timeline Width (px)</value></data>
   <data name="Timeline_Sidebar" xml:space="preserve"><value>X Sidebar</value></data>
   <data name="Timeline_Compose" xml:space="preserve"><value>Compose Area</value></data>
@@ -131,7 +131,7 @@
   <data name="Profiles_Name" xml:space="preserve"><value>Name</value></data>
   <data name="Profiles_BadgeColor" xml:space="preserve"><value>Badge Color</value></data>
   <data name="Profiles_BadgeText" xml:space="preserve"><value>Badge Text</value></data>
-  <data name="Profiles_DefaultDescription" xml:space="preserve"><value>Default profile</value></data>
+  <data name="Profiles_DefaultDescription" xml:space="preserve"><value>Internal profile used by the application</value></data>
 
   <!-- Onboarding (#4) -->
   <data name="Onboarding_WelcomeTitle" xml:space="preserve"><value>Welcome to XTimelineViewer</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -83,7 +83,7 @@
 
   <!-- Timeline pane settings dialog -->
   <data name="Timeline_Settings_Title" xml:space="preserve"><value>設定</value></data>
-  <data name="Timeline_Profile" xml:space="preserve"><value>プロファイル（試験機能）</value></data>
+  <data name="Timeline_Profile" xml:space="preserve"><value>プロファイル</value></data>
   <data name="Timeline_Width" xml:space="preserve"><value>タイムラインの幅（px）</value></data>
   <data name="Timeline_Sidebar" xml:space="preserve"><value>X のサイドバー</value></data>
   <data name="Timeline_Compose" xml:space="preserve"><value>投稿画面</value></data>
@@ -131,7 +131,7 @@
   <data name="Profiles_Name" xml:space="preserve"><value>名前</value></data>
   <data name="Profiles_BadgeColor" xml:space="preserve"><value>バッジの色</value></data>
   <data name="Profiles_BadgeText" xml:space="preserve"><value>バッジテキスト</value></data>
-  <data name="Profiles_DefaultDescription" xml:space="preserve"><value>既定のプロファイル</value></data>
+  <data name="Profiles_DefaultDescription" xml:space="preserve"><value>アプリケーションが利用する内部プロファイルです</value></data>
 
   <!-- Onboarding (#4) -->
   <data name="Onboarding_WelcomeTitle" xml:space="preserve"><value>XTimelineViewer へようこそ</value></data>

--- a/Views/MainWindow.Post.cs
+++ b/Views/MainWindow.Post.cs
@@ -96,8 +96,9 @@ namespace XTimelineViewer.Views
         /// <summary>投稿に使用するプロファイル ID を決定する。</summary>
         private string ResolveComposeProfileId()
         {
-            // 前回使用したプロファイルが存在すればそれを使う
+            // 前回使用したプロファイルが存在し、default でなければそれを使う
             if (_appSettings.LastUsedProfileId is { } last &&
+                last != "default" &&
                 _profiles.Any(p => p.Id == last))
                 return last;
 
@@ -118,9 +119,11 @@ namespace XTimelineViewer.Views
             };
 
             int selectedIndex = 0;
+            int comboIdx = 0;
             for (int i = 0; i < _profiles.Count; i++)
             {
                 var profile = _profiles[i];
+                if (profile.Id == "default") continue;
                 var color = GetProfileColor(profile, profile.Id);
                 var item = new ComboBoxItem
                 {
@@ -148,7 +151,8 @@ namespace XTimelineViewer.Views
                     },
                 };
                 combo.Items.Add(item);
-                if (profile.Id == selectedProfileId) selectedIndex = i;
+                if (profile.Id == selectedProfileId) selectedIndex = comboIdx;
+                comboIdx++;
             }
 
             combo.SelectedIndex = selectedIndex;

--- a/Views/MainWindow.Timeline.cs
+++ b/Views/MainWindow.Timeline.cs
@@ -403,7 +403,7 @@ namespace XTimelineViewer.Views
                 };
 
                 var profileBox = new ComboBox { MinWidth = 200 };
-                foreach (var p in _profiles)
+                foreach (var p in _profiles.Where(p => p.Id != "default"))
                     profileBox.Items.Add(new ComboBoxItem { Content = p.Name, Tag = p.Id });
                 profileBox.SelectedItem = profileBox.Items
                     .OfType<ComboBoxItem>()

--- a/Views/Settings/ProfilesPage.xaml.cs
+++ b/Views/Settings/ProfilesPage.xaml.cs
@@ -39,8 +39,11 @@ namespace XTimelineViewer.Views.Settings
 
             for (int idx = 0; idx < profiles.Count; idx++)
             {
-                var card = BuildProfileCard(profiles[idx], colors);
-                RootPanel.Children.Insert(RootPanel.Children.Count - 1, card);
+                var profile = profiles[idx];
+                var element = profile.Id == "default"
+                    ? (UIElement)BuildDefaultCard()
+                    : BuildProfileCard(profile, colors);
+                RootPanel.Children.Insert(RootPanel.Children.Count - 1, element);
             }
         }
 
@@ -147,44 +150,49 @@ namespace XTimelineViewer.Views.Settings
             expander.Items.Add(colorCard);
             expander.Items.Add(badgeTextCard);
 
-            // ── アクションボタン（初期化/削除）──
-            if (profile.Id == "default")
+            // ── 削除ボタン ──
+            var deleteBtn = new Button { Content = R.Get("Profile_Delete") };
+            var capturedProfile = profile;
+            deleteBtn.Click += async (_, _) =>
             {
-                var resetBtn = new Button
+                var count = _parent?.GetTimelineCount?.Invoke(capturedProfile.Id) ?? 0;
+                var dlg = new ContentDialog
                 {
-                    Content   = R.Get("Profile_Reset"),
-                    IsEnabled = false,
+                    Title             = R.Get("Profile_DeleteConfirmTitle"),
+                    Content           = string.Format(R.Get("Profile_DeleteConfirmBody"), count),
+                    PrimaryButtonText = R.Get("Profile_DeleteConfirm"),
+                    CloseButtonText   = R.Get("Button_Cancel"),
+                    DefaultButton     = ContentDialogButton.Close,
+                    XamlRoot          = XamlRoot,
+                    RequestedTheme    = ((FrameworkElement)_parent!.Content).ActualTheme,
                 };
-                expander.Content = resetBtn;
-            }
-            else
-            {
-                var deleteBtn = new Button { Content = R.Get("Profile_Delete") };
-                var capturedProfile = profile;
-                deleteBtn.Click += async (_, _) =>
+                if (await dlg.ShowAsync() == ContentDialogResult.Primary)
                 {
-                    var count = _parent?.GetTimelineCount?.Invoke(capturedProfile.Id) ?? 0;
-                    var dlg = new ContentDialog
-                    {
-                        Title             = R.Get("Profile_DeleteConfirmTitle"),
-                        Content           = string.Format(R.Get("Profile_DeleteConfirmBody"), count),
-                        PrimaryButtonText = R.Get("Profile_DeleteConfirm"),
-                        CloseButtonText   = R.Get("Button_Cancel"),
-                        DefaultButton     = ContentDialogButton.Close,
-                        XamlRoot          = XamlRoot,
-                        RequestedTheme    = ((FrameworkElement)_parent!.Content).ActualTheme,
-                    };
-                    if (await dlg.ShowAsync() == ContentDialogResult.Primary)
-                    {
-                        if (_parent?.DeleteProfileAsync is not null)
-                            await _parent.DeleteProfileAsync(capturedProfile.Id);
-                        PopulateUI();
-                    }
-                };
-                expander.Content = deleteBtn;
-            }
+                    if (_parent?.DeleteProfileAsync is not null)
+                        await _parent.DeleteProfileAsync(capturedProfile.Id);
+                    PopulateUI();
+                }
+            };
+            expander.Content = deleteBtn;
 
             return expander;
+        }
+
+        /// <summary>default プロファイル用の簡素なカード（展開なし・編集不可）。</summary>
+        private CommunityToolkit.WinUI.Controls.SettingsCard BuildDefaultCard()
+        {
+            return new CommunityToolkit.WinUI.Controls.SettingsCard
+            {
+                Header      = "Default",
+                Description = R.Get("Profiles_DefaultDescription"),
+                HeaderIcon  = new FontIcon
+                {
+                    Glyph      = "",
+                    FontFamily = new FontFamily("Segoe Fluent Icons"),
+                    Opacity    = 0.5,
+                },
+                IsEnabled = false,
+            };
         }
 
         private void AddProfileBtn_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- プロファイル機能から「試験機能」ラベルを除去し、正式機能に昇格
- default プロファイルを投稿ダイアログ・タイムライン設定・プロファイル管理の各 UI から除外
- default プロファイルカードを編集不可の簡易表示（SettingsCard）に変更
- `ResolveComposeProfileId` が default を返さないよう修正（投稿ダイアログの未ログイン表示バグを解消）

## Test plan
- [x] 投稿ダイアログでログイン済みプロファイルのコンポーザーが正しく表示される
- [x] 投稿ダイアログのプロファイルセレクターに default が表示されない
- [x] タイムライン設定のプロファイルプルダウンに default が表示されない
- [x] 設定 → プロファイルで default が無効化された簡易カードで表示される

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)