### PR TITLE
refactor: 多言語対応を MRT Core + PrimaryLanguageOverride に移行 (#198)

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -59,11 +59,9 @@ namespace XTimelineViewer
 
         protected override void OnLaunched(LaunchActivatedEventArgs args)
         {
+            // WinAppSDK 1.6+ の Microsoft.Windows.Globalization 経由で packaged / unpackaged
+            // 両対応の言語上書きを行う（R.Initialize 内で設定）。リソース読み込み前に呼ぶこと。
             var lang = ReadLanguageSetting();
-
-            if (lang != null && PackageContext.IsPackaged)
-                Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride = lang;
-
             R.Initialize(lang);
             _window = new MainWindow();
             _window.Activate();

--- a/R.cs
+++ b/R.cs
@@ -1,79 +1,67 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Xml.Linq;
+using Microsoft.Windows.ApplicationModel.Resources;
 
 namespace XTimelineViewer
 {
+    /// <summary>
+    /// 多言語リソースへのアクセスを提供する。
+    /// MRT Core (ResourceManager) でビルド時生成の resources.pri から文字列を解決する (#198)。
+    /// WinAppSDK 1.6 以降は Microsoft.Windows.Globalization.ApplicationLanguages により
+    /// unpackaged でも PrimaryLanguageOverride が有効。ただし unpackaged では
+    /// セッション間で永続化されないため、起動のたびに設定する。
+    /// </summary>
     internal static class R
     {
-        private static Dictionary<string, string> _dict = [];
-        private static bool _initialized;
+        private static ResourceManager? _manager;
+        private static ResourceMap?     _map;
+        private static ResourceContext? _context;
 
         internal static void Initialize(string? languageOverride = null)
         {
-            if (_initialized) return;
-            _initialized = true;
-
-            // ResourceMap.GetValue() はドットを含むキー（x:Uid バインディング用）を
-            // 特定の言語コンテキストで正しく解決できず COMException をスローする (#40)。
-            // すべての言語で resw 直接パースに統一して回避する。
-            var locale = languageOverride ?? ResolveSystemLocale();
-            _dict = LoadResw(locale) ?? LoadResw("en-US") ?? [];
-        }
-
-        // 実行中に言語を切り替えるためリソース辞書を再読み込みする (#117)。
-        // languageOverride が null の場合はシステム言語にフォールバックする。
-        internal static void Reload(string? languageOverride = null)
-        {
-            _initialized = false;
-            Initialize(languageOverride);
-        }
-
-        // システム言語から使用する resw ロケールフォルダー名を決定する。
-        // ja 系は "ja-JP"、それ以外は "en-US" にフォールバックする。
-        private static string ResolveSystemLocale()
-        {
+            // x:Uid で解決される XAML リソース（#199 で導入予定）にも反映させるため、
+            // 明示コンテキストとは別にプロセス全体の言語も上書きする。
             try
             {
-                var lang = System.Globalization.CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
-                return lang == "ja" ? "ja-JP" : "en-US";
-            }
-            catch
-            {
-                return "en-US";
-            }
-        }
-
-        private static Dictionary<string, string>? LoadResw(string locale)
-        {
-            var path = Path.Combine(AppContext.BaseDirectory, "Strings", locale, "Resources.resw");
-            if (!File.Exists(path)) return null;
-
-            var dict = new Dictionary<string, string>();
-            try
-            {
-                foreach (var data in XDocument.Load(path).Descendants("data"))
-                {
-                    var name  = data.Attribute("name")?.Value;
-                    var value = data.Element("value")?.Value;
-                    if (name != null && value != null)
-                        dict[name] = value;
-                }
+                Microsoft.Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride =
+                    languageOverride ?? "";
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"[R] LoadResw({locale}) FAILED: {ex.Message}");
-                return null;
+                Debug.WriteLine($"[R] PrimaryLanguageOverride FAILED: {ex.Message}");
             }
-            return dict;
+
+            _manager = new ResourceManager();
+            _map     = _manager.MainResourceMap.GetSubtree("Resources");
+
+            // 実行中の言語切り替え (#117) を確実にするため、明示的な ResourceContext で解決する。
+            // 既定コンテキストはプロセス起動時の言語をキャッシュすることがある。
+            _context = _manager.CreateResourceContext();
+            if (languageOverride is not null)
+                _context.QualifierValues["Language"] = languageOverride;
         }
+
+        // 実行中に言語を切り替えるためリソースコンテキストを再構築する (#117)。
+        // languageOverride が null の場合はシステム言語にフォールバックする。
+        internal static void Reload(string? languageOverride = null)
+            => Initialize(languageOverride);
 
         public static string Get(string key)
         {
-            if (!_initialized) Initialize();
-            return _dict.TryGetValue(key, out var val) ? val : string.Empty;
+            if (_map is null || _context is null) Initialize();
+
+            try
+            {
+                // x:Uid 形式のキー（例: PostLabel.Text）は PRI 内では PostLabel/Text として
+                // 格納されるため変換する。ドットのまま GetValue すると COMException になる (#40)。
+                var candidate = _map!.TryGetValue(key.Replace('.', '/'), _context);
+                return candidate?.ValueAsString ?? string.Empty;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[R] Get({key}) FAILED: {ex.Message}");
+                return string.Empty;
+            }
         }
     }
 }

--- a/Views/Settings/GeneralPage.xaml.cs
+++ b/Views/Settings/GeneralPage.xaml.cs
@@ -111,6 +111,10 @@ namespace XTimelineViewer.Views.Settings
             var idx = Math.Clamp(LanguageCombo.SelectedIndex, 0, LangValues.Length - 1);
             _parent.Settings.Language = LangValues[idx];
             _parent.NotifySettingsChanged();
+
+            // NotifySettingsChanged で R が再読込された後、このページ自身の表示も
+            // 新しい言語で再構築する（他ページは遷移時の PopulateUI で反映される）
+            PopulateUI();
         }
 
         private void SidebarToggle_Toggled(object sender, RoutedEventArgs e)

--- a/XTimelineViewer.csproj
+++ b/XTimelineViewer.csproj
@@ -38,8 +38,5 @@
     <Content Include="Assets\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="Strings\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- R クラスの自前 resw パーサーを廃止し、MRT Core `ResourceManager` で resources.pri から文字列を解決する実装に置換（公開 API `Initialize` / `Reload` / `Get` は不変、呼び出し側は無修正）
- WinAppSDK 1.6 で追加された `Microsoft.Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride` により packaged / unpackaged の分岐を撤廃（unpackaged では永続化されないため毎起動時に設定）
- `R.Get` は明示的な `ResourceContext` で解決し、実行中の言語切り替え（#117）を確実化
- x:Uid 形式のドット入りキー（`PostLabel.Text`）は PRI 内で `PostLabel/Text` として格納されるため `.` → `/` 変換で対応 — #40 で MRT を断念した原因の COMException はこれで解消
- csproj から `Strings\**` の出力コピーを削除（resw はビルド時に PRI へ焼き込まれるため、loose ファイル不要に）
- **既存バグ修正**: 言語変更時に表示中の設定ページが再描画されず、ページ内容が前の言語のまま残る問題（v1.5.1 でも再現）を `PopulateUI` 再実行で修正

## 効果
- 自前 XML パーサーのメンテナンス不要に
- XAML で x:Uid が使えるようになり、#199（設定ページ MVVM 化）の前提が整う
- 配布物から Strings フォルダーが消えてわずかにスリム化

## Test plan
- [x] ビルド成功（0 警告 / 0 エラー）
- [x] 出力フォルダーの Strings を削除した状態で全 UI 文字列が表示される（= PRI 経由で解決）
- [x] 言語切り替え（ja ⇔ en）でナビゲーション・ページ内容が即時反映
- [x] 他の設定ページへの遷移後も新しい言語で表示
- [ ] MSIX（packaged）ビルドでの言語切り替え確認 → 次回 Store 申請時に確認

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)