### PR TITLE
refactor: GeneralPage を MVVM 化 (#199 フェーズ1)

### DIFF
--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,95 @@
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using XTimelineViewer.Models;
+
+namespace XTimelineViewer.ViewModels
+{
+    /// <summary>
+    /// 設定ページ用 ViewModel (#199)。AppSettings をラップして双方向 x:Bind を提供する。
+    /// UI 非依存（Microsoft.UI.Xaml を参照しない）に保ち、ユニットテスト可能にする。
+    /// </summary>
+    public partial class SettingsViewModel : ObservableObject
+    {
+        internal static readonly string[] ThemeValues = ["Default", "Light", "Dark"];
+        internal static readonly string[] LangValues  = ["system", "ja-JP", "en-US"];
+
+        private readonly AppSettings _settings;
+        private readonly Action?     _settingsChanged;
+
+        public SettingsViewModel(AppSettings settings, Action? settingsChanged = null)
+        {
+            _settings        = settings;
+            _settingsChanged = settingsChanged;
+        }
+
+        private void Notify(string propertyName)
+        {
+            // 先に設定変更を通知（保存・R.Reload 等）してから PropertyChanged を発火する。
+            // 言語変更時、PropertyChanged 購読側（ページ再構築）が新しいリソースを参照できるようにするため。
+            _settingsChanged?.Invoke();
+            OnPropertyChanged(propertyName);
+        }
+
+        // ── テーマ / 言語（ComboBox の SelectedIndex に対応） ──────────────────────
+
+        public int ThemeIndex
+        {
+            get => Math.Max(0, Array.IndexOf(ThemeValues, _settings.Theme));
+            set
+            {
+                // ItemsSource 再設定時に SelectedIndex が一時的に -1 になるため範囲外は無視する
+                if (value < 0 || value >= ThemeValues.Length) return;
+                if (_settings.Theme == ThemeValues[value]) return;
+                _settings.Theme = ThemeValues[value];
+                Notify(nameof(ThemeIndex));
+            }
+        }
+
+        public int LanguageIndex
+        {
+            get => Math.Max(0, Array.IndexOf(LangValues, _settings.Language));
+            set
+            {
+                if (value < 0 || value >= LangValues.Length) return;
+                if (_settings.Language == LangValues[value]) return;
+                _settings.Language = LangValues[value];
+                Notify(nameof(LanguageIndex));
+            }
+        }
+
+        // ── タイムラインの既定値（ToggleSwitch.IsOn = 表示 なので Hide* を反転） ────
+
+        public bool ShowSidebarByDefault
+        {
+            get => !_settings.DefaultHideSidebar;
+            set
+            {
+                if (_settings.DefaultHideSidebar == !value) return;
+                _settings.DefaultHideSidebar = !value;
+                Notify(nameof(ShowSidebarByDefault));
+            }
+        }
+
+        public bool ShowComposeByDefault
+        {
+            get => !_settings.DefaultHideCompose;
+            set
+            {
+                if (_settings.DefaultHideCompose == !value) return;
+                _settings.DefaultHideCompose = !value;
+                Notify(nameof(ShowComposeByDefault));
+            }
+        }
+
+        public bool ShowListHeaderByDefault
+        {
+            get => !_settings.DefaultHideListHeader;
+            set
+            {
+                if (_settings.DefaultHideListHeader == !value) return;
+                _settings.DefaultHideListHeader = !value;
+                Notify(nameof(ShowListHeaderByDefault));
+            }
+        }
+    }
+}

--- a/Views/Settings/GeneralPage.xaml
+++ b/Views/Settings/GeneralPage.xaml
@@ -17,7 +17,7 @@
                 </controls:SettingsCard.HeaderIcon>
                 <ComboBox x:Name="ThemeCombo"
                           MinWidth="160"
-                          SelectionChanged="ThemeCombo_SelectionChanged"/>
+                          SelectedIndex="{x:Bind VM.ThemeIndex, Mode=TwoWay}"/>
             </controls:SettingsCard>
 
             <!-- Language -->
@@ -27,7 +27,7 @@
                 </controls:SettingsCard.HeaderIcon>
                 <ComboBox x:Name="LanguageCombo"
                           MinWidth="160"
-                          SelectionChanged="LanguageCombo_SelectionChanged"/>
+                          SelectedIndex="{x:Bind VM.LanguageIndex, Mode=TwoWay}"/>
             </controls:SettingsCard>
 
             <!-- Timeline Defaults -->
@@ -38,17 +38,17 @@
                 <controls:SettingsExpander.Items>
                     <controls:SettingsCard x:Name="SidebarCard">
                         <ToggleSwitch x:Name="SidebarToggle"
-                                      Toggled="SidebarToggle_Toggled"
+                                      IsOn="{x:Bind VM.ShowSidebarByDefault, Mode=TwoWay}"
                                       MinWidth="0"/>
                     </controls:SettingsCard>
                     <controls:SettingsCard x:Name="ComposeCard">
                         <ToggleSwitch x:Name="ComposeToggle"
-                                      Toggled="ComposeToggle_Toggled"
+                                      IsOn="{x:Bind VM.ShowComposeByDefault, Mode=TwoWay}"
                                       MinWidth="0"/>
                     </controls:SettingsCard>
                     <controls:SettingsCard x:Name="ListHeaderCard">
                         <ToggleSwitch x:Name="ListHeaderToggle"
-                                      Toggled="ListHeaderToggle_Toggled"
+                                      IsOn="{x:Bind VM.ShowListHeaderByDefault, Mode=TwoWay}"
                                       MinWidth="0"/>
                     </controls:SettingsCard>
                 </controls:SettingsExpander.Items>

--- a/Views/Settings/GeneralPage.xaml.cs
+++ b/Views/Settings/GeneralPage.xaml.cs
@@ -1,18 +1,17 @@
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
-using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using XTimelineViewer.ViewModels;
 
 namespace XTimelineViewer.Views.Settings
 {
     public sealed partial class GeneralPage : Page
     {
-        private static readonly string[] ThemeValues = ["Default", "Light", "Dark"];
-        private static readonly string[] LangValues  = ["system", "ja-JP", "en-US"];
-
         private SettingsWindow? _parent;
-        private bool _isInitializing = true;
+
+        /// <summary>x:Bind のバインディングソース。XAML から参照される。</summary>
+        public SettingsViewModel? VM { get; private set; }
 
         public GeneralPage()
         {
@@ -23,13 +22,29 @@ namespace XTimelineViewer.Views.Settings
         {
             base.OnNavigatedTo(e);
             _parent = e.Parameter as SettingsWindow;
+            VM      = _parent?.ViewModel;
+            if (VM is not null)
+                VM.PropertyChanged += OnViewModelPropertyChanged;
             PopulateUI();
+        }
+
+        protected override void OnNavigatedFrom(NavigationEventArgs e)
+        {
+            base.OnNavigatedFrom(e);
+            // VM はウィンドウと同寿命なので、ページ破棄時に購読を解除してリークを防ぐ
+            if (VM is not null)
+                VM.PropertyChanged -= OnViewModelPropertyChanged;
+        }
+
+        private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            // 言語変更時はこのページ自身の表示も新しい言語で再構築する
+            if (e.PropertyName == nameof(SettingsViewModel.LanguageIndex))
+                PopulateUI();
         }
 
         private void PopulateUI()
         {
-            _isInitializing = true;
-
             PageTitle.Text = R.Get("Nav_General");
 
             // Theme
@@ -41,12 +56,6 @@ namespace XTimelineViewer.Views.Settings
                 R.Get("Theme_Light"),
                 R.Get("Theme_Dark"),
             };
-            ThemeCombo.SelectedIndex = _parent?.Settings.Theme switch
-            {
-                "Light" => 1,
-                "Dark"  => 2,
-                _       => 0,
-            };
 
             // Language
             LanguageCard.Header      = R.Get("Settings_Language");
@@ -57,85 +66,23 @@ namespace XTimelineViewer.Views.Settings
                 R.Get("Language_JA"),
                 R.Get("Language_EN"),
             };
-            var langIdx = Array.IndexOf(LangValues, _parent?.Settings.Language ?? "system");
-            LanguageCombo.SelectedIndex = langIdx < 0 ? 0 : langIdx;
 
             // Timeline Defaults
             DefaultTimelineExpander.Header      = R.Get("Settings_DefaultTimeline");
             DefaultTimelineExpander.Description = R.Get("Settings_DefaultTimeline_Description");
-            if (_parent is not null)
-            {
-                var s = _parent.Settings;
+            SidebarCard.Header       = R.Get("Settings_DefaultSidebar");
+            SidebarToggle.OnContent  = R.Get("Toggle_Show");
+            SidebarToggle.OffContent = R.Get("Toggle_Hide");
+            ComposeCard.Header       = R.Get("Settings_DefaultCompose");
+            ComposeToggle.OnContent  = R.Get("Toggle_Show");
+            ComposeToggle.OffContent = R.Get("Toggle_Hide");
+            ListHeaderCard.Header       = R.Get("Settings_DefaultListHeader");
+            ListHeaderToggle.OnContent  = R.Get("Toggle_Show");
+            ListHeaderToggle.OffContent = R.Get("Toggle_Hide");
 
-                SidebarCard.Header       = R.Get("Settings_DefaultSidebar");
-                SidebarToggle.OnContent  = R.Get("Toggle_Show");
-                SidebarToggle.OffContent = R.Get("Toggle_Hide");
-                SidebarToggle.IsOn       = !s.DefaultHideSidebar;
-
-                ComposeCard.Header       = R.Get("Settings_DefaultCompose");
-                ComposeToggle.OnContent  = R.Get("Toggle_Show");
-                ComposeToggle.OffContent = R.Get("Toggle_Hide");
-                ComposeToggle.IsOn       = !s.DefaultHideCompose;
-
-                ListHeaderCard.Header       = R.Get("Settings_DefaultListHeader");
-                ListHeaderToggle.OnContent  = R.Get("Toggle_Show");
-                ListHeaderToggle.OffContent = R.Get("Toggle_Hide");
-                ListHeaderToggle.IsOn       = !s.DefaultHideListHeader;
-            }
-
-            _isInitializing = false;
-        }
-
-        private void ThemeCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            if (_isInitializing || _parent is null) return;
-
-            var idx = Math.Clamp(ThemeCombo.SelectedIndex, 0, ThemeValues.Length - 1);
-            _parent.Settings.Theme = ThemeValues[idx];
-
-            // テーマは即時反映
-            var theme = idx switch
-            {
-                1 => ElementTheme.Light,
-                2 => ElementTheme.Dark,
-                _ => ElementTheme.Default,
-            };
-            _parent.ApplyTheme(theme);
-            _parent.NotifySettingsChanged();
-        }
-
-        private void LanguageCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            if (_isInitializing || _parent is null) return;
-
-            var idx = Math.Clamp(LanguageCombo.SelectedIndex, 0, LangValues.Length - 1);
-            _parent.Settings.Language = LangValues[idx];
-            _parent.NotifySettingsChanged();
-
-            // NotifySettingsChanged で R が再読込された後、このページ自身の表示も
-            // 新しい言語で再構築する（他ページは遷移時の PopulateUI で反映される）
-            PopulateUI();
-        }
-
-        private void SidebarToggle_Toggled(object sender, RoutedEventArgs e)
-        {
-            if (_isInitializing || _parent is null) return;
-            _parent.Settings.DefaultHideSidebar = !SidebarToggle.IsOn;
-            _parent.NotifySettingsChanged();
-        }
-
-        private void ComposeToggle_Toggled(object sender, RoutedEventArgs e)
-        {
-            if (_isInitializing || _parent is null) return;
-            _parent.Settings.DefaultHideCompose = !ComposeToggle.IsOn;
-            _parent.NotifySettingsChanged();
-        }
-
-        private void ListHeaderToggle_Toggled(object sender, RoutedEventArgs e)
-        {
-            if (_isInitializing || _parent is null) return;
-            _parent.Settings.DefaultHideListHeader = !ListHeaderToggle.IsOn;
-            _parent.NotifySettingsChanged();
+            // ItemsSource 再設定で SelectedIndex が失われるため、バインディングを再評価して
+            // ViewModel の値を反映し直す
+            Bindings.Update();
         }
     }
 }

--- a/Views/SettingsWindow.xaml.cs
+++ b/Views/SettingsWindow.xaml.cs
@@ -22,6 +22,9 @@ namespace XTimelineViewer.Views
         /// <summary>親ウィンドウから渡されたアプリ設定。ページが直接読み書きする。</summary>
         internal AppSettings Settings { get; }
 
+        /// <summary>設定ページが x:Bind する ViewModel (#199)。</summary>
+        internal ViewModels.SettingsViewModel ViewModel { get; }
+
         /// <summary>設定ファイルが格納されているフォルダーパス。</summary>
         internal string SettingsFolder { get; }
 
@@ -80,6 +83,20 @@ namespace XTimelineViewer.Views
             _ownerHwnd = ownerHwnd;
             Settings = settings;
             SettingsFolder = settingsFolder;
+            ViewModel = new ViewModels.SettingsViewModel(settings, NotifySettingsChanged);
+
+            // テーマ変更は設定ウィンドウ自身にも即時反映する
+            ViewModel.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName != nameof(ViewModels.SettingsViewModel.ThemeIndex)) return;
+                ApplyTheme(Settings.Theme switch
+                {
+                    "Light" => ElementTheme.Light,
+                    "Dark"  => ElementTheme.Dark,
+                    _       => ElementTheme.Default,
+                });
+            };
+
             this.InitializeComponent();
 
             // ウィンドウサイズ・アイコン設定

--- a/XTimelineViewer.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/XTimelineViewer.Tests/ViewModels/SettingsViewModelTests.cs
@@ -1,0 +1,151 @@
+using System.Collections.Generic;
+using XTimelineViewer.Models;
+using XTimelineViewer.ViewModels;
+using Xunit;
+
+namespace XTimelineViewer.Tests.ViewModels;
+
+public class SettingsViewModelTests
+{
+    // ── ThemeIndex ────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("Default", 0)]
+    [InlineData("Light",   1)]
+    [InlineData("Dark",    2)]
+    [InlineData("bogus",   0)] // 不正値は既定（システム）にフォールバック
+    public void ThemeIndex_Get_MapsFromSettings(string theme, int expected)
+    {
+        var vm = new SettingsViewModel(new AppSettings { Theme = theme });
+        Assert.Equal(expected, vm.ThemeIndex);
+    }
+
+    [Fact]
+    public void ThemeIndex_Set_UpdatesSettingsAndNotifies()
+    {
+        var s = new AppSettings();
+        var notified = 0;
+        var vm = new SettingsViewModel(s, () => notified++);
+        var raised = new List<string?>();
+        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        vm.ThemeIndex = 2;
+
+        Assert.Equal("Dark", s.Theme);
+        Assert.Equal(1, notified);
+        Assert.Contains(nameof(SettingsViewModel.ThemeIndex), raised);
+    }
+
+    [Theory]
+    [InlineData(-1)] // ItemsSource 再設定時の一時値
+    [InlineData(3)]
+    public void ThemeIndex_Set_OutOfRange_Ignored(int value)
+    {
+        var s = new AppSettings { Theme = "Dark" };
+        var notified = 0;
+        var vm = new SettingsViewModel(s, () => notified++);
+
+        vm.ThemeIndex = value;
+
+        Assert.Equal("Dark", s.Theme);
+        Assert.Equal(0, notified);
+    }
+
+    [Fact]
+    public void ThemeIndex_Set_SameValue_DoesNotNotify()
+    {
+        var s = new AppSettings { Theme = "Light" };
+        var notified = 0;
+        var vm = new SettingsViewModel(s, () => notified++);
+
+        vm.ThemeIndex = 1;
+
+        Assert.Equal(0, notified);
+    }
+
+    // ── LanguageIndex ─────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("system", 0)]
+    [InlineData("ja-JP",  1)]
+    [InlineData("en-US",  2)]
+    public void LanguageIndex_RoundTrip(string lang, int index)
+    {
+        var s = new AppSettings { Language = lang };
+        var vm = new SettingsViewModel(s);
+        Assert.Equal(index, vm.LanguageIndex);
+
+        var s2 = new AppSettings();
+        var vm2 = new SettingsViewModel(s2);
+        vm2.LanguageIndex = index;
+        Assert.Equal(lang, s2.Language);
+    }
+
+    [Fact]
+    public void LanguageIndex_SettingsChangedBeforePropertyChanged()
+    {
+        // 言語変更時はリソース再読込（settingsChanged）→ ページ再構築（PropertyChanged）の
+        // 順序が必須。逆になると旧言語で再構築される。
+        var order = new List<string>();
+        var s = new AppSettings();
+        SettingsViewModel vm = null!;
+        vm = new SettingsViewModel(s, () => order.Add("settingsChanged"));
+        vm.PropertyChanged += (_, _) => order.Add("propertyChanged");
+
+        vm.LanguageIndex = 2;
+
+        Assert.Equal(["settingsChanged", "propertyChanged"], order);
+    }
+
+    // ── タイムラインの既定値（反転ロジック） ───────────────────────────────────
+
+    [Fact]
+    public void ShowSidebarByDefault_InvertsHideFlag()
+    {
+        var s = new AppSettings { DefaultHideSidebar = true };
+        var vm = new SettingsViewModel(s);
+
+        Assert.False(vm.ShowSidebarByDefault);
+
+        vm.ShowSidebarByDefault = true;
+        Assert.False(s.DefaultHideSidebar);
+    }
+
+    [Fact]
+    public void ShowComposeByDefault_InvertsHideFlag()
+    {
+        var s = new AppSettings(); // DefaultHideCompose = true が既定
+        var vm = new SettingsViewModel(s);
+
+        Assert.False(vm.ShowComposeByDefault);
+
+        vm.ShowComposeByDefault = true;
+        Assert.False(s.DefaultHideCompose);
+    }
+
+    [Fact]
+    public void ShowListHeaderByDefault_InvertsHideFlag()
+    {
+        var s = new AppSettings();
+        var vm = new SettingsViewModel(s);
+
+        Assert.True(vm.ShowListHeaderByDefault);
+
+        vm.ShowListHeaderByDefault = false;
+        Assert.True(s.DefaultHideListHeader);
+    }
+
+    [Fact]
+    public void ShowToggles_SameValue_DoesNotNotify()
+    {
+        var s = new AppSettings();
+        var notified = 0;
+        var vm = new SettingsViewModel(s, () => notified++);
+
+        vm.ShowSidebarByDefault    = !s.DefaultHideSidebar;
+        vm.ShowComposeByDefault    = !s.DefaultHideCompose;
+        vm.ShowListHeaderByDefault = !s.DefaultHideListHeader;
+
+        Assert.Equal(0, notified);
+    }
+}

--- a/XTimelineViewer.Tests/XTimelineViewer.Tests.csproj
+++ b/XTimelineViewer.Tests/XTimelineViewer.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
@@ -31,6 +32,7 @@
     <Compile Include="..\Services\EdgeService.cs"    Link="Services\EdgeService.cs" />
     <Compile Include="..\Services\UrlHelper.cs"      Link="Services\UrlHelper.cs" />
     <Compile Include="..\Services\SearchQueryHelper.cs" Link="Services\SearchQueryHelper.cs" />
+    <Compile Include="..\ViewModels\SettingsViewModel.cs" Link="ViewModels\SettingsViewModel.cs" />
   </ItemGroup>
 
 </Project>

--- a/XTimelineViewer.csproj
+++ b/XTimelineViewer.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.2.251219" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250602001" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />


### PR DESCRIPTION
## Summary
- **CommunityToolkit.Mvvm 8.4.0** を導入
- `ViewModels/SettingsViewModel.cs` を新設 — AppSettings をラップし、双方向 x:Bind 用のプロパティを提供
  - `ThemeIndex` / `LanguageIndex`（ComboBox.SelectedIndex 用）
  - `Show*ByDefault`（ToggleSwitch.IsOn 用、Hide フラグの反転）
  - **UI 非依存**（Microsoft.UI.Xaml を参照しない）なのでユニットテスト可能
- GeneralPage のコンボ 2 つ・トグル 3 つを `x:Bind TwoWay` 化
  - イベントハンドラー 5 つと `_isInitializing` フラグを全廃
  - `ItemsSource` 再設定時の `SelectedIndex = -1` は VM 側の範囲ガードで無視
  - `PopulateUI` は文字列設定のみに縮小し、末尾の `Bindings.Update()` で選択状態を復元
- SettingsWindow が `ViewModel` を保持し、テーマ変更を自ウィンドウに即時適用
- **通知順序の設計保証**: `settingsChanged`（保存・R.Reload）→ `PropertyChanged`（ページ再構築）。逆だと言語変更時に旧言語で再構築される。順序をテストで固定
- `SettingsViewModelTests` 16 件を追加（インデックス変換、範囲外無視、反転ロジック、通知順序）

## スコープ
#199 のフェーズ1。ExperimentalPage / DataPage の MVVM 化と x:Uid 導入は後続 PR で対応。

## Test plan
- [x] ビルド成功（0 警告 / 0 エラー）
- [x] ユニットテスト 91 件全パス（新規 16 件）
- [x] テーマ変更が設定ウィンドウ・メインウィンドウに即時反映
- [x] 言語変更でナビ + ページ内容が新言語で再構築
- [x] タイムライン既定値トグルの変更が新規タイムラインに反映
- [x] 再起動後も設定が保持される

Refs #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)