### PR TITLE
refactor: ExperimentalPage を MVVM 化 (#199 フェーズ2)

### DIFF
--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -10,8 +10,9 @@ namespace XTimelineViewer.ViewModels
     /// </summary>
     public partial class SettingsViewModel : ObservableObject
     {
-        internal static readonly string[] ThemeValues = ["Default", "Light", "Dark"];
-        internal static readonly string[] LangValues  = ["system", "ja-JP", "en-US"];
+        internal static readonly string[] ThemeValues   = ["Default", "Light", "Dark"];
+        internal static readonly string[] LangValues    = ["system", "ja-JP", "en-US"];
+        internal static readonly string[] BrowserValues = ["system", "edge"];
 
         private readonly AppSettings _settings;
         private readonly Action?     _settingsChanged;
@@ -91,5 +92,70 @@ namespace XTimelineViewer.ViewModels
                 Notify(nameof(ShowListHeaderByDefault));
             }
         }
+
+        // ── 試験機能 ──────────────────────────────────────────────────────────────
+
+        public bool OpenComposerInBrowser
+        {
+            get => _settings.OpenComposerInBrowser;
+            set
+            {
+                if (_settings.OpenComposerInBrowser == value) return;
+                _settings.OpenComposerInBrowser = value;
+                Notify(nameof(OpenComposerInBrowser));
+            }
+        }
+
+        public bool OpenTimestampInBrowser
+        {
+            get => _settings.OpenTimestampInBrowser;
+            set
+            {
+                if (_settings.OpenTimestampInBrowser == value) return;
+                _settings.OpenTimestampInBrowser = value;
+                Notify(nameof(OpenTimestampInBrowser));
+            }
+        }
+
+        /// <summary>NumberBox.Value（double）にバインドする。NaN（空欄）は無視し、0–60 に丸める。</summary>
+        public double AutoActivateMinutes
+        {
+            get => _settings.AutoActivateMinutes;
+            set
+            {
+                if (double.IsNaN(value)) return;
+                var minutes = (int)Math.Clamp(value, 0, 60);
+                if (_settings.AutoActivateMinutes == minutes) return;
+                _settings.AutoActivateMinutes = minutes;
+                Notify(nameof(AutoActivateMinutes));
+            }
+        }
+
+        public bool ShowAutoActivateLabel
+        {
+            get => _settings.ShowAutoActivateLabel;
+            set
+            {
+                if (_settings.ShowAutoActivateLabel == value) return;
+                _settings.ShowAutoActivateLabel = value;
+                Notify(nameof(ShowAutoActivateLabel));
+            }
+        }
+
+        public int BrowserIndex
+        {
+            get => Math.Max(0, Array.IndexOf(BrowserValues, _settings.ExternalBrowser));
+            set
+            {
+                if (value < 0 || value >= BrowserValues.Length) return;
+                if (_settings.ExternalBrowser == BrowserValues[value]) return;
+                _settings.ExternalBrowser = BrowserValues[value];
+                Notify(nameof(BrowserIndex));
+                OnPropertyChanged(nameof(IsEdgeSelected));
+            }
+        }
+
+        /// <summary>Edge プロファイル ComboBox の有効/無効判定に使う。</summary>
+        public bool IsEdgeSelected => _settings.ExternalBrowser == "edge";
     }
 }

--- a/Views/Settings/ExperimentalPage.xaml
+++ b/Views/Settings/ExperimentalPage.xaml
@@ -16,7 +16,7 @@
                     <FontIcon Glyph="&#xE70F;" FontFamily="Segoe Fluent Icons"/>
                 </controls:SettingsCard.HeaderIcon>
                 <ToggleSwitch x:Name="OpenComposerToggle"
-                              Toggled="OpenComposerToggle_Toggled"/>
+                              IsOn="{x:Bind VM.OpenComposerInBrowser, Mode=TwoWay}"/>
             </controls:SettingsCard>
 
             <!-- Open Timestamp Links in External Browser -->
@@ -25,7 +25,7 @@
                     <FontIcon Glyph="&#xE71B;" FontFamily="Segoe Fluent Icons"/>
                 </controls:SettingsCard.HeaderIcon>
                 <ToggleSwitch x:Name="OpenTimestampToggle"
-                              Toggled="OpenTimestampToggle_Toggled"/>
+                              IsOn="{x:Bind VM.OpenTimestampInBrowser, Mode=TwoWay}"/>
             </controls:SettingsCard>
 
             <!-- Auto-Activate Home Timeline -->
@@ -38,7 +38,7 @@
                            SmallChange="1" LargeChange="5"
                            SpinButtonPlacementMode="Inline"
                            Width="160"
-                           ValueChanged="AutoActivateBox_ValueChanged"/>
+                           Value="{x:Bind VM.AutoActivateMinutes, Mode=TwoWay}"/>
             </controls:SettingsCard>
 
             <!-- Show Auto-Activate Status in Toolbar -->
@@ -47,7 +47,7 @@
                     <FontIcon Glyph="&#xE7B3;" FontFamily="Segoe Fluent Icons"/>
                 </controls:SettingsCard.HeaderIcon>
                 <ToggleSwitch x:Name="ShowAutoActivateLabelToggle"
-                              Toggled="ShowAutoActivateLabelToggle_Toggled"/>
+                              IsOn="{x:Bind VM.ShowAutoActivateLabel, Mode=TwoWay}"/>
             </controls:SettingsCard>
 
             <!-- External Browser Section Header -->
@@ -62,7 +62,7 @@
                 </controls:SettingsCard.HeaderIcon>
                 <ComboBox x:Name="BrowserCombo"
                           MinWidth="200"
-                          SelectionChanged="BrowserCombo_SelectionChanged"/>
+                          SelectedIndex="{x:Bind VM.BrowserIndex, Mode=TwoWay}"/>
             </controls:SettingsCard>
 
             <!-- Edge Profile -->

--- a/Views/Settings/ExperimentalPage.xaml.cs
+++ b/Views/Settings/ExperimentalPage.xaml.cs
@@ -1,19 +1,19 @@
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
-using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using XTimelineViewer.Services;
+using XTimelineViewer.ViewModels;
 
 namespace XTimelineViewer.Views.Settings
 {
     public sealed partial class ExperimentalPage : Page
     {
-        private static readonly string[] BrowserValues = ["system", "edge"];
-
         private SettingsWindow? _parent;
-        private bool _isInitializing = true;
         private List<EdgeProfile> _edgeProfiles = [];
+
+        /// <summary>x:Bind のバインディングソース。XAML から参照される。</summary>
+        public SettingsViewModel? VM { get; private set; }
 
         public ExperimentalPage()
         {
@@ -24,51 +24,66 @@ namespace XTimelineViewer.Views.Settings
         {
             base.OnNavigatedTo(e);
             _parent = e.Parameter as SettingsWindow;
+            VM      = _parent?.ViewModel;
+            if (VM is not null)
+                VM.PropertyChanged += OnViewModelPropertyChanged;
             PopulateUI();
         }
 
+        protected override void OnNavigatedFrom(NavigationEventArgs e)
+        {
+            base.OnNavigatedFrom(e);
+            if (VM is not null)
+                VM.PropertyChanged -= OnViewModelPropertyChanged;
+        }
+
+        private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            switch (e.PropertyName)
+            {
+                case nameof(SettingsViewModel.LanguageIndex):
+                    PopulateUI();
+                    break;
+                case nameof(SettingsViewModel.IsEdgeSelected):
+                    UpdateEdgeProfileComboEnabled();
+                    break;
+            }
+        }
+
+        private void UpdateEdgeProfileComboEnabled()
+            => EdgeProfileCombo.IsEnabled = (VM?.IsEdgeSelected ?? false) && _edgeProfiles.Count > 0;
+
         private void PopulateUI()
         {
-            _isInitializing = true;
             var s = _parent?.Settings;
 
             PageTitle.Text = R.Get("Nav_Experimental");
 
-            // Open Composer in Browser
             OpenComposerCard.Header      = R.Get("Settings_OpenComposerInBrowser");
             OpenComposerCard.Description = R.Get("Settings_OpenComposerInBrowser_Description");
             OpenComposerToggle.OnContent  = R.Get("Toggle_On");
             OpenComposerToggle.OffContent = R.Get("Toggle_Off");
-            OpenComposerToggle.IsOn       = s?.OpenComposerInBrowser ?? false;
 
-            // Open Timestamp in Browser
             OpenTimestampCard.Header      = R.Get("Settings_OpenTimestampInBrowser");
             OpenTimestampCard.Description = R.Get("Settings_OpenTimestampInBrowser_Description");
             OpenTimestampToggle.OnContent  = R.Get("Toggle_On");
             OpenTimestampToggle.OffContent = R.Get("Toggle_Off");
-            OpenTimestampToggle.IsOn       = s?.OpenTimestampInBrowser ?? false;
 
-            // Auto-Activate
             AutoActivateCard.Header      = R.Get("Settings_AutoActivate");
             AutoActivateCard.Description = R.Get("Settings_AutoActivate_Description");
-            AutoActivateBox.Value        = s?.AutoActivateMinutes ?? 0;
 
-            // Show Auto-Activate Label
             ShowAutoActivateLabelCard.Header      = R.Get("Settings_ShowAutoActivateLabel");
             ShowAutoActivateLabelCard.Description = R.Get("Settings_ShowAutoActivateLabel_Description");
             ShowAutoActivateLabelToggle.OnContent  = R.Get("Toggle_On");
             ShowAutoActivateLabelToggle.OffContent = R.Get("Toggle_Off");
-            ShowAutoActivateLabelToggle.IsOn       = s?.ShowAutoActivateLabel ?? false;
 
-            // External Browser Section
             ExternalBrowserHeader.Text = R.Get("Section_ExternalBrowser");
 
             BrowserCard.Header      = R.Get("Settings_ExternalBrowser");
             BrowserCard.Description = R.Get("Settings_ExternalBrowser_Description");
             BrowserCombo.ItemsSource = new List<string> { R.Get("Browser_System"), "Microsoft Edge" };
-            BrowserCombo.SelectedIndex = s?.ExternalBrowser == "edge" ? 1 : 0;
 
-            // Edge Profile
+            // Edge Profile（ファイルシステム列挙に依存するためコードビハインドで構築）
             EdgeProfileCard.Header      = R.Get("Settings_EdgeProfile");
             EdgeProfileCard.Description = R.Get("Settings_EdgeProfile_Description");
             _edgeProfiles = EdgeService.EnumerateProfiles();
@@ -77,7 +92,6 @@ namespace XTimelineViewer.Views.Settings
             {
                 EdgeProfileCombo.ItemsSource   = new List<string> { R.Get("Browser_EdgeNotFound") };
                 EdgeProfileCombo.SelectedIndex = 0;
-                EdgeProfileCombo.IsEnabled     = false;
             }
             else
             {
@@ -93,62 +107,25 @@ namespace XTimelineViewer.Views.Settings
                 }
                 EdgeProfileCombo.ItemsSource   = names;
                 EdgeProfileCombo.SelectedIndex = selectedIdx;
-                EdgeProfileCombo.IsEnabled     = s?.ExternalBrowser == "edge";
             }
+            UpdateEdgeProfileComboEnabled();
 
-            _isInitializing = false;
-        }
-
-        private void OpenComposerToggle_Toggled(object sender, RoutedEventArgs e)
-        {
-            if (_isInitializing || _parent is null) return;
-            _parent.Settings.OpenComposerInBrowser = OpenComposerToggle.IsOn;
-            _parent.NotifySettingsChanged();
-        }
-
-        private void OpenTimestampToggle_Toggled(object sender, RoutedEventArgs e)
-        {
-            if (_isInitializing || _parent is null) return;
-            _parent.Settings.OpenTimestampInBrowser = OpenTimestampToggle.IsOn;
-            _parent.NotifySettingsChanged();
-        }
-
-        private void AutoActivateBox_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
-        {
-            if (_isInitializing || _parent is null) return;
-            _parent.Settings.AutoActivateMinutes = (int)Math.Clamp(args.NewValue, 0, 60);
-            _parent.NotifySettingsChanged();
-        }
-
-        private void ShowAutoActivateLabelToggle_Toggled(object sender, RoutedEventArgs e)
-        {
-            if (_isInitializing || _parent is null) return;
-            _parent.Settings.ShowAutoActivateLabel = ShowAutoActivateLabelToggle.IsOn;
-            _parent.NotifySettingsChanged();
-        }
-
-        private void BrowserCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            if (_isInitializing || _parent is null) return;
-
-            var idx = Math.Clamp(BrowserCombo.SelectedIndex, 0, BrowserValues.Length - 1);
-            _parent.Settings.ExternalBrowser = BrowserValues[idx];
-
-            // Edge プロファイル ComboBox の有効/無効を切り替え
-            var isEdge = idx == 1;
-            EdgeProfileCombo.IsEnabled = isEdge && _edgeProfiles.Count > 0;
-
-            _parent.NotifySettingsChanged();
+            // ItemsSource 再設定で SelectedIndex が失われるため、バインディングを再評価する
+            Bindings.Update();
         }
 
         private void EdgeProfileCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (_isInitializing || _parent is null) return;
+            if (_parent is null) return;
 
             var idx = EdgeProfileCombo.SelectedIndex;
-            if (_edgeProfiles.Count > 0 && idx >= 0 && idx < _edgeProfiles.Count)
-                _parent.Settings.EdgeProfileDirectory = _edgeProfiles[idx].Directory;
+            if (_edgeProfiles.Count == 0 || idx < 0 || idx >= _edgeProfiles.Count) return;
 
+            // PopulateUI による再設定では値が変わらないため通知しない
+            var dir = _edgeProfiles[idx].Directory;
+            if (_parent.Settings.EdgeProfileDirectory == dir) return;
+
+            _parent.Settings.EdgeProfileDirectory = dir;
             _parent.NotifySettingsChanged();
         }
     }

--- a/XTimelineViewer.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/XTimelineViewer.Tests/ViewModels/SettingsViewModelTests.cs
@@ -135,6 +135,76 @@ public class SettingsViewModelTests
         Assert.True(s.DefaultHideListHeader);
     }
 
+    // ── 試験機能 ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AutoActivateMinutes_ClampsToRange()
+    {
+        var s = new AppSettings();
+        var vm = new SettingsViewModel(s);
+
+        vm.AutoActivateMinutes = 999;
+        Assert.Equal(60, s.AutoActivateMinutes);
+
+        vm.AutoActivateMinutes = -5;
+        Assert.Equal(0, s.AutoActivateMinutes);
+    }
+
+    [Fact]
+    public void AutoActivateMinutes_NaN_Ignored()
+    {
+        var s = new AppSettings { AutoActivateMinutes = 10 };
+        var notified = 0;
+        var vm = new SettingsViewModel(s, () => notified++);
+
+        vm.AutoActivateMinutes = double.NaN;
+
+        Assert.Equal(10, s.AutoActivateMinutes);
+        Assert.Equal(0, notified);
+    }
+
+    [Theory]
+    [InlineData("system", 0, false)]
+    [InlineData("edge",   1, true)]
+    public void BrowserIndex_MapsAndReportsEdgeSelection(string browser, int index, bool isEdge)
+    {
+        var s = new AppSettings { ExternalBrowser = browser };
+        var vm = new SettingsViewModel(s);
+
+        Assert.Equal(index, vm.BrowserIndex);
+        Assert.Equal(isEdge, vm.IsEdgeSelected);
+    }
+
+    [Fact]
+    public void BrowserIndex_Set_RaisesIsEdgeSelected()
+    {
+        var s = new AppSettings();
+        var vm = new SettingsViewModel(s);
+        var raised = new List<string?>();
+        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        vm.BrowserIndex = 1;
+
+        Assert.Equal("edge", s.ExternalBrowser);
+        Assert.Contains(nameof(SettingsViewModel.BrowserIndex),    raised);
+        Assert.Contains(nameof(SettingsViewModel.IsEdgeSelected),  raised);
+    }
+
+    [Fact]
+    public void ExperimentalToggles_UpdateSettings()
+    {
+        var s = new AppSettings();
+        var vm = new SettingsViewModel(s);
+
+        vm.OpenComposerInBrowser  = true;
+        vm.OpenTimestampInBrowser = true;
+        vm.ShowAutoActivateLabel  = true;
+
+        Assert.True(s.OpenComposerInBrowser);
+        Assert.True(s.OpenTimestampInBrowser);
+        Assert.True(s.ShowAutoActivateLabel);
+    }
+
     [Fact]
     public void ShowToggles_SameValue_DoesNotNotify()
     {


### PR DESCRIPTION
## Summary
- `SettingsViewModel` に試験機能ページ用プロパティを追加
  - `OpenComposerInBrowser` / `OpenTimestampInBrowser` / `ShowAutoActivateLabel`（トグル）
  - `AutoActivateMinutes` — NumberBox の `Value`（double）に直接バインド。NaN（空欄）は無視し 0–60 に丸める
  - `BrowserIndex` + `IsEdgeSelected`（読み取り専用の派生プロパティ）
- トグル 3 つ・NumberBox・ブラウザーコンボを `x:Bind TwoWay` 化し、イベントハンドラー 5 つと `_isInitializing` を廃止
- **Edge プロファイルコンボのみコードビハインドに残置** — `EdgeService.EnumerateProfiles()`（ファイルシステム列挙）に依存し、項目が動的なため。`IsEdgeSelected` の PropertyChanged 購読で有効/無効を切り替え、値が変わらない再設定では通知しないガードを追加
- ユニットテスト 6 件追加（クランプ、NaN 無視、Edge 選択の派生通知など）

## Test plan
- [x] ビルド成功（0 警告 / 0 エラー）
- [x] ユニットテスト 97 件全パス（新規 6 件）
- [x] 試験機能ページの各設定の変更・保存
- [x] ブラウザー選択による Edge プロファイルコンボの有効/無効切り替え
- [x] NumberBox 空欄でも保存値が壊れない
- [x] 言語切り替えへの追随

Refs #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)