### PR TITLE
feat: ツールバーに検索ボックスを追加 (#182)

### DIFF
--- a/Models/Models.cs
+++ b/Models/Models.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace XTimelineViewer.Models
 {
@@ -46,5 +47,6 @@ namespace XTimelineViewer.Models
         public string  ExternalBrowser       { get; set; } = "system";  // "system" | "edge"
         public string  EdgeProfileDirectory  { get; set; } = "";        // "Default" | "Profile 1" など
         public string? LastUsedProfileId     { get; set; } = null;      // 投稿画面で最後に使ったプロファイル
+        public List<string> SavedSearchQueries { get; set; } = [];        // 検索ボックスのサジェスト用
     }
 }

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -185,6 +185,12 @@
   <data name="Settings_DefaultListHeader" xml:space="preserve"><value>Notifications / Search / Bookmarks / List Header</value></data>
   <data name="Onboarding_DefaultsHint" xml:space="preserve"><value>You can change these later in Settings</value></data>
 
+  <!-- Search box (#182) -->
+  <data name="Search_Placeholder" xml:space="preserve"><value>Search</value></data>
+  <data name="Search_Tooltip" xml:space="preserve"><value>Search X</value></data>
+  <data name="Search_DialogTitle" xml:space="preserve"><value>Search Results</value></data>
+  <data name="Search_AddBtn" xml:space="preserve"><value>Add as Timeline</value></data>
+
   <!-- About dialog sections -->
   <data name="About_Copyright" xml:space="preserve"><value>© 2026 daruyanagi</value></data>
   <data name="About_Links" xml:space="preserve"><value>Links</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -185,6 +185,12 @@
   <data name="Settings_DefaultListHeader" xml:space="preserve"><value>通知・検索・ブックマーク・リストのヘッダー</value></data>
   <data name="Onboarding_DefaultsHint" xml:space="preserve"><value>これらの設定は後から変更できます</value></data>
 
+  <!-- Search box (#182) -->
+  <data name="Search_Placeholder" xml:space="preserve"><value>検索</value></data>
+  <data name="Search_Tooltip" xml:space="preserve"><value>X を検索</value></data>
+  <data name="Search_DialogTitle" xml:space="preserve"><value>検索結果</value></data>
+  <data name="Search_AddBtn" xml:space="preserve"><value>タイムラインとして追加</value></data>
+
   <!-- About dialog sections -->
   <data name="About_Copyright" xml:space="preserve"><value>© 2026 daruyanagi</value></data>
   <data name="About_Links" xml:space="preserve"><value>リンク</value></data>

--- a/Views/MainWindow.Post.cs
+++ b/Views/MainWindow.Post.cs
@@ -241,6 +241,9 @@ namespace XTimelineViewer.Views
                     else
                         _ = OpenPostDialogAsync(senderWebView);
                     break;
+                case "focusSearch":
+                    SearchBox.Focus(FocusState.Programmatic);
+                    break;
             }
         }
 

--- a/Views/MainWindow.Search.cs
+++ b/Views/MainWindow.Search.cs
@@ -1,0 +1,161 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Web.WebView2.Core;
+
+namespace XTimelineViewer.Views
+{
+    public sealed partial class MainWindow : Window
+    {
+        private void SearchBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
+        {
+            if (args.ChosenSuggestion is string chosen)
+            {
+                _ = OpenSearchDialogAsync(chosen);
+                return;
+            }
+            var query = (args.QueryText ?? sender.Text)?.Trim();
+            if (string.IsNullOrEmpty(query)) return;
+            _ = OpenSearchDialogAsync(query);
+        }
+
+        private void SearchBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+        {
+            if (args.Reason != AutoSuggestionBoxTextChangeReason.UserInput) return;
+            var text = sender.Text?.Trim() ?? "";
+            var saved = _appSettings.SavedSearchQueries;
+            if (saved.Count == 0)
+            {
+                sender.ItemsSource = null;
+                return;
+            }
+            var filtered = string.IsNullOrEmpty(text)
+                ? saved.ToList()
+                : saved.Where(q => q.Contains(text, StringComparison.OrdinalIgnoreCase)).ToList();
+            sender.ItemsSource = filtered.Count > 0 ? filtered : null;
+        }
+
+        private void SearchBox_SuggestionChosen(AutoSuggestBox sender, AutoSuggestBoxSuggestionChosenEventArgs args)
+        {
+            if (args.SelectedItem is string chosen)
+                sender.Text = chosen;
+        }
+
+        private async Task OpenSearchDialogAsync(string query)
+        {
+            var profileId = ResolveComposeProfileId();
+
+            var webView = new WebView2 { Width = 500, MinHeight = 520 };
+
+            var dlg = new ContentDialog
+            {
+                Title              = R.Get("Search_DialogTitle"),
+                Content            = webView,
+                PrimaryButtonText  = R.Get("Search_AddBtn"),
+                CloseButtonText    = R.Get("Button_Close"),
+                XamlRoot           = Content.XamlRoot,
+                DefaultButton      = ContentDialogButton.Primary,
+            };
+
+            string currentQuery = query;
+
+            await InitSearchWebView(webView, profileId, q => currentQuery = q);
+            webView.Source = new Uri(BuildSearchUrl(query));
+
+            foreach (var wv in _webViews)
+                wv.Visibility = Visibility.Collapsed;
+            try
+            {
+                var result = await ShowDialogAsync(dlg);
+                if (result == ContentDialogResult.Primary)
+                {
+                    var finalQuery = ExtractQueryFromUrl(webView.Source?.ToString()) ?? currentQuery;
+                    if (!string.IsNullOrEmpty(finalQuery))
+                    {
+                        var url = BuildSearchUrl(finalQuery);
+                        AddTimeline(CreateDefaultConfig(url));
+                        AddSavedSearchQuery(finalQuery);
+                    }
+                }
+            }
+            finally
+            {
+                foreach (var wv in _webViews)
+                    wv.Visibility = Visibility.Visible;
+
+                try { webView.Close(); } catch { }
+            }
+
+            SearchBox.Text = "";
+        }
+
+        private void AddSavedSearchQuery(string query)
+        {
+            var saved = _appSettings.SavedSearchQueries;
+            saved.Remove(query);
+            saved.Insert(0, query);
+            SaveSettings();
+        }
+
+        private async Task InitSearchWebView(WebView2 webView, string profileId, Action<string> onQueryChanged)
+        {
+            var env = await GetOrCreateProfileEnvAsync(profileId);
+            await webView.EnsureCoreWebView2Async(env);
+
+            var root = (FrameworkElement)Content;
+            var scheme = root.ActualTheme switch
+            {
+                ElementTheme.Light => CoreWebView2PreferredColorScheme.Light,
+                ElementTheme.Dark  => CoreWebView2PreferredColorScheme.Dark,
+                _                  => CoreWebView2PreferredColorScheme.Auto,
+            };
+            webView.CoreWebView2.Profile.PreferredColorScheme = scheme;
+
+            webView.CoreWebView2.NavigationCompleted += async (s, args) =>
+            {
+                if (!args.IsSuccess) return;
+
+                var q = ExtractQueryFromUrl(webView.Source?.ToString());
+                if (q is not null) onQueryChanged(q);
+
+                await webView.CoreWebView2.ExecuteScriptAsync("""
+                    (function() {
+                        var id = 'xtv-search-style';
+                        if (document.getElementById(id)) return;
+                        var s = document.createElement('style');
+                        s.id = id;
+                        s.textContent =
+                            '[data-testid="sidebarColumn"],' +
+                            'header[role="banner"]' +
+                            '{display:none!important}' +
+                            '[data-testid="primaryColumn"]{max-width:100%!important}';
+                        document.head.appendChild(s);
+                    })();
+                    """);
+            };
+        }
+
+        private static string BuildSearchUrl(string query)
+        {
+            var encoded = Uri.EscapeDataString(query);
+            return $"https://x.com/search?q={encoded}&src=typed_query";
+        }
+
+        private static string? ExtractQueryFromUrl(string? url)
+        {
+            if (url is null || !Uri.TryCreate(url, UriKind.Absolute, out var uri)) return null;
+            var qs = uri.Query;
+            if (string.IsNullOrEmpty(qs)) return null;
+            foreach (var pair in qs.TrimStart('?').Split('&'))
+            {
+                var parts = pair.Split('=', 2);
+                if (parts.Length == 2 && parts[0] == "q")
+                    return Uri.UnescapeDataString(parts[1]);
+            }
+            return null;
+        }
+    }
+}

--- a/Views/MainWindow.Search.cs
+++ b/Views/MainWindow.Search.cs
@@ -1,5 +1,6 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,6 +11,12 @@ namespace XTimelineViewer.Views
 {
     public sealed partial class MainWindow : Window
     {
+        private void FocusSearchBox_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+        {
+            SearchBox.Focus(FocusState.Programmatic);
+            args.Handled = true;
+        }
+
         private void SearchBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
         {
             if (args.ChosenSuggestion is string chosen)

--- a/Views/MainWindow.Search.cs
+++ b/Views/MainWindow.Search.cs
@@ -41,19 +41,24 @@ namespace XTimelineViewer.Views
             }
             var filtered = string.IsNullOrEmpty(text)
                 ? saved.ToList()
-                : saved.Where(q => q.Contains(text, StringComparison.OrdinalIgnoreCase)).ToList();
+                : saved.Where(q => DecodeSearchPath(q).Contains(text, StringComparison.OrdinalIgnoreCase)).ToList();
             sender.ItemsSource = filtered.Count > 0 ? filtered : null;
         }
 
         private void SearchBox_SuggestionChosen(AutoSuggestBox sender, AutoSuggestBoxSuggestionChosenEventArgs args)
         {
             if (args.SelectedItem is string chosen)
-                sender.Text = chosen;
+                sender.Text = ExtractQueryFromSearchPath(chosen) ?? chosen;
         }
 
-        private async Task OpenSearchDialogAsync(string query)
+        private async Task OpenSearchDialogAsync(string input)
         {
             var profileId = ResolveComposeProfileId();
+
+            // サジェストからのクエリパス or 直接入力のキーワード
+            var initialUrl = input.StartsWith("/search?", StringComparison.OrdinalIgnoreCase)
+                ? "https://x.com" + input
+                : BuildSearchUrl(input);
 
             var webView = new WebView2 { Width = 500, MinHeight = 520 };
 
@@ -67,10 +72,8 @@ namespace XTimelineViewer.Views
                 DefaultButton      = ContentDialogButton.Primary,
             };
 
-            string currentQuery = query;
-
-            await InitSearchWebView(webView, profileId, q => currentQuery = q);
-            webView.Source = new Uri(BuildSearchUrl(query));
+            await InitSearchWebView(webView, profileId);
+            webView.Source = new Uri(initialUrl);
 
             foreach (var wv in _webViews)
                 wv.Visibility = Visibility.Collapsed;
@@ -79,12 +82,13 @@ namespace XTimelineViewer.Views
                 var result = await ShowDialogAsync(dlg);
                 if (result == ContentDialogResult.Primary)
                 {
-                    var finalQuery = ExtractQueryFromUrl(webView.Source?.ToString()) ?? currentQuery;
-                    if (!string.IsNullOrEmpty(finalQuery))
+                    var currentUrl = webView.Source?.ToString();
+                    if (currentUrl is not null && ExtractQueryFromUrl(currentUrl) is not null)
                     {
-                        var url = BuildSearchUrl(finalQuery);
-                        AddTimeline(CreateDefaultConfig(url));
-                        AddSavedSearchQuery(finalQuery);
+                        AddTimeline(CreateDefaultConfig(currentUrl));
+                        var searchPath = ExtractSearchPath(currentUrl);
+                        if (searchPath is not null)
+                            AddSavedSearchQuery(searchPath);
                     }
                 }
             }
@@ -99,15 +103,15 @@ namespace XTimelineViewer.Views
             SearchBox.Text = "";
         }
 
-        private void AddSavedSearchQuery(string query)
+        private void AddSavedSearchQuery(string searchPath)
         {
             var saved = _appSettings.SavedSearchQueries;
-            saved.Remove(query);
-            saved.Insert(0, query);
+            saved.Remove(searchPath);
+            saved.Insert(0, searchPath);
             SaveSettings();
         }
 
-        private async Task InitSearchWebView(WebView2 webView, string profileId, Action<string> onQueryChanged)
+        private async Task InitSearchWebView(WebView2 webView, string profileId)
         {
             var env = await GetOrCreateProfileEnvAsync(profileId);
             await webView.EnsureCoreWebView2Async(env);
@@ -124,10 +128,6 @@ namespace XTimelineViewer.Views
             webView.CoreWebView2.NavigationCompleted += async (s, args) =>
             {
                 if (!args.IsSuccess) return;
-
-                var q = ExtractQueryFromUrl(webView.Source?.ToString());
-                if (q is not null) onQueryChanged(q);
-
                 await webView.CoreWebView2.ExecuteScriptAsync("""
                     (function() {
                         var id = 'xtv-search-style';
@@ -151,6 +151,22 @@ namespace XTimelineViewer.Views
             return $"https://x.com/search?q={encoded}&src=typed_query";
         }
 
+        /// <summary>URL からクエリパス部分を抽出する（例: /search?q=test&amp;f=live）。src= は除外。</summary>
+        private static string? ExtractSearchPath(string? url)
+        {
+            if (url is null || !Uri.TryCreate(url, UriKind.Absolute, out var uri)) return null;
+            if (!uri.AbsolutePath.Equals("/search", StringComparison.OrdinalIgnoreCase)) return null;
+            var qs = uri.Query;
+            if (string.IsNullOrEmpty(qs)) return null;
+            var meaningful = qs.TrimStart('?').Split('&')
+                .Where(p => !p.StartsWith("src=", StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+            return meaningful.Length > 0
+                ? "/search?" + string.Join("&", meaningful)
+                : null;
+        }
+
+        /// <summary>URL から q= パラメータの値を抽出する。</summary>
         private static string? ExtractQueryFromUrl(string? url)
         {
             if (url is null || !Uri.TryCreate(url, UriKind.Absolute, out var uri)) return null;
@@ -163,6 +179,16 @@ namespace XTimelineViewer.Views
                     return Uri.UnescapeDataString(parts[1]);
             }
             return null;
+        }
+
+        /// <summary>クエリパスをデコードして表示用文字列を返す。x:Bind から呼ばれる。</summary>
+        public static string DecodeSearchPath(string searchPath)
+            => Uri.UnescapeDataString(searchPath);
+
+        /// <summary>クエリパス（/search?q=...&amp;f=live）から q= の値を抽出する。</summary>
+        private static string? ExtractQueryFromSearchPath(string searchPath)
+        {
+            return ExtractQueryFromUrl("https://x.com" + searchPath);
         }
     }
 }

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -5,6 +5,10 @@
     Title="XTimelineViewer">
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <Grid.KeyboardAccelerators>
+            <KeyboardAccelerator Key="F" Modifiers="Control" Invoked="FocusSearchBox_Invoked"/>
+            <KeyboardAccelerator Key="F3" Invoked="FocusSearchBox_Invoked"/>
+        </Grid.KeyboardAccelerators>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
@@ -41,11 +45,7 @@
                             IsEnabled="{x:Bind ViewModel.HasNamedProfiles, Mode=OneWay}"
                             QuerySubmitted="SearchBox_QuerySubmitted"
                             TextChanged="SearchBox_TextChanged"
-                            SuggestionChosen="SearchBox_SuggestionChosen">
-                <AutoSuggestBox.KeyboardAccelerators>
-                    <KeyboardAccelerator Key="F" Modifiers="Control"/>
-                </AutoSuggestBox.KeyboardAccelerators>
-            </AutoSuggestBox>
+                            SuggestionChosen="SearchBox_SuggestionChosen"/>
             <StackPanel x:Name="RightToolbar"
                         Orientation="Horizontal"
                         Spacing="4"

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -2,6 +2,7 @@
     x:Class="XTimelineViewer.Views.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:XTimelineViewer.Views"
     Title="XTimelineViewer">
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
@@ -45,7 +46,16 @@
                             IsEnabled="{x:Bind ViewModel.HasNamedProfiles, Mode=OneWay}"
                             QuerySubmitted="SearchBox_QuerySubmitted"
                             TextChanged="SearchBox_TextChanged"
-                            SuggestionChosen="SearchBox_SuggestionChosen"/>
+                            SuggestionChosen="SearchBox_SuggestionChosen"
+                            UpdateTextOnSelect="False">
+                <AutoSuggestBox.ItemTemplate>
+                    <DataTemplate x:DataType="x:String">
+                        <TextBlock Text="{x:Bind local:MainWindow.DecodeSearchPath((x:String))}"
+                                   TextTrimming="CharacterEllipsis"
+                                   ToolTipService.ToolTip="{x:Bind local:MainWindow.DecodeSearchPath((x:String))}"/>
+                    </DataTemplate>
+                </AutoSuggestBox.ItemTemplate>
+            </AutoSuggestBox>
             <StackPanel x:Name="RightToolbar"
                         Orientation="Horizontal"
                         Spacing="4"

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -33,6 +33,19 @@
                     <TextBlock x:Name="PostLabel" VerticalAlignment="Center"/>
                 </StackPanel>
             </Button>
+            <AutoSuggestBox x:Name="SearchBox"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Width="300"
+                            QueryIcon="Find"
+                            IsEnabled="{x:Bind ViewModel.HasNamedProfiles, Mode=OneWay}"
+                            QuerySubmitted="SearchBox_QuerySubmitted"
+                            TextChanged="SearchBox_TextChanged"
+                            SuggestionChosen="SearchBox_SuggestionChosen">
+                <AutoSuggestBox.KeyboardAccelerators>
+                    <KeyboardAccelerator Key="F" Modifiers="Control"/>
+                </AutoSuggestBox.KeyboardAccelerators>
+            </AutoSuggestBox>
             <StackPanel x:Name="RightToolbar"
                         Orientation="Horizontal"
                         Spacing="4"

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -159,9 +159,10 @@ namespace XTimelineViewer.Views
                         if (k === 'n')          { e.preventDefault(); window.chrome.webview.postMessage('newPost');   return; }
                         if (k === 'ArrowUp')    { e.preventDefault(); navigatePosts(-1); return; }
                         if (k === 'ArrowDown')  { e.preventDefault(); navigatePosts(1);  return; }
+                        if (k === 'f')          { e.preventDefault(); window.chrome.webview.postMessage('focusSearch'); return; }
                         if (k === 'r' && ni)    { e.preventDefault(); actOnPost('retweet',  'unretweet');      return; }
                         if (k === 'b' && ni)    { e.preventDefault(); actOnPost('bookmark', 'removeBookmark'); return; }
-                        if (k === 'f' && ni)    { e.preventDefault(); actOnPost('like',     'unlike');         return; }
+                        if (k === 'l' && ni)    { e.preventDefault(); actOnPost('like',     'unlike');         return; }
                     }
                     if (!c && !s && !a) {
                         if (k === 'Home'      && ni) { window.scrollTo({ top: 0, behavior: 'smooth' }); return; }

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -266,6 +266,10 @@ namespace XTimelineViewer.Views
             AddHomeIcon.Glyph          = GetTimelineGlyph(HomeTimelineUrl);
             AddNotificationsIcon.Glyph = GetTimelineGlyph(NotificationsTimelineUrl);
             AddBookmarksIcon.Glyph     = GetTimelineGlyph(BookmarksTimelineUrl);
+
+            SearchBox.PlaceholderText = R.Get("Search_Placeholder");
+            ToolTipService.SetToolTip(SearchBox, R.Get("Search_Tooltip"));
+            AutomationProperties.SetName(SearchBox, R.Get("Search_Tooltip"));
         }
 
         private async Task<ContentDialogResult> ShowDialogAsync(ContentDialog dlg)


### PR DESCRIPTION
## Summary
- ツールバー中央に AutoSuggestBox を追加（Ctrl+F でフォーカス）
- クエリ入力 → ContentDialog + WebView2 で X の検索結果を表示
- X ネイティブの検索タブ（話題/最新/ユーザー/メディア等）をそのまま利用可能
- 「タイムラインとして追加」ボタンで検索結果（タブ含む）をタイムラインに追加
- 追加したクエリは保存され、次回以降サジェストとして表示

## Test plan
- [x] 検索ボックスにクエリを入力して Enter → 検索結果ダイアログが表示される
- [x] X 内で検索タブ（最新/ユーザー/メディア）を切り替えられる
- [x] 「タイムラインとして追加」でタイムラインが追加される
- [x] タブを切り替えた状態で追加すると `&f=live` 等が反映される
- [x] 追加したクエリが次回検索時にサジェストされる
- [x] Ctrl+F で検索ボックスにフォーカスが移る
- [ ] プロファイルがない状態では検索ボックスが無効化される

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)