### PR TITLE
プロファイル削除ボタンを Expander 内に移動 (#178)

### DIFF
--- a/Views/Settings/ProfilesPage.xaml.cs
+++ b/Views/Settings/ProfilesPage.xaml.cs
@@ -150,8 +150,13 @@ namespace XTimelineViewer.Views.Settings
             expander.Items.Add(colorCard);
             expander.Items.Add(badgeTextCard);
 
-            // ── 削除ボタン ──
-            var deleteBtn = new Button { Content = R.Get("Profile_Delete") };
+            // ── 削除ボタン（Expander 内の末尾に配置 #178） ──
+            var deleteBtn = new Button
+            {
+                Content             = R.Get("Profile_Delete"),
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                Foreground          = (Brush)Application.Current.Resources["SystemFillColorCriticalBrush"],
+            };
             var capturedProfile = profile;
             deleteBtn.Click += async (_, _) =>
             {
@@ -173,7 +178,12 @@ namespace XTimelineViewer.Views.Settings
                     PopulateUI();
                 }
             };
-            expander.Content = deleteBtn;
+            var deleteCard = new CommunityToolkit.WinUI.Controls.SettingsCard
+            {
+                Content                    = deleteBtn,
+                HorizontalContentAlignment = HorizontalAlignment.Stretch,
+            };
+            expander.Items.Add(deleteCard);
 
             return expander;
         }


### PR DESCRIPTION
## Summary
- プロファイル削除ボタンを Expander の Header 右側（展開矢印の隣）から、展開内の末尾に移動
- 誤操作防止のため赤文字で視覚的に警告

## Test plan
- [ ] プロファイルの Expander を展開し、末尾に赤文字の削除ボタンがあること
- [ ] Expander の Header 右側に削除ボタンがないこと
- [ ] 削除ボタンをクリックすると確認ダイアログが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)