### PR TITLE
refactor: 自動更新チェックを winget ベースに簡素化

### DIFF
--- a/Models/Models.cs
+++ b/Models/Models.cs
@@ -38,7 +38,6 @@ namespace XTimelineViewer.Models
         public string  Theme                 { get; set; } = "Default"; // "Light" | "Dark" | "Default"
         public int     AutoActivateMinutes   { get; set; } = 0;
         public string  Language              { get; set; } = "system";  // "system" | "ja-JP" | "en-US"
-        public string? LastUpdateCheck       { get; set; } = null;      // UTC ISO-8601
         public string? CachedLatestVersion   { get; set; } = null;      // "v1.4.0" など
         public bool    ShowAutoActivateLabel { get; set; } = false;
         public string  ExternalBrowser       { get; set; } = "system";  // "system" | "edge"

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -171,9 +171,7 @@
   <data name="CheckUpdate_Checking" xml:space="preserve"><value>Checking...</value></data>
   <data name="CheckUpdate_Latest" xml:space="preserve"><value>You're up to date</value></data>
   <data name="CheckUpdate_Available" xml:space="preserve"><value>{0} is available</value></data>
-  <data name="CheckUpdate_Download_Store" xml:space="preserve"><value>Update in Microsoft Store</value></data>
   <data name="CheckUpdate_Download_Winget" xml:space="preserve"><value>Exit and Update via winget</value></data>
-  <data name="CheckUpdate_Download_GitHub" xml:space="preserve"><value>Download from GitHub</value></data>
   <data name="CheckUpdate_Error" xml:space="preserve"><value>Update check failed</value></data>
   <data name="CheckUpdate_WingetTitle" xml:space="preserve"><value>Update via winget</value></data>
   <data name="CheckUpdate_WingetBody" xml:space="preserve"><value>The app will close and update via winget. Please restart the app manually after the update completes.</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -171,9 +171,7 @@
   <data name="CheckUpdate_Checking" xml:space="preserve"><value>確認中...</value></data>
   <data name="CheckUpdate_Latest" xml:space="preserve"><value>最新版です</value></data>
   <data name="CheckUpdate_Available" xml:space="preserve"><value>{0} が利用可能です</value></data>
-  <data name="CheckUpdate_Download_Store" xml:space="preserve"><value>Microsoft Store で更新</value></data>
   <data name="CheckUpdate_Download_Winget" xml:space="preserve"><value>winget で更新してアプリを終了</value></data>
-  <data name="CheckUpdate_Download_GitHub" xml:space="preserve"><value>GitHub でダウンロード</value></data>
   <data name="CheckUpdate_Error" xml:space="preserve"><value>確認に失敗しました</value></data>
   <data name="CheckUpdate_WingetTitle" xml:space="preserve"><value>winget でアップデート</value></data>
   <data name="CheckUpdate_WingetBody" xml:space="preserve"><value>アプリを終了して winget でアップデートします。完了後、アプリを手動で再起動してください。</value></data>

--- a/Views/MainWindow.Settings.cs
+++ b/Views/MainWindow.Settings.cs
@@ -102,8 +102,7 @@ namespace XTimelineViewer.Views
             }
             settingsWin.EdgeVersion = edgeVer;
             settingsWin.HasWinget = !PackageContext.IsPackaged && FindWinget() is not null;
-            settingsWin.FetchLatestReleaseAsync = FetchLatestReleaseAsync;
-            settingsWin.CheckIsUpdateAvailable = IsUpdateAvailable;
+            settingsWin.FetchWingetLatestVersionAsync = FetchWingetLatestVersionAsync;
             settingsWin.SaveSettingsOnly = SaveSettings;
             settingsWin.UpdateMenuBadge = UpdateMenuUpdateBadge;
             settingsWin.ExitAndRunWingetUpdate = () =>

--- a/Views/MainWindow.Updates.cs
+++ b/Views/MainWindow.Updates.cs
@@ -1,12 +1,9 @@
 using Microsoft.UI.Xaml;
 using System;
-using System.Globalization;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Net.Http;
-using System.Net.NetworkInformation;
 using System.Reflection;
-using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace XTimelineViewer.Views
@@ -15,42 +12,75 @@ namespace XTimelineViewer.Views
     {
         // ── Update check ─────────────────────────────────────────────────────
 
-        private static bool IsUpdateAvailable(Version current, Version latest)
+        /// <summary>
+        /// winget show --versions の出力から最新バージョンを取得する。
+        /// 失敗時は null を返す（winget 未インストール、ネットワーク不通、パース失敗など）。
+        /// </summary>
+        private static async Task<Version?> FetchWingetLatestVersionAsync()
         {
-            if (PackageContext.IsPackaged)
-                return latest.Major > current.Major
-                    || (latest.Major == current.Major && latest.Minor > current.Minor);
-            return latest > current;
-        }
-
-        private static async Task<(Version version, string tag, string releaseUrl)> FetchLatestReleaseAsync()
-        {
-            using var client = new HttpClient();
-            client.DefaultRequestHeaders.Add("User-Agent", "XTimelineViewer");
-            var json = await client.GetStringAsync(
-                "https://api.github.com/repos/daruyanagi/XTimelineViewer/releases/latest");
-            using var doc = JsonDocument.Parse(json);
-            var tag = doc.RootElement.GetProperty("tag_name").GetString()!;
-            var url = doc.RootElement.GetProperty("html_url").GetString()!;
-            return (new Version(tag.TrimStart('v')), tag, url);
-        }
-
-        private async Task CheckForUpdatesInBackgroundAsync()
-        {
-            await Task.Delay(3000);
-            if (!NetworkInterface.GetIsNetworkAvailable()) return;
-
-            if (_appSettings.LastUpdateCheck is { } raw
-                && DateTime.TryParse(raw, null, DateTimeStyles.RoundtripKind, out var last)
-                && (DateTime.UtcNow - last).TotalDays < 7)
-                return;
+            var winget = FindWinget();
+            if (winget is null) return null;
 
             try
             {
-                var (latest, tag, _) = await FetchLatestReleaseAsync();
+                var psi = new ProcessStartInfo
+                {
+                    FileName               = winget,
+                    Arguments              = "show daruyanagi.XTimelineViewer --versions --disable-interactivity",
+                    RedirectStandardOutput = true,
+                    UseShellExecute        = false,
+                    CreateNoWindow         = true,
+                };
+                using var proc = Process.Start(psi);
+                if (proc is null) return null;
+
+                var output = await proc.StandardOutput.ReadToEndAsync();
+                await proc.WaitForExitAsync();
+                if (proc.ExitCode != 0) return null;
+
+                // "---" 区切り線より後の行からバージョンを抽出
+                var lines = output.Split('\n', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+                var separatorIndex = Array.FindIndex(lines, l => l.StartsWith("---"));
+                if (separatorIndex < 0) return null;
+
+                // 区切り線の直後が最新バージョン（降順表示）
+                for (int i = separatorIndex + 1; i < lines.Length; i++)
+                {
+                    if (Version.TryParse(lines[i], out var version))
+                        return version;
+                }
+
+                return null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// アプリ起動後にアイドルで更新チェックを行う。
+        /// winget ベースで確認し、MSIX (Store) 版や winget のない環境ではスキップする。
+        /// </summary>
+        private async Task CheckForUpdatesInBackgroundAsync()
+        {
+            await Task.Delay(5000);
+
+            // MSIX 版は Store の自動更新に任せる
+            if (PackageContext.IsPackaged) return;
+
+            // winget がなければチェック不要
+            if (FindWinget() is null) return;
+
+            try
+            {
+                var latest = await FetchWingetLatestVersionAsync();
+                if (latest is null) return;
+
                 var current = Assembly.GetExecutingAssembly().GetName().Version!;
-                _appSettings.LastUpdateCheck     = DateTime.UtcNow.ToString("O");
-                _appSettings.CachedLatestVersion = IsUpdateAvailable(current, latest) ? tag : null;
+                _appSettings.CachedLatestVersion = latest > current
+                    ? $"v{latest.ToString(3)}"
+                    : null;
                 SaveSettings();
                 UpdateMenuUpdateBadge();
             }

--- a/Views/Settings/AboutPage.xaml.cs
+++ b/Views/Settings/AboutPage.xaml.cs
@@ -134,7 +134,10 @@ namespace XTimelineViewer.Views.Settings
         {
             if (_parent is null) return;
 
-            string? latestReleaseUrl = null;
+            // MSIX 版は Store の自動更新に任せる / winget がなければ更新チェック不要
+            bool hasWinget = _parent.HasWinget;
+            if (PackageContext.IsPackaged || !hasWinget) return;
+
             var settings = _parent.Settings;
 
             var statusText = new TextBlock
@@ -144,15 +147,9 @@ namespace XTimelineViewer.Views.Settings
                 Visibility = Visibility.Collapsed,
             };
 
-            bool hasWinget = _parent.HasWinget;
-            var updateBtnLabel = PackageContext.IsPackaged
-                ? R.Get("CheckUpdate_Download_Store")
-                : hasWinget
-                    ? R.Get("CheckUpdate_Download_Winget")
-                    : R.Get("CheckUpdate_Download_GitHub");
             var updateBtn = new Button
             {
-                Content    = updateBtnLabel,
+                Content    = R.Get("CheckUpdate_Download_Winget"),
                 Margin     = new Thickness(0, 4, 0, 0),
                 Visibility = Visibility.Collapsed,
             };
@@ -160,9 +157,8 @@ namespace XTimelineViewer.Views.Settings
             // キャッシュがあれば初期表示
             if (settings.CachedLatestVersion is { } cached
                 && Version.TryParse(cached.TrimStart('v'), out var cachedVersion)
-                && (_parent.CheckIsUpdateAvailable?.Invoke(currentVersion, cachedVersion) ?? false))
+                && cachedVersion > currentVersion)
             {
-                latestReleaseUrl      = $"{repoUrl}/releases/tag/{cached}";
                 statusText.Text       = string.Format(R.Get("CheckUpdate_Available"), cached);
                 statusText.Visibility = Visibility.Visible;
                 updateBtn.Visibility  = Visibility.Visible;
@@ -177,12 +173,11 @@ namespace XTimelineViewer.Views.Settings
                 updateBtn.Visibility  = Visibility.Collapsed;
                 try
                 {
-                    if (_parent.FetchLatestReleaseAsync is null) return;
-                    var (latest, tag, freshUrl) = await _parent.FetchLatestReleaseAsync();
-                    latestReleaseUrl = freshUrl;
-                    settings.LastUpdateCheck = DateTime.UtcNow.ToString("O");
-                    if (_parent.CheckIsUpdateAvailable?.Invoke(currentVersion, latest) ?? false)
+                    if (_parent.FetchWingetLatestVersionAsync is null) return;
+                    var latest = await _parent.FetchWingetLatestVersionAsync();
+                    if (latest is not null && latest > currentVersion)
                     {
+                        var tag = $"v{latest.ToString(3)}";
                         settings.CachedLatestVersion = tag;
                         statusText.Text      = string.Format(R.Get("CheckUpdate_Available"), tag);
                         updateBtn.Visibility = Visibility.Visible;
@@ -207,35 +202,21 @@ namespace XTimelineViewer.Views.Settings
 
             updateBtn.Click += async (_, _) =>
             {
-                var url = latestReleaseUrl ?? fallbackUrl;
-                if (PackageContext.IsPackaged)
+                var confirmDlg = new ContentDialog
                 {
-                    if (_parent.LaunchUriAsync is not null)
-                        await _parent.LaunchUriAsync(new Uri("ms-windows-store://pdp/?ProductId=9P308HB5BLJ1"));
-                }
-                else if (hasWinget)
-                {
-                    var confirmDlg = new ContentDialog
+                    Title             = R.Get("CheckUpdate_WingetTitle"),
+                    Content           = new TextBlock
                     {
-                        Title             = R.Get("CheckUpdate_WingetTitle"),
-                        Content           = new TextBlock
-                        {
-                            Text         = R.Get("CheckUpdate_WingetBody"),
-                            TextWrapping = TextWrapping.Wrap,
-                        },
-                        PrimaryButtonText = R.Get("CheckUpdate_WingetConfirm"),
-                        CloseButtonText   = R.Get("Button_Cancel"),
-                        XamlRoot          = XamlRoot,
-                        RequestedTheme    = ((FrameworkElement)_parent.Content).ActualTheme,
-                    };
-                    if (await confirmDlg.ShowAsync() != ContentDialogResult.Primary) return;
-                    _parent.ExitAndRunWingetUpdate?.Invoke();
-                }
-                else
-                {
-                    if (_parent.LaunchUriAsync is not null)
-                        await _parent.LaunchUriAsync(new Uri(url));
-                }
+                        Text         = R.Get("CheckUpdate_WingetBody"),
+                        TextWrapping = TextWrapping.Wrap,
+                    },
+                    PrimaryButtonText = R.Get("CheckUpdate_WingetConfirm"),
+                    CloseButtonText   = R.Get("Button_Cancel"),
+                    XamlRoot          = XamlRoot,
+                    RequestedTheme    = ((FrameworkElement)_parent.Content).ActualTheme,
+                };
+                if (await confirmDlg.ShowAsync() != ContentDialogResult.Primary) return;
+                _parent.ExitAndRunWingetUpdate?.Invoke();
             };
 
             var updateCard = new CommunityToolkit.WinUI.Controls.SettingsCard

--- a/Views/SettingsWindow.xaml.cs
+++ b/Views/SettingsWindow.xaml.cs
@@ -63,11 +63,8 @@ namespace XTimelineViewer.Views
         /// <summary>winget が利用可能かどうか（unpackaged のみ意味がある）。</summary>
         internal bool HasWinget { get; set; }
 
-        /// <summary>最新リリース情報を取得するコールバック。</summary>
-        internal Func<Task<(Version version, string tag, string releaseUrl)>>? FetchLatestReleaseAsync { get; set; }
-
-        /// <summary>バージョン比較で更新が利用可能かを判定するコールバック。</summary>
-        internal Func<Version, Version, bool>? CheckIsUpdateAvailable { get; set; }
+        /// <summary>winget から最新バージョンを取得するコールバック。</summary>
+        internal Func<Task<Version?>>? FetchWingetLatestVersionAsync { get; set; }
 
         /// <summary>設定のみ保存する（テーマ適用等はしない）コールバック。</summary>
         internal Action? SaveSettingsOnly { get; set; }


### PR DESCRIPTION
## Summary

Closes #171

- GitHub API (`releases/latest`) ベースの更新チェックを廃止し、`winget show --versions` でバージョンを直接取得する方式に変更
- MSIX (Store) 版は Store の自動更新に任せ、更新チェック UI を非表示に
- winget のない環境では更新チェック機能自体をスキップ

## 変更内容

| ファイル | 変更 |
|---|---|
| `Views/MainWindow.Updates.cs` | `FetchLatestReleaseAsync`（GitHub API）→ `FetchWingetLatestVersionAsync`（winget CLI）に書き換え。`IsUpdateAvailable` 関数を削除し、単純な `Version` 比較に |
| `Views/Settings/AboutPage.xaml.cs` | `BuildUpdateSection` を簡素化 — Store/GitHub ボタン分岐を削除し winget 一本に。MSIX/winget なし環境ではセクション自体を非表示 |
| `Views/SettingsWindow.xaml.cs` | `FetchLatestReleaseAsync` / `CheckIsUpdateAvailable` コールバックを `FetchWingetLatestVersionAsync` に統合 |
| `Views/MainWindow.Settings.cs` | コールバック配線を新 API に更新 |
| `Models/Models.cs` | 不要になった `LastUpdateCheck` プロパティを削除 |
| `Strings/ja-JP/Resources.resw` | `CheckUpdate_Download_Store`, `CheckUpdate_Download_GitHub` を削除 |
| `Strings/en-US/Resources.resw` | 同上 |

## 背景

GitHub タグの公開と winget への登録にはタイムラグがあり、GitHub API で新バージョンを検出しても winget でインストールできない期間が発生していた。更新チェック自体を winget ベースにすることで「検出＝即インストール可能」を保証する。

## Test plan

- [ ] 設定 → バージョン情報 → 「更新を確認」ボタンが表示される（winget がある環境）
- [ ] 「更新を確認」クリックで winget ベースのバージョンチェックが動作する
- [ ] 更新がある場合「winget で更新してアプリを終了」ボタンが表示される
- [ ] MSIX 版では更新セクションが非表示になる
- [ ] ビルド成功・全テスト（21件）合格を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)