### PR TITLE
fix: 保存済みクエリの削除を即時反映（データバインディング化）

### DIFF
--- a/Views/Settings/GeneralPage.xaml
+++ b/Views/Settings/GeneralPage.xaml
@@ -2,7 +2,8 @@
     x:Class="XTimelineViewer.Views.Settings.GeneralPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="using:CommunityToolkit.WinUI.Controls">
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls"
+    xmlns:local="using:XTimelineViewer.Views.Settings">
 
     <ScrollViewer Padding="24,16">
         <StackPanel Spacing="4">
@@ -63,10 +64,21 @@
             </controls:SettingsExpander>
 
             <!-- Saved Search Queries -->
-            <controls:SettingsExpander x:Name="SavedQueriesExpander">
+            <controls:SettingsExpander x:Name="SavedQueriesExpander"
+                                       ItemsSource="{x:Bind SavedQueries}">
                 <controls:SettingsExpander.HeaderIcon>
                     <FontIcon Glyph="&#xE721;" FontFamily="Segoe Fluent Icons"/>
                 </controls:SettingsExpander.HeaderIcon>
+                <controls:SettingsExpander.ItemTemplate>
+                    <DataTemplate x:DataType="local:SavedQueryItem">
+                        <controls:SettingsCard Header="{x:Bind Decoded}">
+                            <Button Content="{x:Bind DeleteLabel}"
+                                    Tag="{x:Bind Path}"
+                                    Click="SavedQueryDelete_Click"
+                                    Foreground="{ThemeResource SystemFillColorCriticalBrush}"/>
+                        </controls:SettingsCard>
+                    </DataTemplate>
+                </controls:SettingsExpander.ItemTemplate>
             </controls:SettingsExpander>
         </StackPanel>
     </ScrollViewer>

--- a/Views/Settings/GeneralPage.xaml.cs
+++ b/Views/Settings/GeneralPage.xaml.cs
@@ -3,12 +3,25 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 
 namespace XTimelineViewer.Views.Settings
 {
+    /// <summary>保存済み検索クエリの表示用アイテム。x:Bind から参照される。</summary>
+    public sealed class SavedQueryItem(string path, string decoded, string deleteLabel)
+    {
+        public string Path        { get; set; } = path;
+        public string Decoded     { get; set; } = decoded;
+        public string DeleteLabel { get; set; } = deleteLabel;
+    }
+
     public sealed partial class GeneralPage : Page
     {
+        /// <summary>x:Bind のバインディングソース。XAML から参照される。</summary>
+        public ObservableCollection<SavedQueryItem> SavedQueries { get; } = [];
+
         private static readonly string[] ThemeValues = ["Default", "Light", "Dark"];
         private static readonly string[] LangValues  = ["system", "ja-JP", "en-US"];
 
@@ -99,38 +112,26 @@ namespace XTimelineViewer.Views.Settings
 
         private void RebuildSavedQueriesItems()
         {
-            SavedQueriesExpander.Items.Clear();
+            SavedQueries.Clear();
             if (_parent is null) return;
 
-            var saved = _parent.Settings.SavedSearchQueries;
-            if (saved.Count == 0)
+            var deleteLabel = R.Get("Profile_Delete");
+            foreach (var path in _parent.Settings.SavedSearchQueries)
+                SavedQueries.Add(new SavedQueryItem(path, Uri.UnescapeDataString(path), deleteLabel));
+
+            UpdateSavedQueriesExpanderState();
+        }
+
+        private void UpdateSavedQueriesExpanderState()
+        {
+            if (SavedQueries.Count == 0)
             {
                 SavedQueriesExpander.IsExpanded = false;
                 SavedQueriesExpander.IsEnabled  = false;
-                return;
             }
-
-            SavedQueriesExpander.IsEnabled = true;
-
-            foreach (var path in saved)
+            else
             {
-                var decoded = Uri.UnescapeDataString(path);
-
-                var deleteBtn = new Button
-                {
-                    Content = R.Get("Profile_Delete"),
-                    Tag     = path,
-                    Foreground = (Microsoft.UI.Xaml.Media.Brush)
-                        Application.Current.Resources["SystemFillColorCriticalBrush"],
-                };
-                deleteBtn.Click += SavedQueryDelete_Click;
-
-                var card = new CommunityToolkit.WinUI.Controls.SettingsCard
-                {
-                    Header  = decoded,
-                    Content = deleteBtn,
-                };
-                SavedQueriesExpander.Items.Add(card);
+                SavedQueriesExpander.IsEnabled = true;
             }
         }
 
@@ -139,7 +140,10 @@ namespace XTimelineViewer.Views.Settings
             if (_parent is null || sender is not Button btn || btn.Tag is not string path) return;
             _parent.Settings.SavedSearchQueries.Remove(path);
             _parent.NotifySettingsChanged();
-            RebuildSavedQueriesItems();
+
+            var item = SavedQueries.FirstOrDefault(q => q.Path == path);
+            if (item is not null) SavedQueries.Remove(item);
+            UpdateSavedQueriesExpanderState();
         }
 
         private void ThemeCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)


### PR DESCRIPTION
## Summary
- #185 のフォローアップ。削除ボタンを押しても一覧が即時更新されない問題の修正
- `SettingsExpander.Items` の動的変更は描画に反映されないため、`ItemsSource` + `ObservableCollection<SavedQueryItem>` + `ItemTemplate` のデータバインディング構成に変更
- `ObservableCollection` からの削除で UI が即時更新される

## Test plan
- [x] 「削除」ボタンでクエリが一覧から即時に消える
- [x] 削除後、検索ボックスのサジェストからも消えている
- [x] 全件削除すると Expander が無効化される

Refs #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)