### PR TITLE
refactor: URL 判定・クエリ解析の純粋ロジックをヘルパーに抽出 (#192)

### DIFF
--- a/Services/SearchQueryHelper.cs
+++ b/Services/SearchQueryHelper.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Linq;
+
+namespace XTimelineViewer.Services
+{
+    /// <summary>検索クエリ URL の構築・解析の純粋ロジック（UI 非依存）。</summary>
+    internal static class SearchQueryHelper
+    {
+        internal static string BuildSearchUrl(string query)
+        {
+            var encoded = Uri.EscapeDataString(query);
+            return $"https://x.com/search?q={encoded}&src=typed_query";
+        }
+
+        /// <summary>URL からクエリパス部分を抽出する（例: /search?q=test&amp;f=live）。src= は除外。</summary>
+        internal static string? ExtractSearchPath(string? url)
+        {
+            if (url is null || !Uri.TryCreate(url, UriKind.Absolute, out var uri)) return null;
+            if (!uri.AbsolutePath.Equals("/search", StringComparison.OrdinalIgnoreCase)) return null;
+            var qs = uri.Query;
+            if (string.IsNullOrEmpty(qs)) return null;
+            var meaningful = qs.TrimStart('?').Split('&')
+                .Where(p => !p.StartsWith("src=", StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+            return meaningful.Length > 0
+                ? "/search?" + string.Join("&", meaningful)
+                : null;
+        }
+
+        /// <summary>URL から q= パラメータの値を抽出する。</summary>
+        internal static string? ExtractQueryFromUrl(string? url)
+        {
+            if (url is null || !Uri.TryCreate(url, UriKind.Absolute, out var uri)) return null;
+            var qs = uri.Query;
+            if (string.IsNullOrEmpty(qs)) return null;
+            foreach (var pair in qs.TrimStart('?').Split('&'))
+            {
+                var parts = pair.Split('=', 2);
+                if (parts.Length == 2 && parts[0] == "q")
+                    return Uri.UnescapeDataString(parts[1]);
+            }
+            return null;
+        }
+
+        /// <summary>クエリパスをデコードして表示用文字列を返す。</summary>
+        internal static string DecodeSearchPath(string searchPath)
+            => Uri.UnescapeDataString(searchPath);
+
+        /// <summary>クエリパス（/search?q=...&amp;f=live）から q= の値を抽出する。</summary>
+        internal static string? ExtractQueryFromSearchPath(string searchPath)
+            => ExtractQueryFromUrl("https://x.com" + searchPath);
+    }
+}

--- a/Services/UrlHelper.cs
+++ b/Services/UrlHelper.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace XTimelineViewer.Services
+{
+    /// <summary>URL 判定・解析の純粋ロジック（UI 非依存）。</summary>
+    internal static class UrlHelper
+    {
+        internal static bool IsXUrl(string url) =>
+            url.Contains("x.com",       StringComparison.OrdinalIgnoreCase) ||
+            url.Contains("twitter.com", StringComparison.OrdinalIgnoreCase);
+
+        internal static bool IsOnBaseUrl(string currentUrl, string baseUrl)
+        {
+            if (!Uri.TryCreate(currentUrl, UriKind.Absolute, out var cur))  return false;
+            if (!Uri.TryCreate(baseUrl,    UriKind.Absolute, out var @base)) return false;
+            return string.Equals(cur.Host,         @base.Host,         StringComparison.OrdinalIgnoreCase)
+                && string.Equals(cur.AbsolutePath, @base.AbsolutePath, StringComparison.OrdinalIgnoreCase);
+        }
+
+        // グリフは Segoe Fluent Icons の私用領域(PUA)コードポイント。
+        // 生の PUA 文字を直書きするとエンコーディング事故で欠落するため (#122)、
+        // 必ず "\uXXXX" エスケープ表記で記述すること。
+        internal static string GetTimelineGlyph(string url)
+        {
+            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return "";
+            var p = uri.AbsolutePath;
+            if (p.StartsWith("/home"))                                return "\uE80F"; // Home
+            if (p.StartsWith("/notifications"))                       return "\uE7E7"; // Bell
+            if (p.StartsWith("/search") || p.StartsWith("/explore")) return "\uE71E"; // Search
+            if (p == "/bookmarks" || p.StartsWith("/bookmarks/") ||
+                p == "/i/bookmarks" || p.StartsWith("/i/bookmarks/")) return "\uE734"; // Bookmark
+            if (p.StartsWith("/i/lists/"))                            return "\uE71D"; // BulletedList
+            if (p.StartsWith("/messages"))                            return "\uE8BD"; // Chat
+            if (Regex.IsMatch(p, @"^/[^/]+$"))                        return "\uE77B"; // Contact
+            return "\uE774"; // Globe
+        }
+
+        private static bool IsProfilePath(string p) =>
+            Regex.IsMatch(p, @"^/[A-Za-z0-9_]+$") &&
+            !p.StartsWith("/home") && !p.StartsWith("/notifications") &&
+            !p.StartsWith("/search") && !p.StartsWith("/explore") &&
+            !p.StartsWith("/bookmarks") && !p.StartsWith("/messages") &&
+            !p.StartsWith("/i/");
+
+        internal static bool IsListHeaderApplicable(string url)
+        {
+            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return false;
+            var p = uri.AbsolutePath;
+            return p.StartsWith("/notifications") ||
+                   p.StartsWith("/search")        ||
+                   p.StartsWith("/explore")       ||
+                   p == "/bookmarks" || p.StartsWith("/bookmarks/") ||
+                   p == "/i/bookmarks" || p.StartsWith("/i/bookmarks/") ||
+                   p.StartsWith("/i/lists/")      ||
+                   IsProfilePath(p);
+        }
+
+        /// <summary>.url ショートカットファイルの行から URL を抽出する。</summary>
+        internal static string? ParseUrlShortcut(IEnumerable<string> lines)
+        {
+            foreach (var line in lines)
+                if (line.StartsWith("URL=", StringComparison.OrdinalIgnoreCase))
+                    return line[4..].Trim();
+            return null;
+        }
+    }
+}

--- a/Views/MainWindow.Search.cs
+++ b/Views/MainWindow.Search.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Web.WebView2.Core;
+using XTimelineViewer.Services;
 
 namespace XTimelineViewer.Views
 {
@@ -41,14 +42,14 @@ namespace XTimelineViewer.Views
             }
             var filtered = string.IsNullOrEmpty(text)
                 ? saved.ToList()
-                : saved.Where(q => DecodeSearchPath(q).Contains(text, StringComparison.OrdinalIgnoreCase)).ToList();
+                : saved.Where(q => SearchQueryHelper.DecodeSearchPath(q).Contains(text, StringComparison.OrdinalIgnoreCase)).ToList();
             sender.ItemsSource = filtered.Count > 0 ? filtered : null;
         }
 
         private void SearchBox_SuggestionChosen(AutoSuggestBox sender, AutoSuggestBoxSuggestionChosenEventArgs args)
         {
             if (args.SelectedItem is string chosen)
-                sender.Text = ExtractQueryFromSearchPath(chosen) ?? chosen;
+                sender.Text = SearchQueryHelper.ExtractQueryFromSearchPath(chosen) ?? chosen;
         }
 
         private async Task OpenSearchDialogAsync(string input)
@@ -58,7 +59,7 @@ namespace XTimelineViewer.Views
             // サジェストからのクエリパス or 直接入力のキーワード
             var initialUrl = input.StartsWith("/search?", StringComparison.OrdinalIgnoreCase)
                 ? "https://x.com" + input
-                : BuildSearchUrl(input);
+                : SearchQueryHelper.BuildSearchUrl(input);
 
             var webView = new WebView2 { Width = 500, MinHeight = 520 };
 
@@ -83,10 +84,10 @@ namespace XTimelineViewer.Views
                 if (result == ContentDialogResult.Primary)
                 {
                     var currentUrl = webView.Source?.ToString();
-                    if (currentUrl is not null && ExtractQueryFromUrl(currentUrl) is not null)
+                    if (currentUrl is not null && SearchQueryHelper.ExtractQueryFromUrl(currentUrl) is not null)
                     {
                         AddTimeline(CreateDefaultConfig(currentUrl));
-                        var searchPath = ExtractSearchPath(currentUrl);
+                        var searchPath = SearchQueryHelper.ExtractSearchPath(currentUrl);
                         if (searchPath is not null)
                             AddSavedSearchQuery(searchPath);
                     }
@@ -145,50 +146,8 @@ namespace XTimelineViewer.Views
             };
         }
 
-        private static string BuildSearchUrl(string query)
-        {
-            var encoded = Uri.EscapeDataString(query);
-            return $"https://x.com/search?q={encoded}&src=typed_query";
-        }
-
-        /// <summary>URL からクエリパス部分を抽出する（例: /search?q=test&amp;f=live）。src= は除外。</summary>
-        private static string? ExtractSearchPath(string? url)
-        {
-            if (url is null || !Uri.TryCreate(url, UriKind.Absolute, out var uri)) return null;
-            if (!uri.AbsolutePath.Equals("/search", StringComparison.OrdinalIgnoreCase)) return null;
-            var qs = uri.Query;
-            if (string.IsNullOrEmpty(qs)) return null;
-            var meaningful = qs.TrimStart('?').Split('&')
-                .Where(p => !p.StartsWith("src=", StringComparison.OrdinalIgnoreCase))
-                .ToArray();
-            return meaningful.Length > 0
-                ? "/search?" + string.Join("&", meaningful)
-                : null;
-        }
-
-        /// <summary>URL から q= パラメータの値を抽出する。</summary>
-        private static string? ExtractQueryFromUrl(string? url)
-        {
-            if (url is null || !Uri.TryCreate(url, UriKind.Absolute, out var uri)) return null;
-            var qs = uri.Query;
-            if (string.IsNullOrEmpty(qs)) return null;
-            foreach (var pair in qs.TrimStart('?').Split('&'))
-            {
-                var parts = pair.Split('=', 2);
-                if (parts.Length == 2 && parts[0] == "q")
-                    return Uri.UnescapeDataString(parts[1]);
-            }
-            return null;
-        }
-
-        /// <summary>クエリパスをデコードして表示用文字列を返す。x:Bind から呼ばれる。</summary>
+        /// <summary>クエリパスをデコードして表示用文字列を返す。x:Bind から呼ばれるため MainWindow に残している。</summary>
         public static string DecodeSearchPath(string searchPath)
-            => Uri.UnescapeDataString(searchPath);
-
-        /// <summary>クエリパス（/search?q=...&amp;f=live）から q= の値を抽出する。</summary>
-        private static string? ExtractQueryFromSearchPath(string searchPath)
-        {
-            return ExtractQueryFromUrl("https://x.com" + searchPath);
-        }
+            => SearchQueryHelper.DecodeSearchPath(searchPath);
     }
 }

--- a/Views/MainWindow.Timeline.cs
+++ b/Views/MainWindow.Timeline.cs
@@ -21,6 +21,7 @@ using Windows.Storage;
 using Windows.UI;
 
 using XTimelineViewer.Models;
+using XTimelineViewer.Services;
 
 namespace XTimelineViewer.Views
 {
@@ -77,7 +78,7 @@ namespace XTimelineViewer.Views
                         file.FileType.Equals(".url", StringComparison.OrdinalIgnoreCase))
                     {
                         var url = await ParseUrlShortcutAsync(file);
-                        if (url is not null && IsXUrl(url))
+                        if (url is not null && UrlHelper.IsXUrl(url))
                             AddTimeline(CreateDefaultConfig(url));
                     }
                 }
@@ -90,17 +91,11 @@ namespace XTimelineViewer.Views
             try
             {
                 var lines = await FileIO.ReadLinesAsync(file);
-                foreach (var line in lines)
-                    if (line.StartsWith("URL=", StringComparison.OrdinalIgnoreCase))
-                        return line[4..].Trim();
+                return UrlHelper.ParseUrlShortcut(lines);
             }
             catch { }
             return null;
         }
-
-        private static bool IsXUrl(string url) =>
-            url.Contains("x.com",       StringComparison.OrdinalIgnoreCase) ||
-            url.Contains("twitter.com", StringComparison.OrdinalIgnoreCase);
 
         // ── Quick add from menu (#120) ────────────────────────────────────────
 
@@ -192,7 +187,7 @@ namespace XTimelineViewer.Views
 
             var typeIcon = new FontIcon
             {
-                Glyph             = GetTimelineGlyph(cfg.Url),
+                Glyph             = UrlHelper.GetTimelineGlyph(cfg.Url),
                 FontFamily        = new FontFamily("Segoe Fluent Icons"),
                 FontSize          = 14,
                 Opacity           = 0.8,
@@ -377,7 +372,7 @@ namespace XTimelineViewer.Views
                     OffContent = R.Get("Toggle_Show")
                 };
 
-                var listHeaderApplicable = IsListHeaderApplicable(cfg.Url);
+                var listHeaderApplicable = UrlHelper.IsListHeaderApplicable(cfg.Url);
                 var hideListHeaderToggle = new ToggleSwitch
                 {
                     IsOn       = cfg.HideListHeader,

--- a/Views/MainWindow.WebView2.cs
+++ b/Views/MainWindow.WebView2.cs
@@ -21,50 +21,13 @@ using Windows.Storage;
 using Windows.UI;
 
 using XTimelineViewer.Models;
+using XTimelineViewer.Services;
 
 namespace XTimelineViewer.Views
 {
     public sealed partial class MainWindow : Window
     {
         // ── WebView2 init ─────────────────────────────────────────────────────
-
-        // グリフは Segoe Fluent Icons の私用領域(PUA)コードポイント。
-        // 生の PUA 文字を直書きするとエンコーディング事故で欠落するため (#122)、
-        // 必ず "\uXXXX" エスケープ表記で記述すること。
-        private static string GetTimelineGlyph(string url)
-        {
-            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return "";
-            var p = uri.AbsolutePath;
-            if (p.StartsWith("/home"))                                return "\uE80F"; // Home
-            if (p.StartsWith("/notifications"))                       return "\uE7E7"; // Bell
-            if (p.StartsWith("/search") || p.StartsWith("/explore")) return "\uE71E"; // Search
-            if (p == "/bookmarks" || p.StartsWith("/bookmarks/") ||
-                p == "/i/bookmarks" || p.StartsWith("/i/bookmarks/")) return "\uE734"; // Bookmark
-            if (p.StartsWith("/i/lists/"))                            return "\uE71D"; // BulletedList
-            if (p.StartsWith("/messages"))                            return "\uE8BD"; // Chat
-            if (System.Text.RegularExpressions.Regex.IsMatch(p, @"^/[^/]+$")) return "\uE77B"; // Contact
-            return "\uE774"; // Globe
-        }
-
-        private static bool IsProfilePath(string p) =>
-            System.Text.RegularExpressions.Regex.IsMatch(p, @"^/[A-Za-z0-9_]+$") &&
-            !p.StartsWith("/home") && !p.StartsWith("/notifications") &&
-            !p.StartsWith("/search") && !p.StartsWith("/explore") &&
-            !p.StartsWith("/bookmarks") && !p.StartsWith("/messages") &&
-            !p.StartsWith("/i/");
-
-        private static bool IsListHeaderApplicable(string url)
-        {
-            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return false;
-            var p = uri.AbsolutePath;
-            return p.StartsWith("/notifications") ||
-                   p.StartsWith("/search")        ||
-                   p.StartsWith("/explore")       ||
-                   p == "/bookmarks" || p.StartsWith("/bookmarks/") ||
-                   p == "/i/bookmarks" || p.StartsWith("/i/bookmarks/") ||
-                   p.StartsWith("/i/lists/")      ||
-                   IsProfilePath(p);
-        }
 
         private static string BuildHideListHeaderJs(bool hide) => $$"""
             (function(hide){
@@ -392,7 +355,7 @@ namespace XTimelineViewer.Views
                 await webView.EnsureCoreWebView2Async(env);
                 webView.CoreWebView2.SourceChanged += (s, e) =>
                 {
-                    bool diverged = !IsOnBaseUrl(webView.CoreWebView2.Source, cfg.Url);
+                    bool diverged = !UrlHelper.IsOnBaseUrl(webView.CoreWebView2.Source, cfg.Url);
                     if (diverged)
                     {
                         _urlDivergedWebViews.Add(webView);

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -264,9 +264,9 @@ namespace XTimelineViewer.Views
             AddNotificationsTimelineItem.Text = R.Get("Timeline_Notifications");
             AddBookmarksTimelineItem.Text     = R.Get("Timeline_Bookmarks");
             // アイコンは既存ペインと同じく URL 種別から導出して一貫性を保つ
-            AddHomeIcon.Glyph          = GetTimelineGlyph(HomeTimelineUrl);
-            AddNotificationsIcon.Glyph = GetTimelineGlyph(NotificationsTimelineUrl);
-            AddBookmarksIcon.Glyph     = GetTimelineGlyph(BookmarksTimelineUrl);
+            AddHomeIcon.Glyph          = UrlHelper.GetTimelineGlyph(HomeTimelineUrl);
+            AddNotificationsIcon.Glyph = UrlHelper.GetTimelineGlyph(NotificationsTimelineUrl);
+            AddBookmarksIcon.Glyph     = UrlHelper.GetTimelineGlyph(BookmarksTimelineUrl);
 
             SearchBox.PlaceholderText = R.Get("Search_Placeholder");
             ToolTipService.SetToolTip(SearchBox, R.Get("Search_Tooltip"));
@@ -285,14 +285,6 @@ namespace XTimelineViewer.Views
                 _dialogOpenCount--;
                 if (_dialogOpenCount == 0) RestartAutoActivateTimer();
             }
-        }
-
-        private static bool IsOnBaseUrl(string currentUrl, string baseUrl)
-        {
-            if (!Uri.TryCreate(currentUrl, UriKind.Absolute, out var cur))  return false;
-            if (!Uri.TryCreate(baseUrl,    UriKind.Absolute, out var @base)) return false;
-            return string.Equals(cur.Host,         @base.Host,         StringComparison.OrdinalIgnoreCase)
-                && string.Equals(cur.AbsolutePath, @base.AbsolutePath, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/XTimelineViewer.Tests/Services/SearchQueryHelperTests.cs
+++ b/XTimelineViewer.Tests/Services/SearchQueryHelperTests.cs
@@ -1,0 +1,80 @@
+using XTimelineViewer.Services;
+using Xunit;
+
+namespace XTimelineViewer.Tests.Services;
+
+public class SearchQueryHelperTests
+{
+    // ── BuildSearchUrl ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildSearchUrl_EncodesQuery()
+        => Assert.Equal(
+            "https://x.com/search?q=%E6%97%A5%E6%9C%AC%E4%BB%A3%E8%A1%A8&src=typed_query",
+            SearchQueryHelper.BuildSearchUrl("日本代表"));
+
+    [Fact]
+    public void BuildSearchUrl_EncodesSpecialChars()
+        => Assert.Equal(
+            "https://x.com/search?q=Ohtani%20AND%20MLB&src=typed_query",
+            SearchQueryHelper.BuildSearchUrl("Ohtani AND MLB"));
+
+    // ── ExtractQueryFromUrl ───────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("https://x.com/search?q=test&src=typed_query", "test")]
+    [InlineData("https://x.com/search?q=%E6%97%A5%E6%9C%AC",   "日本")]
+    [InlineData("https://x.com/search?f=live&q=test",          "test")]
+    [InlineData("https://x.com/home",                          null)]
+    [InlineData("not-a-url",                                   null)]
+    [InlineData(null,                                          null)]
+    public void ExtractQueryFromUrl_Works(string? url, string? expected)
+        => Assert.Equal(expected, SearchQueryHelper.ExtractQueryFromUrl(url));
+
+    // ── ExtractSearchPath ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void ExtractSearchPath_RemovesSrcParam()
+        => Assert.Equal(
+            "/search?q=test",
+            SearchQueryHelper.ExtractSearchPath("https://x.com/search?q=test&src=typed_query"));
+
+    [Fact]
+    public void ExtractSearchPath_KeepsFilterParam()
+        => Assert.Equal(
+            "/search?q=test&f=live",
+            SearchQueryHelper.ExtractSearchPath("https://x.com/search?q=test&f=live&src=typed_query"));
+
+    [Theory]
+    [InlineData("https://x.com/home")]
+    [InlineData("https://x.com/search")]
+    [InlineData("not-a-url")]
+    [InlineData(null)]
+    public void ExtractSearchPath_InvalidInput_ReturnsNull(string? url)
+        => Assert.Null(SearchQueryHelper.ExtractSearchPath(url));
+
+    // ── DecodeSearchPath ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void DecodeSearchPath_DecodesJapanese()
+        => Assert.Equal(
+            "/search?q=日本代表&f=live",
+            SearchQueryHelper.DecodeSearchPath("/search?q=%E6%97%A5%E6%9C%AC%E4%BB%A3%E8%A1%A8&f=live"));
+
+    // ── ExtractQueryFromSearchPath ────────────────────────────────────────────
+
+    [Fact]
+    public void ExtractQueryFromSearchPath_Works()
+        => Assert.Equal(
+            "日本代表",
+            SearchQueryHelper.ExtractQueryFromSearchPath("/search?q=%E6%97%A5%E6%9C%AC%E4%BB%A3%E8%A1%A8&f=live"));
+
+    // ── 往復（Build → Extract） ───────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("日本代表")]
+    [InlineData("Ohtani AND MLB")]
+    [InlineData("#ハッシュタグ from:user")]
+    public void BuildAndExtract_RoundTrip(string query)
+        => Assert.Equal(query, SearchQueryHelper.ExtractQueryFromUrl(SearchQueryHelper.BuildSearchUrl(query)));
+}

--- a/XTimelineViewer.Tests/Services/UrlHelperTests.cs
+++ b/XTimelineViewer.Tests/Services/UrlHelperTests.cs
@@ -1,0 +1,86 @@
+using XTimelineViewer.Services;
+using Xunit;
+
+namespace XTimelineViewer.Tests.Services;
+
+public class UrlHelperTests
+{
+    // ── IsXUrl ────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("https://x.com/home",           true)]
+    [InlineData("https://twitter.com/home",     true)]
+    [InlineData("https://X.COM/home",           true)]
+    [InlineData("https://example.com/",         false)]
+    [InlineData("https://nitter.net/home",      false)]
+    public void IsXUrl_Works(string url, bool expected)
+        => Assert.Equal(expected, UrlHelper.IsXUrl(url));
+
+    // ── IsOnBaseUrl ───────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("https://x.com/home",          "https://x.com/home",  true)]
+    [InlineData("https://x.com/home?foo=bar",  "https://x.com/home",  true)]  // クエリは無視
+    [InlineData("https://X.com/HOME",          "https://x.com/home",  true)]  // 大文字小文字を無視
+    [InlineData("https://x.com/notifications", "https://x.com/home",  false)]
+    [InlineData("https://twitter.com/home",    "https://x.com/home",  false)] // ホストが異なる
+    [InlineData("not-a-url",                   "https://x.com/home",  false)]
+    [InlineData("https://x.com/home",          "not-a-url",           false)]
+    public void IsOnBaseUrl_Works(string current, string baseUrl, bool expected)
+        => Assert.Equal(expected, UrlHelper.IsOnBaseUrl(current, baseUrl));
+
+    // ── GetTimelineGlyph ──────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("https://x.com/home",              "\uE80F")] // Home
+    [InlineData("https://x.com/notifications",     "\uE7E7")] // Bell
+    [InlineData("https://x.com/search?q=test",     "\uE71E")] // Search
+    [InlineData("https://x.com/explore",           "\uE71E")] // Search
+    [InlineData("https://x.com/i/bookmarks",       "\uE734")] // Bookmark
+    [InlineData("https://x.com/i/lists/123",       "\uE71D")] // BulletedList
+    [InlineData("https://x.com/messages",          "\uE8BD")] // Chat
+    [InlineData("https://x.com/daruyanagi",        "\uE77B")] // Contact
+    [InlineData("https://x.com/i/grok",            "\uE774")] // Globe (fallback)
+    [InlineData("not-a-url",                       "")]
+    public void GetTimelineGlyph_Works(string url, string expected)
+        => Assert.Equal(expected, UrlHelper.GetTimelineGlyph(url));
+
+    // ── IsListHeaderApplicable ────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("https://x.com/notifications",  true)]
+    [InlineData("https://x.com/search?q=test",  true)]
+    [InlineData("https://x.com/explore",        true)]
+    [InlineData("https://x.com/i/bookmarks",    true)]
+    [InlineData("https://x.com/i/lists/123",    true)]
+    [InlineData("https://x.com/daruyanagi",     true)]  // プロファイルページ
+    [InlineData("https://x.com/home",           false)]
+    [InlineData("https://x.com/messages",       false)]
+    [InlineData("https://x.com/i/grok",         false)]
+    [InlineData("not-a-url",                    false)]
+    public void IsListHeaderApplicable_Works(string url, bool expected)
+        => Assert.Equal(expected, UrlHelper.IsListHeaderApplicable(url));
+
+    // ── ParseUrlShortcut ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void ParseUrlShortcut_ExtractsUrl()
+    {
+        string[] lines = ["[InternetShortcut]", "URL=https://x.com/home", "IconIndex=0"];
+        Assert.Equal("https://x.com/home", UrlHelper.ParseUrlShortcut(lines));
+    }
+
+    [Fact]
+    public void ParseUrlShortcut_CaseInsensitiveAndTrimmed()
+    {
+        string[] lines = ["url=https://x.com/home  "];
+        Assert.Equal("https://x.com/home", UrlHelper.ParseUrlShortcut(lines));
+    }
+
+    [Fact]
+    public void ParseUrlShortcut_NoUrlLine_ReturnsNull()
+    {
+        string[] lines = ["[InternetShortcut]", "IconIndex=0"];
+        Assert.Null(UrlHelper.ParseUrlShortcut(lines));
+    }
+}

--- a/XTimelineViewer.Tests/XTimelineViewer.Tests.csproj
+++ b/XTimelineViewer.Tests/XTimelineViewer.Tests.csproj
@@ -29,6 +29,8 @@
     <Compile Include="..\Models\*.cs"                  Link="Models\%(Filename)%(Extension)" />
     <Compile Include="..\Services\SettingsService.cs" Link="Services\SettingsService.cs" />
     <Compile Include="..\Services\EdgeService.cs"    Link="Services\EdgeService.cs" />
+    <Compile Include="..\Services\UrlHelper.cs"      Link="Services\UrlHelper.cs" />
+    <Compile Include="..\Services\SearchQueryHelper.cs" Link="Services\SearchQueryHelper.cs" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- `Services/UrlHelper.cs` を新設 — `IsXUrl` / `IsOnBaseUrl` / `GetTimelineGlyph` / `IsListHeaderApplicable` / `ParseUrlShortcut`（.url 解析の純粋部分）
- `Services/SearchQueryHelper.cs` を新設 — `BuildSearchUrl` / `ExtractQueryFromUrl` / `ExtractSearchPath` / `ExtractQueryFromSearchPath` / `DecodeSearchPath`
- MainWindow の partial class（xaml.cs / Timeline.cs / WebView2.cs / Search.cs）から該当メソッドを削除し、呼び出し側をヘルパー参照に置換
- **ロジックの変更は一切なし**（機械的な移動のみ）
- XAML の `x:Bind` から参照される `MainWindow.DecodeSearchPath` のみ委譲ラッパーとして残置
- **ユニットテスト 54 件を新規追加**（`UrlHelperTests` / `SearchQueryHelperTests`）— 移動したロジックの挙動を固定

## レビューポイント
- `GetTimelineGlyph` のグリフは PUA コードポイントのため `\uXXXX` エスケープ表記を維持（#122 のエンコーディング事故対策）。テストでグリフ値も検証済み
- `ParseUrlShortcutAsync`（WinRT 依存）は Timeline.cs に残し、行解析の純粋部分だけ `UrlHelper.ParseUrlShortcut` に委譲

## Test plan
- [x] ビルド成功（0 警告 / 0 エラー）
- [x] ユニットテスト 75 件全パス（既存 21 + 新規 54）
- [x] デバッグ実行で目視確認: メニュー/ペインのアイコン表示、検索 → サジェスト → タイムライン追加、リストヘッダートグルの有効/無効

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)