### PR TITLE
test: AppSettings 後方互換と保存済みクエリのテストを拡充 (#194)

### DIFF
--- a/Services/SearchQueryHelper.cs
+++ b/Services/SearchQueryHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace XTimelineViewer.Services
@@ -49,5 +50,12 @@ namespace XTimelineViewer.Services
         /// <summary>クエリパス（/search?q=...&amp;f=live）から q= の値を抽出する。</summary>
         internal static string? ExtractQueryFromSearchPath(string searchPath)
             => ExtractQueryFromUrl("https://x.com" + searchPath);
+
+        /// <summary>保存済みクエリの先頭に追加する。既存の同一クエリは重複させず先頭へ移動する。</summary>
+        internal static void AddSavedQuery(IList<string> saved, string searchPath)
+        {
+            saved.Remove(searchPath);
+            saved.Insert(0, searchPath);
+        }
     }
 }

--- a/Views/MainWindow.Search.cs
+++ b/Views/MainWindow.Search.cs
@@ -106,9 +106,7 @@ namespace XTimelineViewer.Views
 
         private void AddSavedSearchQuery(string searchPath)
         {
-            var saved = _appSettings.SavedSearchQueries;
-            saved.Remove(searchPath);
-            saved.Insert(0, searchPath);
+            SearchQueryHelper.AddSavedQuery(_appSettings.SavedSearchQueries, searchPath);
             SaveSettings();
         }
 

--- a/XTimelineViewer.Tests/Services/SearchQueryHelperTests.cs
+++ b/XTimelineViewer.Tests/Services/SearchQueryHelperTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using XTimelineViewer.Services;
 using Xunit;
 
@@ -68,6 +69,38 @@ public class SearchQueryHelperTests
         => Assert.Equal(
             "日本代表",
             SearchQueryHelper.ExtractQueryFromSearchPath("/search?q=%E6%97%A5%E6%9C%AC%E4%BB%A3%E8%A1%A8&f=live"));
+
+    // ── AddSavedQuery（重複排除・先頭挿入） ───────────────────────────────────
+
+    [Fact]
+    public void AddSavedQuery_NewQuery_InsertsAtHead()
+    {
+        var saved = new List<string> { "/search?q=old" };
+
+        SearchQueryHelper.AddSavedQuery(saved, "/search?q=new");
+
+        Assert.Equal(["/search?q=new", "/search?q=old"], saved);
+    }
+
+    [Fact]
+    public void AddSavedQuery_ExistingQuery_MovesToHeadWithoutDuplicate()
+    {
+        var saved = new List<string> { "/search?q=a", "/search?q=b", "/search?q=c" };
+
+        SearchQueryHelper.AddSavedQuery(saved, "/search?q=b");
+
+        Assert.Equal(["/search?q=b", "/search?q=a", "/search?q=c"], saved);
+    }
+
+    [Fact]
+    public void AddSavedQuery_EmptyList_Works()
+    {
+        var saved = new List<string>();
+
+        SearchQueryHelper.AddSavedQuery(saved, "/search?q=first");
+
+        Assert.Equal(["/search?q=first"], saved);
+    }
 
     // ── 往復（Build → Extract） ───────────────────────────────────────────────
 

--- a/XTimelineViewer.Tests/Services/SettingsServiceTests.cs
+++ b/XTimelineViewer.Tests/Services/SettingsServiceTests.cs
@@ -79,6 +79,82 @@ public class SettingsServiceTests : IDisposable
         Assert.Equal(10,       loaded.AutoActivateMinutes);
     }
 
+    // ── 後方互換 ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void LoadSettings_OldVersionJson_NewPropertiesGetDefaults()
+    {
+        // v1.4 相当の settings.json（後から追加されたプロパティを含まない）
+        File.WriteAllText(At("settings.json"),
+            """{"OpenComposerInBrowser":true,"Theme":"Dark","Language":"ja-JP"}""");
+
+        var s = SettingsService.LoadSettings(At("settings.json"));
+
+        Assert.True(s.OpenComposerInBrowser);
+        // 後から追加されたプロパティはクラス既定値で初期化される
+        Assert.False(s.DefaultHideSidebar);
+        Assert.True(s.DefaultHideCompose);
+        Assert.False(s.DefaultHideListHeader);
+        Assert.Equal("system", s.ExternalBrowser);
+        Assert.Null(s.LastUsedProfileId);
+        Assert.NotNull(s.SavedSearchQueries);
+        Assert.Empty(s.SavedSearchQueries);
+    }
+
+    [Fact]
+    public void LoadSettings_UnknownProperty_Ignored()
+    {
+        // 将来バージョンからのダウングレードを想定（未知プロパティが含まれる）
+        File.WriteAllText(At("settings.json"),
+            """{"Theme":"Light","FuturePropertyFromV99":{"nested":[1,2,3]}}""");
+
+        var s = SettingsService.LoadSettings(At("settings.json"));
+
+        Assert.Equal("Light", s.Theme);
+    }
+
+    [Fact]
+    public void SaveAndLoadSettings_RoundTrip_AllProperties()
+    {
+        var path = At("settings.json");
+        var original = new AppSettings
+        {
+            OpenComposerInBrowser  = true,
+            OpenTimestampInBrowser = true,
+            Theme                  = "Dark",
+            AutoActivateMinutes    = 15,
+            Language               = "en-US",
+            CachedLatestVersion    = "v9.9.9",
+            DefaultHideSidebar     = true,
+            DefaultHideCompose     = false,
+            DefaultHideListHeader  = true,
+            ShowAutoActivateLabel  = true,
+            ExternalBrowser        = "edge",
+            EdgeProfileDirectory   = "Profile 1",
+            LastUsedProfileId      = "abc123",
+            SavedSearchQueries     = ["/search?q=%E6%97%A5%E6%9C%AC&f=live", "/search?q=test"],
+        };
+
+        SettingsService.SaveSettings(path, original);
+        var loaded = SettingsService.LoadSettings(path);
+
+        Assert.True(loaded.OpenComposerInBrowser);
+        Assert.True(loaded.OpenTimestampInBrowser);
+        Assert.Equal("Dark",      loaded.Theme);
+        Assert.Equal(15,          loaded.AutoActivateMinutes);
+        Assert.Equal("en-US",     loaded.Language);
+        Assert.Equal("v9.9.9",    loaded.CachedLatestVersion);
+        Assert.True(loaded.DefaultHideSidebar);
+        Assert.False(loaded.DefaultHideCompose);
+        Assert.True(loaded.DefaultHideListHeader);
+        Assert.True(loaded.ShowAutoActivateLabel);
+        Assert.Equal("edge",      loaded.ExternalBrowser);
+        Assert.Equal("Profile 1", loaded.EdgeProfileDirectory);
+        Assert.Equal("abc123",    loaded.LastUsedProfileId);
+        Assert.Equal(["/search?q=%E6%97%A5%E6%9C%AC&f=live", "/search?q=test"],
+                     loaded.SavedSearchQueries);
+    }
+
     // ── LoadProfiles ──────────────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary
- **AppSettings の後方互換テスト**を追加
  - v1.4 相当の古い settings.json（新プロパティなし）→ クラス既定値で初期化されること
  - 未知プロパティを含む JSON（将来バージョンからのダウングレード想定）→ 無視して読めること
  - 全 14 プロパティのシリアライズ往復
- **SavedSearchQueries の重複排除・先頭挿入**を `SearchQueryHelper.AddSavedQuery` に抽出してテスト化（4 行の機械的な移動、動作不変）
- テスト合計 100 → **106 件**

## ProfileService について（対象外）
イシューに挙げていた `ProfileService` のテストは見送り。唯一のメソッド `GetProfilesDataDir` が `Windows.Storage`（WinRT）に依存しており、net8.0 のテストプロジェクトにソースリンクできない。10 行のパス算出のみで、テストのために抽象化を挟む費用対効果が合わないため。

## Test plan
- [x] ビルド成功（0 警告 / 0 エラー）
- [x] ユニットテスト 106 件全パス
- [x] デバッグ実行で検索 → タイムライン追加 → サジェスト表示を確認（抽出したロジックの経路）

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)