### PR TITLE
fix: タイムライン追加時に名前付きプロファイルを自動選択 (#166)

### DIFF
--- a/Views/MainWindow.Timeline.cs
+++ b/Views/MainWindow.Timeline.cs
@@ -121,6 +121,13 @@ namespace XTimelineViewer.Views
 
         private void AddTimeline(TimelineConfig cfg)
         {
+            // ProfileId が未指定または default の場合、最初の名前付きプロファイルを割り当てる
+            if (cfg.ProfileId == "default")
+            {
+                var named = _profiles.FirstOrDefault(p => p.Id != "default");
+                if (named is not null) cfg.ProfileId = named.Id;
+            }
+
             _configs.Add(cfg);
             _ = SaveTimelinesAsync();
 


### PR DESCRIPTION
## Summary
- `AddTimeline` の入口で `ProfileId` が `default` の場合、最初の名前付きプロファイルに自動補完
- メニュー（Home / Notifications / Bookmarks）やドロップからのタイムライン追加で正しいプロファイルが使われるようになる

## Test plan
- [x] メニューからタイムラインを追加して、名前付きプロファイルが自動選択されることを確認
- [x] 既存タイムラインに影響がないことを確認

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)