### PR TITLE
refactor: Models.cs をクラスごとにファイル分割 (#191)

### DIFF
--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -1,37 +1,7 @@
-using System;
 using System.Collections.Generic;
 
 namespace XTimelineViewer.Models
 {
-    internal record ExtensionInfo(
-        string Name,
-        string DirectoryPath,
-        string? IconPath,
-        string? OptionsPage,
-        string? HomepageUrl,
-        string? ExtensionId
-    );
-
-    internal class TimelineConfig
-    {
-        public string Url                { get; set; } = "";
-        public double Width              { get; set; } = 350;
-        public bool   HideSidebar       { get; set; } = false;
-        public bool   HideCompose       { get; set; } = true;
-        public bool   HideListHeader    { get; set; } = false;
-        public bool   HardReloadEnabled { get; set; } = false;
-        public int    HardReloadInterval{ get; set; } = 3;
-        public string ProfileId         { get; set; } = "default";
-    }
-
-    public class ProfileConfig
-    {
-        public string  Id             { get; set; } = Guid.NewGuid().ToString("N");
-        public string  Name           { get; set; } = "";
-        public int?    BadgeColorIndex{ get; set; }
-        public string? BadgeText      { get; set; }
-    }
-
     public class AppSettings
     {
         public bool    OpenComposerInBrowser { get; set; } = false;

--- a/Models/ExtensionInfo.cs
+++ b/Models/ExtensionInfo.cs
@@ -1,0 +1,11 @@
+namespace XTimelineViewer.Models
+{
+    internal record ExtensionInfo(
+        string Name,
+        string DirectoryPath,
+        string? IconPath,
+        string? OptionsPage,
+        string? HomepageUrl,
+        string? ExtensionId
+    );
+}

--- a/Models/ProfileConfig.cs
+++ b/Models/ProfileConfig.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace XTimelineViewer.Models
+{
+    public class ProfileConfig
+    {
+        public string  Id             { get; set; } = Guid.NewGuid().ToString("N");
+        public string  Name           { get; set; } = "";
+        public int?    BadgeColorIndex{ get; set; }
+        public string? BadgeText      { get; set; }
+    }
+}

--- a/Models/TimelineConfig.cs
+++ b/Models/TimelineConfig.cs
@@ -1,0 +1,14 @@
+namespace XTimelineViewer.Models
+{
+    internal class TimelineConfig
+    {
+        public string Url                { get; set; } = "";
+        public double Width              { get; set; } = 350;
+        public bool   HideSidebar       { get; set; } = false;
+        public bool   HideCompose       { get; set; } = true;
+        public bool   HideListHeader    { get; set; } = false;
+        public bool   HardReloadEnabled { get; set; } = false;
+        public int    HardReloadInterval{ get; set; } = 3;
+        public string ProfileId         { get; set; } = "default";
+    }
+}

--- a/XTimelineViewer.Tests/XTimelineViewer.Tests.csproj
+++ b/XTimelineViewer.Tests/XTimelineViewer.Tests.csproj
@@ -26,7 +26,7 @@
     UI 非依存なファイルだけをリンクして参照する。
   -->
   <ItemGroup>
-    <Compile Include="..\Models\Models.cs"             Link="Models\Models.cs" />
+    <Compile Include="..\Models\*.cs"                  Link="Models\%(Filename)%(Extension)" />
     <Compile Include="..\Services\SettingsService.cs" Link="Services\SettingsService.cs" />
     <Compile Include="..\Services\EdgeService.cs"    Link="Services\EdgeService.cs" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- `Models/Models.cs` を 1 クラス 1 ファイルに分割
  - `ExtensionInfo.cs` / `TimelineConfig.cs` / `ProfileConfig.cs` / `AppSettings.cs`
- 名前空間 `XTimelineViewer.Models` は変更なし（利用側の修正不要）
- テストプロジェクトのリンク参照を `Models\*.cs` ワイルドカードに変更（今後ファイルが増えても csproj 修正不要）

## Test plan
- [x] ビルド成功（0 警告 / 0 エラー）
- [x] ユニットテスト 21 件全パス

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)