### PR TITLE
設定ページの表示順を使用頻度順に変更 (#176)

### DIFF
--- a/Views/SettingsWindow.xaml
+++ b/Views/SettingsWindow.xaml
@@ -17,9 +17,9 @@
                         <FontIcon Glyph="&#xE790;" FontFamily="Segoe Fluent Icons"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
-                <NavigationViewItem x:Name="NavExperimental" Tag="Experimental">
+                <NavigationViewItem x:Name="NavProfiles" Tag="Profiles">
                     <NavigationViewItem.Icon>
-                        <FontIcon Glyph="&#xE9A1;" FontFamily="Segoe Fluent Icons"/>
+                        <FontIcon Glyph="&#xE716;" FontFamily="Segoe Fluent Icons"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
                 <NavigationViewItem x:Name="NavExtensions" Tag="Extensions">
@@ -27,9 +27,9 @@
                         <FontIcon Glyph="&#xEA86;" FontFamily="Segoe Fluent Icons"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
-                <NavigationViewItem x:Name="NavProfiles" Tag="Profiles">
+                <NavigationViewItem x:Name="NavExperimental" Tag="Experimental">
                     <NavigationViewItem.Icon>
-                        <FontIcon Glyph="&#xE716;" FontFamily="Segoe Fluent Icons"/>
+                        <FontIcon Glyph="&#xE9A1;" FontFamily="Segoe Fluent Icons"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
             </NavigationView.MenuItems>


### PR DESCRIPTION
## Summary
- 設定ナビゲーションの並び順を使用頻度順に変更: 全般 → プロファイル → 拡張機能 → 試験機能

## Test plan
- [x] 設定画面を開き、左ナビの順番が 全般 → プロファイル → 拡張機能 → 試験機能 になっていること
- [ ] 各ページへの遷移が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)