### PR TITLE
chore: SeparateComposeEnv の残骸を完全に削除 (#18)

### DIFF
--- a/Models/Models.cs
+++ b/Models/Models.cs
@@ -33,7 +33,6 @@ namespace XTimelineViewer.Models
 
     public class AppSettings
     {
-        public bool    SeparateComposeEnv    { get; set; } = false;
         public bool    OpenComposerInBrowser { get; set; } = false;
         public bool    OpenTimestampInBrowser{ get; set; } = false;
         public string  Theme                 { get; set; } = "Default"; // "Light" | "Dark" | "Default"

--- a/Services/SettingsService.cs
+++ b/Services/SettingsService.cs
@@ -22,13 +22,11 @@ namespace XTimelineViewer.Services
             try
             {
                 var json = File.ReadAllText(filePath);
-                var settings = JsonSerializer.Deserialize<AppSettings>(json) ?? new();
-                settings.SeparateComposeEnv = false; // 廃止予定: 強制無効化 (#17)
-                return settings;
+                return JsonSerializer.Deserialize<AppSettings>(json) ?? new();
             }
             catch
             {
-                return new() { SeparateComposeEnv = false };
+                return new();
             }
         }
 

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -54,8 +54,6 @@
   <data name="Settings_Language_Description" xml:space="preserve"><value>Change the display language</value></data>
   <data name="Section_Experimental" xml:space="preserve"><value>Experimental Features</value></data>
   <data name="Section_About" xml:space="preserve"><value>About</value></data>
-  <data name="Settings_SeparateCompose" xml:space="preserve"><value>Open Composer in Separate Profile (Deprecated)</value></data>
-  <data name="Settings_SeparateCompose_Description" xml:space="preserve"><value>This feature has been deprecated</value></data>
   <data name="Settings_OpenComposerInBrowser" xml:space="preserve"><value>Open Composer in External Browser</value></data>
   <data name="Settings_OpenComposerInBrowser_Description" xml:space="preserve"><value>Open new posts in an external browser instead of the built-in composer</value></data>
   <data name="Settings_OpenTimestampInBrowser" xml:space="preserve"><value>Open Timestamp Links in External Browser</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -54,8 +54,6 @@
   <data name="Settings_Language_Description" xml:space="preserve"><value>アプリの表示言語を変更します</value></data>
   <data name="Section_Experimental" xml:space="preserve"><value>試験機能</value></data>
   <data name="Section_About" xml:space="preserve"><value>バージョン情報</value></data>
-  <data name="Settings_SeparateCompose" xml:space="preserve"><value>投稿画面を別プロファイルで開く（廃止予定）</value></data>
-  <data name="Settings_SeparateCompose_Description" xml:space="preserve"><value>この機能は廃止予定です</value></data>
   <data name="Settings_OpenComposerInBrowser" xml:space="preserve"><value>新規投稿を外部ブラウザーで開く</value></data>
   <data name="Settings_OpenComposerInBrowser_Description" xml:space="preserve"><value>内蔵のコンポーザーの代わりに外部ブラウザーで新規投稿を開きます</value></data>
   <data name="Settings_OpenTimestampInBrowser" xml:space="preserve"><value>タイムスタンプリンクを外部ブラウザーで開く</value></data>

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -99,7 +99,6 @@ namespace XTimelineViewer.Views
         private bool _extensionsLoaded = false;
         private readonly List<ExtensionInfo> _loadedExtensions = [];
         private readonly Dictionary<string, CoreWebView2Environment> _profileEnvs = [];
-        private CoreWebView2Environment? _composeEnv;
         private List<ProfileConfig> _profiles = [];
         private readonly Dictionary<WebView2, Grid>            _webViewToPane  = [];
         private readonly Dictionary<Grid, Action>              _paneToSetFocus = [];
@@ -211,19 +210,6 @@ namespace XTimelineViewer.Views
             _profileEnvs[profileId] = env;
             Debug.WriteLine($"[Profile] Env created: profileId={profileId}, UserDataFolder={env.UserDataFolder}");
             return env;
-        }
-
-        private static readonly string ComposeUserDataFolder = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "XTimelineViewer", "compose-profile");
-
-        private async Task<CoreWebView2Environment> GetOrCreateComposeEnvAsync()
-        {
-            if (_composeEnv is not null) return _composeEnv;
-            var options = new CoreWebView2EnvironmentOptions { AreBrowserExtensionsEnabled = false };
-            _composeEnv = await CoreWebView2Environment.CreateWithOptionsAsync(
-                "", userDataFolder: ComposeUserDataFolder, options);
-            return _composeEnv;
         }
 
         public MainWindow()

--- a/Views/Settings/ExperimentalPage.xaml
+++ b/Views/Settings/ExperimentalPage.xaml
@@ -10,14 +10,6 @@
                        Style="{StaticResource TitleTextBlockStyle}"
                        Margin="0,0,0,16"/>
 
-            <!-- Open Composer in Separate Profile (Deprecated) -->
-            <controls:SettingsCard x:Name="SeparateComposeCard" IsEnabled="False">
-                <controls:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE8A7;" FontFamily="Segoe Fluent Icons"/>
-                </controls:SettingsCard.HeaderIcon>
-                <ToggleSwitch x:Name="SeparateComposeToggle" IsOn="False" IsEnabled="False"/>
-            </controls:SettingsCard>
-
             <!-- Open Composer in External Browser -->
             <controls:SettingsCard x:Name="OpenComposerCard">
                 <controls:SettingsCard.HeaderIcon>

--- a/Views/Settings/ExperimentalPage.xaml.cs
+++ b/Views/Settings/ExperimentalPage.xaml.cs
@@ -34,10 +34,6 @@ namespace XTimelineViewer.Views.Settings
 
             PageTitle.Text = R.Get("Nav_Experimental");
 
-            // Separate Compose (Deprecated)
-            SeparateComposeCard.Header      = R.Get("Settings_SeparateCompose");
-            SeparateComposeCard.Description = R.Get("Settings_SeparateCompose_Description");
-
             // Open Composer in Browser
             OpenComposerCard.Header      = R.Get("Settings_OpenComposerInBrowser");
             OpenComposerCard.Description = R.Get("Settings_OpenComposerInBrowser_Description");

--- a/XTimelineViewer.Tests/Services/SettingsServiceTests.cs
+++ b/XTimelineViewer.Tests/Services/SettingsServiceTests.cs
@@ -50,15 +50,6 @@ public class SettingsServiceTests : IDisposable
         Assert.Equal("Default", s.Theme);
     }
 
-    [Fact]
-    public void LoadSettings_AlwaysDisablesSeparateComposeEnv()
-    {
-        File.WriteAllText(At("settings.json"), """{"SeparateComposeEnv":true}""");
-
-        var s = SettingsService.LoadSettings(At("settings.json"));
-        Assert.False(s.SeparateComposeEnv); // 廃止予定: 強制無効化 (#17)
-    }
-
     // ── SaveSettings / Round-trip ─────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary
- `AppSettings.SeparateComposeEnv` プロパティを削除
- `SettingsService` の強制無効化コード（`#17`）を削除
- Experimental ページから廃止済み UI カード（トグル）を削除
- `MainWindow` から未使用の `_composeEnv` / `GetOrCreateComposeEnvAsync` / `ComposeUserDataFolder` を削除
- 日英リソース文字列 `Settings_SeparateCompose` / `Settings_SeparateCompose_Description` を削除
- 対応するテスト `LoadSettings_AlwaysDisablesSeparateComposeEnv` を削除

## Test plan
- [x] ビルド成功（0 warnings, 0 errors）
- [x] テスト全21件パス
- [x] 設定 → Experimental に廃止済みカードが表示されないことを確認
- [x] アプリ全体の動作に影響がないことを確認

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)