### PR TITLE
feat: タイムラインのベース URL を現在のページに固定できるようにする (#189)

### DIFF
--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -73,6 +73,8 @@
 
   <!-- Timeline pane settings dialog -->
   <data name="Timeline_Settings_Title" xml:space="preserve"><value>Settings</value></data>
+  <data name="Timeline_BaseUrl" xml:space="preserve"><value>Base URL</value></data>
+  <data name="Timeline_SetBaseUrl" xml:space="preserve"><value>Set current page as base URL</value></data>
   <data name="Timeline_Profile" xml:space="preserve"><value>Profile</value></data>
   <data name="Timeline_Width" xml:space="preserve"><value>Timeline Width (px)</value></data>
   <data name="Timeline_Sidebar" xml:space="preserve"><value>X Sidebar</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -73,6 +73,8 @@
 
   <!-- Timeline pane settings dialog -->
   <data name="Timeline_Settings_Title" xml:space="preserve"><value>設定</value></data>
+  <data name="Timeline_BaseUrl" xml:space="preserve"><value>ベース URL</value></data>
+  <data name="Timeline_SetBaseUrl" xml:space="preserve"><value>現在のページをベース URL にする</value></data>
   <data name="Timeline_Profile" xml:space="preserve"><value>プロファイル</value></data>
   <data name="Timeline_Width" xml:space="preserve"><value>タイムラインの幅（px）</value></data>
   <data name="Timeline_Sidebar" xml:space="preserve"><value>X のサイドバー</value></data>

--- a/Views/MainWindow.Timeline.cs
+++ b/Views/MainWindow.Timeline.cs
@@ -427,7 +427,40 @@ namespace XTimelineViewer.Views
                     .FirstOrDefault(i => (string)i.Tag == cfg.ProfileId)
                     ?? profileBox.Items.OfType<ComboBoxItem>().FirstOrDefault();
 
+                // ── ベース URL (#189) ──
+                // WebView2 の現在の表示 URL がベース URL と異なる（別ページを閲覧中）かつ
+                // X の URL のときだけ「現在のページをベース URL にする」を有効化する。
+                var currentSource = webView.CoreWebView2?.Source ?? cfg.Url;
+                string? stagedBaseUrl = null;  // ［適用］で確定する新しいベース URL
+
+                var baseUrlText = new TextBlock
+                {
+                    Text                   = SearchQueryHelper.DecodeSearchPath(cfg.Url),
+                    FontSize               = 12,
+                    Opacity                = 0.8,
+                    TextWrapping           = TextWrapping.Wrap,
+                    IsTextSelectionEnabled = true,
+                };
+
+                var setBaseUrlBtn = new Button
+                {
+                    Content             = R.Get("Timeline_SetBaseUrl"),
+                    HorizontalAlignment = HorizontalAlignment.Stretch,
+                    IsEnabled           = UrlHelper.IsXUrl(currentSource)
+                                       && !UrlHelper.IsOnBaseUrl(currentSource, cfg.Url),
+                };
+                setBaseUrlBtn.Click += (_, _) =>
+                {
+                    stagedBaseUrl        = currentSource;
+                    baseUrlText.Text     = SearchQueryHelper.DecodeSearchPath(stagedBaseUrl);
+                    setBaseUrlBtn.IsEnabled = false;
+                };
+
                 var panel = new StackPanel { Spacing = 8 };
+                panel.Children.Add(new TextBlock { Text = R.Get("Timeline_BaseUrl") });
+                panel.Children.Add(baseUrlText);
+                panel.Children.Add(setBaseUrlBtn);
+                panel.Children.Add(new NavigationViewItemSeparator { Margin = new Thickness(0, 8, 0, 0) });
                 panel.Children.Add(new TextBlock { Text = R.Get("Timeline_Profile") });
                 panel.Children.Add(profileBox);
                 panel.Children.Add(new TextBlock { Text = R.Get("Timeline_Width"), Margin = new Thickness(0, 8, 0, 0) });
@@ -494,6 +527,27 @@ namespace XTimelineViewer.Views
                 }
                 else if (result == ContentDialogResult.Primary)
                 {
+                    // ベース URL の変更を反映 (#189)。プロファイル再生成より前に cfg.Url を
+                    // 更新しておき、再生成時は新しいベース URL へ遷移させる。
+                    bool baseUrlChanged = stagedBaseUrl is not null && stagedBaseUrl != cfg.Url;
+                    if (baseUrlChanged)
+                    {
+                        cfg.Url = stagedBaseUrl!;
+
+                        // ヘッダーの URL ラベル・種別アイコンを更新
+                        urlLabel.Text = Uri.TryCreate(cfg.Url, UriKind.Absolute, out var newUri)
+                            ? SearchQueryHelper.DecodeSearchPath(newUri.Host + newUri.PathAndQuery)
+                            : cfg.Url;
+                        typeIcon.Glyph = UrlHelper.GetTimelineGlyph(cfg.Url);
+                        AutomationProperties.SetName(webView, urlLabel.Text);
+
+                        // ホームタイムライン判定を更新（自動アクティブ化の対象が変わる）
+                        bool nowHome = Uri.TryCreate(cfg.Url, UriKind.Absolute, out var hu)
+                                    && hu.AbsolutePath.StartsWith("/home", StringComparison.OrdinalIgnoreCase);
+                        if (nowHome) _homeHeaderGrids.Add(headerGrid);
+                        else         _homeHeaderGrids.Remove(headerGrid);
+                    }
+
                     var prevProfileId = cfg.ProfileId;
                     cfg.ProfileId = (profileBox.SelectedItem as ComboBoxItem)?.Tag as string ?? "default";
 
@@ -537,6 +591,14 @@ namespace XTimelineViewer.Views
                             await ApplyHideSidebarAsync(webView, cfg.HideSidebar);
                             await ApplyHideComposeAsync(webView, cfg.HideCompose);
                             await ApplyHideListHeaderAsync(webView, cfg.HideListHeader);
+                        }
+
+                        // ベース URL を現在のページに合わせたので乖離状態を解消し、
+                        // 定期ハードリロードの一時停止を再評価する
+                        if (baseUrlChanged)
+                        {
+                            _urlDivergedWebViews.Remove(webView);
+                            EvaluateHardReloadPause(webView);
                         }
                     }
 


### PR DESCRIPTION
## Summary
- ペイン設定ダイアログ（ヘッダーの歯車）の最上部に「ベース URL」セクションを追加
  - 現在のベース URL をデコード表示（読み取り専用・テキスト選択可）
  - 「現在のページをベース URL にする」ボタン — WebView2 の表示 URL がベース URL と異なり、かつ X の URL のときだけ有効
  - ボタン押下で新ベース URL をステージングし、［適用］で確定
- ［適用］時に以下を更新
  - `cfg.Url`（プロファイル再生成より前に更新し、再生成時は新ベースへ遷移）
  - ヘッダーの URL ラベル・種別アイコン・AutomationProperties
  - ホームタイムライン判定（`_homeHeaderGrids`）→ 自動アクティブ化の対象が正しく切り替わる
  - URL 乖離状態（`_urlDivergedWebViews`）を解消し、定期ハードリロードの一時停止を再評価
  - ペインのダブルタップで戻る先も `cfg.Url` 参照のため自動追従
- 判定は既存の `UrlHelper.IsOnBaseUrl` / `IsXUrl` を再利用（新規ロジックなし）

## 既知の制約
- ベース URL を /home → /search のようにヘッダー適用可否が変わる種別へ変更した場合、その回のダイアログでは「リストヘッダー」トグルは旧 URL 基準のまま。再度設定を開けば新基準で操作できる。

## Test plan
- [x] ビルド成功（0 警告 / 0 エラー）
- [x] ユニットテスト 106 件全パス
- [ ] リスト/検索結果などへ移動 → 設定でボタンが有効 → 適用でヘッダー URL・アイコンが変わる
- [ ] ダブルタップで新ベース URL に戻る
- [ ] アプリ再起動で新ベース URL が復元される
- [ ] 同一ベースを表示中（未遷移）はボタンが無効
- [ ] プロファイル変更とベース URL 変更の同時適用

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)