### PR TITLE
feat: 検索タイムラインのヘッダー URL をデコード表示

### DIFF
--- a/Views/MainWindow.Timeline.cs
+++ b/Views/MainWindow.Timeline.cs
@@ -183,7 +183,8 @@ namespace XTimelineViewer.Views
             // URL label
             string displayText = cfg.Url;
             if (Uri.TryCreate(cfg.Url, UriKind.Absolute, out var uri))
-                displayText = uri.Host + uri.PathAndQuery;
+                // 検索クエリの %xx を人間が読めるようデコードする（既存の検索ロジックを再利用）
+                displayText = SearchQueryHelper.DecodeSearchPath(uri.Host + uri.PathAndQuery);
 
             var typeIcon = new FontIcon
             {


### PR DESCRIPTION
## Summary
- タイムラインヘッダーの URL ラベルを `SearchQueryHelper.DecodeSearchPath`（= `Uri.UnescapeDataString`）でデコードして表示
- 検索タイムラインのヘッダーが `x.com/search?q=%E6%97%A5%E6%9C%AC...` ではなく `x.com/search?q=日本代表&f=live` のように人間が読める形になる
- 既存の検索クエリ用デコードロジックを再利用（新規ロジックなし）。検索以外の URL も %xx を含めば読みやすくなる副次効果あり

## Test plan
- [x] ビルド成功（0 警告 / 0 エラー）
- [x] 日本語クエリの検索タイムラインを追加し、ヘッダーがデコード表示される
- [x] ホーム/通知など通常タイムラインのヘッダー表示が従来どおり

🤖 Generated with [Claude Code](https://claude.com/claude-code)