### PR TITLE
chore: 未使用の RestartRequired リソースキーを削除

### DIFF
--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -68,7 +68,7 @@
   <data name="Language_System" xml:space="preserve"><value>System Language</value></data>
   <data name="Language_JA" xml:space="preserve"><value>日本語</value></data>
   <data name="Language_EN" xml:space="preserve"><value>English</value></data>
-  <data name="RestartRequired" xml:space="preserve"><value>Language changed. The change will take effect on the next launch.</value></data>
+
 
   <!-- Common buttons -->
   <data name="Button_Save" xml:space="preserve"><value>Save</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -68,7 +68,7 @@
   <data name="Language_System" xml:space="preserve"><value>システム言語</value></data>
   <data name="Language_JA" xml:space="preserve"><value>日本語</value></data>
   <data name="Language_EN" xml:space="preserve"><value>English</value></data>
-  <data name="RestartRequired" xml:space="preserve"><value>言語を変更しました。次回起動時に反映されます。</value></data>
+
 
   <!-- Common buttons -->
   <data name="Button_Save" xml:space="preserve"><value>保存</value></data>


### PR DESCRIPTION
## Summary

Closes #119

- 言語切り替えが即時反映になった (#117) ため不要になった `RestartRequired` リソースキーを削除
- `Strings/ja-JP/Resources.resw` と `Strings/en-US/Resources.resw` から各1行削除

## Test plan

- [ ] ビルド成功を確認済み
- [ ] コードからの参照がないことを grep で確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)