### PR TITLE
投稿完了後にダイアログを自動で閉じる (#180)

### DIFF
--- a/Views/MainWindow.Post.cs
+++ b/Views/MainWindow.Post.cs
@@ -204,6 +204,19 @@ namespace XTimelineViewer.Views
                     dlg.Hide();
             };
 
+            // SPA 遷移では NavigationStarting が発火しないため、
+            // 投稿 API のレスポンスを監視して自動で閉じる (#180)
+            webView.CoreWebView2.WebResourceResponseReceived += (s, args) =>
+            {
+                if (!composerReady) return;
+                var uri = args.Request.Uri;
+                if (uri.Contains("/CreateTweet", StringComparison.OrdinalIgnoreCase) &&
+                    args.Response.StatusCode >= 200 && args.Response.StatusCode < 300)
+                {
+                    dlg.DispatcherQueue.TryEnqueue(() => dlg.Hide());
+                }
+            };
+
             webView.Source = new Uri("https://x.com/compose/post");
         }
 


### PR DESCRIPTION
## Summary
- `WebResourceResponseReceived` で X の `CreateTweet` API 成功レスポンスを検知し、投稿ダイアログを自動で閉じる
- 既存の `NavigationStarting` フックも維持（フォールバック）

## Test plan
- [x] 投稿ダイアログからポスト → 自動でダイアログが閉じる
- [x] ダイアログを手動で閉じる操作も引き続き動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)