### PR TITLE
feat: 設定ダイアログに保存済み検索クエリの管理 UI を追加 (#184)

### DIFF
--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -190,6 +190,8 @@
   <data name="Search_Tooltip" xml:space="preserve"><value>Search X</value></data>
   <data name="Search_DialogTitle" xml:space="preserve"><value>Search Results</value></data>
   <data name="Search_AddBtn" xml:space="preserve"><value>Add as Timeline</value></data>
+  <data name="Settings_SavedQueries" xml:space="preserve"><value>Saved Search Queries</value></data>
+  <data name="Settings_SavedQueries_Description" xml:space="preserve"><value>Queries shown as suggestions in the search box</value></data>
 
   <!-- About dialog sections -->
   <data name="About_Copyright" xml:space="preserve"><value>© 2026 daruyanagi</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -190,6 +190,8 @@
   <data name="Search_Tooltip" xml:space="preserve"><value>X を検索</value></data>
   <data name="Search_DialogTitle" xml:space="preserve"><value>検索結果</value></data>
   <data name="Search_AddBtn" xml:space="preserve"><value>タイムラインとして追加</value></data>
+  <data name="Settings_SavedQueries" xml:space="preserve"><value>保存済み検索クエリ</value></data>
+  <data name="Settings_SavedQueries_Description" xml:space="preserve"><value>検索ボックスのサジェストに表示されるクエリ</value></data>
 
   <!-- About dialog sections -->
   <data name="About_Copyright" xml:space="preserve"><value>© 2026 daruyanagi</value></data>

--- a/Views/Settings/GeneralPage.xaml
+++ b/Views/Settings/GeneralPage.xaml
@@ -61,6 +61,13 @@
                     </controls:SettingsCard>
                 </controls:SettingsExpander.Items>
             </controls:SettingsExpander>
+
+            <!-- Saved Search Queries -->
+            <controls:SettingsExpander x:Name="SavedQueriesExpander">
+                <controls:SettingsExpander.HeaderIcon>
+                    <FontIcon Glyph="&#xE721;" FontFamily="Segoe Fluent Icons"/>
+                </controls:SettingsExpander.HeaderIcon>
+            </controls:SettingsExpander>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/Views/Settings/GeneralPage.xaml.cs
+++ b/Views/Settings/GeneralPage.xaml.cs
@@ -89,7 +89,57 @@ namespace XTimelineViewer.Views.Settings
                 ListHeaderToggle.IsOn       = !s.DefaultHideListHeader;
             }
 
+            // Saved Search Queries
+            SavedQueriesExpander.Header      = R.Get("Settings_SavedQueries");
+            SavedQueriesExpander.Description = R.Get("Settings_SavedQueries_Description");
+            RebuildSavedQueriesItems();
+
             _isInitializing = false;
+        }
+
+        private void RebuildSavedQueriesItems()
+        {
+            SavedQueriesExpander.Items.Clear();
+            if (_parent is null) return;
+
+            var saved = _parent.Settings.SavedSearchQueries;
+            if (saved.Count == 0)
+            {
+                SavedQueriesExpander.IsExpanded = false;
+                SavedQueriesExpander.IsEnabled  = false;
+                return;
+            }
+
+            SavedQueriesExpander.IsEnabled = true;
+
+            foreach (var path in saved)
+            {
+                var decoded = Uri.UnescapeDataString(path);
+
+                var deleteBtn = new Button
+                {
+                    Content = R.Get("Profile_Delete"),
+                    Tag     = path,
+                    Foreground = (Microsoft.UI.Xaml.Media.Brush)
+                        Application.Current.Resources["SystemFillColorCriticalBrush"],
+                };
+                deleteBtn.Click += SavedQueryDelete_Click;
+
+                var card = new CommunityToolkit.WinUI.Controls.SettingsCard
+                {
+                    Header  = decoded,
+                    Content = deleteBtn,
+                };
+                SavedQueriesExpander.Items.Add(card);
+            }
+        }
+
+        private void SavedQueryDelete_Click(object sender, RoutedEventArgs e)
+        {
+            if (_parent is null || sender is not Button btn || btn.Tag is not string path) return;
+            _parent.Settings.SavedSearchQueries.Remove(path);
+            _parent.NotifySettingsChanged();
+            RebuildSavedQueriesItems();
         }
 
         private void ThemeCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)


### PR DESCRIPTION
## Summary
- 設定 → 全般ページに「保存済み検索クエリ」セクションを追加
- SettingsExpander 内に保存済みクエリをデコード表示で一覧
- 各クエリに「削除」ボタンを配置し、個別に削除可能
- クエリがない場合は Expander を無効化
- #182 で検索ボックスのサジェストから直接削除できない問題の代替手段

## Test plan
- [x] 設定 → 全般 → 「保存済み検索クエリ」Expander が表示される
- [x] 保存済みクエリがデコード済み日本語で一覧表示される
- [x] 「削除」ボタンでクエリが削除され、一覧が即時更新される
- [x] 削除後、検索ボックスのサジェストからも消えている
- [x] クエリが0件の場合、Expander が無効化される

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)