### PR TITLE
feat: 「タイムラインを追加」にリストを追加 (#190)

### DIFF
--- a/Models/ProfileConfig.cs
+++ b/Models/ProfileConfig.cs
@@ -8,5 +8,12 @@ namespace XTimelineViewer.Models
         public string  Name           { get; set; } = "";
         public int?    BadgeColorIndex{ get; set; }
         public string? BadgeText      { get; set; }
+
+        /// <summary>
+        /// X のスクリーンネーム（@ 以降のハンドル）。Name はユーザーが自由に変更できるため、
+        /// ハンドル依存の URL（リスト一覧など）の組み立てにはこちらを使う。
+        /// 作成時に検出し、ペイン読み込み時にも補完する。
+        /// </summary>
+        public string? ScreenName     { get; set; }
     }
 }

--- a/Services/UrlHelper.cs
+++ b/Services/UrlHelper.cs
@@ -19,6 +19,14 @@ namespace XTimelineViewer.Services
                 && string.Equals(cur.AbsolutePath, @base.AbsolutePath, StringComparison.OrdinalIgnoreCase);
         }
 
+        /// <summary>
+        /// アカウント依存のリスト一覧 URL（https://x.com/&lt;handle&gt;/lists）かどうか。
+        /// プロファイル切り替え時にハンドルを差し替える対象の判定に使う。
+        /// </summary>
+        internal static bool IsPerUserListsUrl(string url)
+            => Uri.TryCreate(url, UriKind.Absolute, out var u)
+               && Regex.IsMatch(u.AbsolutePath, @"^/[^/]+/lists$");
+
         // グリフは Segoe Fluent Icons の私用領域(PUA)コードポイント。
         // 生の PUA 文字を直書きするとエンコーディング事故で欠落するため (#122)、
         // 必ず "\uXXXX" エスケープ表記で記述すること。
@@ -31,7 +39,8 @@ namespace XTimelineViewer.Services
             if (p.StartsWith("/search") || p.StartsWith("/explore")) return "\uE71E"; // Search
             if (p == "/bookmarks" || p.StartsWith("/bookmarks/") ||
                 p == "/i/bookmarks" || p.StartsWith("/i/bookmarks/")) return "\uE734"; // Bookmark
-            if (p.StartsWith("/i/lists/"))                            return "\uE71D"; // BulletedList
+            if (p == "/i/lists" || p.StartsWith("/i/lists/") ||
+                Regex.IsMatch(p, @"^/[^/]+/lists$"))                  return "\uE71D"; // BulletedList (lists index / individual)
             if (p.StartsWith("/messages"))                            return "\uE8BD"; // Chat
             if (Regex.IsMatch(p, @"^/[^/]+$"))                        return "\uE77B"; // Contact
             return "\uE774"; // Globe

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -22,6 +22,7 @@
   <data name="Timeline_Home" xml:space="preserve"><value>Home</value></data>
   <data name="Timeline_Notifications" xml:space="preserve"><value>Notifications</value></data>
   <data name="Timeline_Bookmarks" xml:space="preserve"><value>Bookmarks</value></data>
+  <data name="Timeline_Lists" xml:space="preserve"><value>Lists</value></data>
 
   <!-- Add profile window -->
   <data name="AddProfile_Title" xml:space="preserve"><value>Add New Profile</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -22,6 +22,7 @@
   <data name="Timeline_Home" xml:space="preserve"><value>ホーム</value></data>
   <data name="Timeline_Notifications" xml:space="preserve"><value>通知</value></data>
   <data name="Timeline_Bookmarks" xml:space="preserve"><value>ブックマーク</value></data>
+  <data name="Timeline_Lists" xml:space="preserve"><value>リスト</value></data>
 
   <!-- Add profile window -->
   <data name="AddProfile_Title" xml:space="preserve"><value>新しいプロファイルを追加</value></data>

--- a/Views/Controls/ProfileLoginControl.xaml.cs
+++ b/Views/Controls/ProfileLoginControl.xaml.cs
@@ -19,6 +19,9 @@ namespace XTimelineViewer.Views.Controls
     {
         private readonly string _profileId = Guid.NewGuid().ToString("N");
 
+        // ログイン時に検出した X のスクリーンネーム。Name はユーザーが編集できるため別に保持する。
+        private string? _detectedScreenName;
+
         /// <summary>このコントロールが扱う新規プロファイルの ID。</summary>
         public string ProfileId => _profileId;
 
@@ -65,6 +68,7 @@ namespace XTimelineViewer.Views.Controls
                 if (!uri.AbsolutePath.TrimEnd('/').Equals("/home", StringComparison.OrdinalIgnoreCase)) return;
 
                 var screenName = await TryGetScreenNameAsync();
+                _detectedScreenName = screenName;
                 ShowConfirmPhase(screenName);
                 LoginDetected?.Invoke(screenName);
             };
@@ -104,7 +108,7 @@ namespace XTimelineViewer.Views.Controls
         {
             var name = ProfileNameBox.Text.Trim();
             if (string.IsNullOrEmpty(name)) return null;
-            return new ProfileConfig { Id = _profileId, Name = name };
+            return new ProfileConfig { Id = _profileId, Name = name, ScreenName = _detectedScreenName };
         }
     }
 }

--- a/Views/MainWindow.Timeline.cs
+++ b/Views/MainWindow.Timeline.cs
@@ -103,6 +103,15 @@ namespace XTimelineViewer.Views
         internal const string NotificationsTimelineUrl = "https://x.com/notifications";
         internal const string BookmarksTimelineUrl     = "https://x.com/i/bookmarks";
 
+        // リスト一覧はアカウント依存の URL（https://x.com/&lt;handle&gt;/lists）。
+        // 実際に追加する URL はクリック時にプロファイルのハンドルから組み立てる。
+        internal static string BuildListsUrl(string handle) => $"https://x.com/{handle}/lists";
+
+        // ハンドル依存 URL の組み立てに使うスクリーンネームを解決する。
+        // Name はユーザーが編集できるため、検出済みの ScreenName を優先する。
+        private static string ResolveProfileHandle(ProfileConfig profile)
+            => profile.ScreenName is { Length: > 0 } sn ? sn : profile.Name;
+
         private void AddHomeTimelineItem_Click(object _, RoutedEventArgs __)
             => AddTimeline(CreateDefaultConfig(HomeTimelineUrl));
 
@@ -111,6 +120,18 @@ namespace XTimelineViewer.Views
 
         private void AddBookmarksTimelineItem_Click(object _, RoutedEventArgs __)
             => AddTimeline(CreateDefaultConfig(BookmarksTimelineUrl));
+
+        private void AddListsTimelineItem_Click(object _, RoutedEventArgs __)
+        {
+            // ハンドルが必要なため、URL を組み立てる名前付きプロファイルを先に決める
+            // （AddTimeline の既定割り当てと同じく最初の名前付きプロファイル）
+            var profile = _profiles.FirstOrDefault(p => p.Id != "default");
+            if (profile is null) return;
+
+            var cfg = CreateDefaultConfig(BuildListsUrl(ResolveProfileHandle(profile)));
+            cfg.ProfileId = profile.Id;
+            AddTimeline(cfg);
+        }
 
         // ── CreateDefaultConfig ───────────────────────────────────────────────
 
@@ -527,19 +548,13 @@ namespace XTimelineViewer.Views
                 }
                 else if (result == ContentDialogResult.Primary)
                 {
-                    // ベース URL の変更を反映 (#189)。プロファイル再生成より前に cfg.Url を
-                    // 更新しておき、再生成時は新しいベース URL へ遷移させる。
-                    bool baseUrlChanged = stagedBaseUrl is not null && stagedBaseUrl != cfg.Url;
-                    if (baseUrlChanged)
+                    // ヘッダーの URL 表示・種別アイコン・ホーム判定を cfg.Url に合わせて更新する
+                    void RefreshUrlChrome()
                     {
-                        cfg.Url = stagedBaseUrl!;
-
-                        // ヘッダーの URL ラベル・種別アイコンを更新
-                        urlLabel.Text = Uri.TryCreate(cfg.Url, UriKind.Absolute, out var newUri)
-                            ? SearchQueryHelper.DecodeSearchPath(newUri.Host + newUri.PathAndQuery)
+                        urlLabel.Text = Uri.TryCreate(cfg.Url, UriKind.Absolute, out var u)
+                            ? SearchQueryHelper.DecodeSearchPath(u.Host + u.PathAndQuery)
                             : cfg.Url;
                         typeIcon.Glyph = UrlHelper.GetTimelineGlyph(cfg.Url);
-                        AutomationProperties.SetName(webView, urlLabel.Text);
 
                         // ホームタイムライン判定を更新（自動アクティブ化の対象が変わる）
                         bool nowHome = Uri.TryCreate(cfg.Url, UriKind.Absolute, out var hu)
@@ -548,8 +563,30 @@ namespace XTimelineViewer.Views
                         else         _homeHeaderGrids.Remove(headerGrid);
                     }
 
+                    // ベース URL の変更を反映 (#189)。プロファイル再生成より前に cfg.Url を
+                    // 更新しておき、再生成時は新しいベース URL へ遷移させる。
+                    bool baseUrlChanged = stagedBaseUrl is not null && stagedBaseUrl != cfg.Url;
+                    if (baseUrlChanged)
+                    {
+                        cfg.Url = stagedBaseUrl!;
+                        RefreshUrlChrome();
+                        AutomationProperties.SetName(webView, urlLabel.Text);
+                    }
+
                     var prevProfileId = cfg.ProfileId;
                     cfg.ProfileId = (profileBox.SelectedItem as ComboBoxItem)?.Tag as string ?? "default";
+
+                    // リスト一覧はハンドル依存 URL のため、プロファイル切り替えに合わせて
+                    // URL のハンドルも新しいプロファイルに差し替える (#190)
+                    if (prevProfileId != cfg.ProfileId && UrlHelper.IsPerUserListsUrl(cfg.Url))
+                    {
+                        var newProfile = _profiles.FirstOrDefault(p => p.Id == cfg.ProfileId);
+                        if (newProfile is not null)
+                        {
+                            cfg.Url = BuildListsUrl(ResolveProfileHandle(newProfile));
+                            RefreshUrlChrome();
+                        }
+                    }
 
                     cfg.Width  = Math.Clamp(widthBox.Value, 100, 2000);
                     pane.Width = cfg.Width;
@@ -574,6 +611,7 @@ namespace XTimelineViewer.Views
                         pane.Children.Add(webView);
                         _webViews.Add(webView);
                         _webViewToPane[webView] = pane;
+                        AutomationProperties.SetName(webView, urlLabel.Text);
 
                         var newBadge = CreateProfileBadge(cfg.ProfileId);
                         Grid.SetColumn(newBadge, 1);

--- a/Views/MainWindow.WebView2.cs
+++ b/Views/MainWindow.WebView2.cs
@@ -347,6 +347,47 @@ namespace XTimelineViewer.Views
             catch { /* ログ書き込み失敗は無視 */ }
         }
 
+        /// <summary>
+        /// ログイン中セッションから X のスクリーンネームを読み取り、プロファイルに未保存なら補完する。
+        /// 左ナビの「プロフィール」リンク（AppTabBar_Profile_Link）はセッション所有者のハンドルを指すため、
+        /// どの X ページでも取得できる。既に保存済みのプロファイルは触らない（不要な保存を避ける）。
+        /// </summary>
+        private async Task BackfillScreenNameAsync(WebView2 webView, string profileId)
+        {
+            var profile = _profiles.FirstOrDefault(p => p.Id == profileId);
+            if (profile is null || profile.ScreenName is { Length: > 0 }) return;
+
+            // 左ナビ（AppTabBar_Profile_Link）は SPA のため NavigationCompleted の後に描画される。
+            // /home では間に合うが、検索や /&lt;user&gt;/lists などでは遅延するため、
+            // 要素が現れるまで数回リトライする。
+            for (int attempt = 0; attempt < 6; attempt++)
+            {
+                // 別ペインが先に解決済みなら終了（保存の重複も避ける）
+                if (profile.ScreenName is { Length: > 0 }) return;
+
+                try
+                {
+                    var result = await webView.CoreWebView2.ExecuteScriptAsync(
+                        "document.querySelector('[data-testid=\"AppTabBar_Profile_Link\"]')?.href?.split('/').pop() ?? null");
+                    if (result?.Trim('"') is { Length: > 0 } name && name != "null")
+                    {
+                        profile.ScreenName = name;
+                        SaveProfiles();
+                        Debug.WriteLine($"[Profile] ScreenName backfilled: {profile.Name} -> @{name} (attempt {attempt + 1})");
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"[Profile] BackfillScreenNameAsync failed: {ex.Message}");
+                    return;
+                }
+
+                await Task.Delay(700);
+            }
+            Debug.WriteLine($"[Profile] ScreenName not found for {profile.Name} (nav link absent — logged out?)");
+        }
+
         private async Task InitWebViewAsync(WebView2 webView, TimelineConfig cfg)
         {
             try
@@ -453,6 +494,10 @@ namespace XTimelineViewer.Views
                     {
                         await ApplyAutoShowNewPostsAsync(webView, cfg.Url);
                     }
+
+                    // プロファイルのスクリーンネームが未取得なら、ログイン中セッションから補完する
+                    // （旧バージョンで作成したプロファイルや、Name を編集したプロファイルの救済）。
+                    await BackfillScreenNameAsync(webView, cfg.ProfileId);
                 }
             };
 

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -95,6 +95,11 @@
                                         <FontIcon x:Name="AddBookmarksIcon" FontFamily="Segoe Fluent Icons"/>
                                     </MenuFlyoutItem.Icon>
                                 </MenuFlyoutItem>
+                                <MenuFlyoutItem x:Name="AddListsTimelineItem" Click="AddListsTimelineItem_Click">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon x:Name="AddListsIcon" FontFamily="Segoe Fluent Icons"/>
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
                             </MenuFlyoutSubItem>
                             <MenuFlyoutSeparator/>
                             <MenuFlyoutSubItem x:Name="ThemeSubMenu">

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -263,10 +263,13 @@ namespace XTimelineViewer.Views
             AddHomeTimelineItem.Text          = R.Get("Timeline_Home");
             AddNotificationsTimelineItem.Text = R.Get("Timeline_Notifications");
             AddBookmarksTimelineItem.Text     = R.Get("Timeline_Bookmarks");
+            AddListsTimelineItem.Text         = R.Get("Timeline_Lists");
             // アイコンは既存ペインと同じく URL 種別から導出して一貫性を保つ
             AddHomeIcon.Glyph          = UrlHelper.GetTimelineGlyph(HomeTimelineUrl);
             AddNotificationsIcon.Glyph = UrlHelper.GetTimelineGlyph(NotificationsTimelineUrl);
             AddBookmarksIcon.Glyph     = UrlHelper.GetTimelineGlyph(BookmarksTimelineUrl);
+            // リスト URL はハンドル依存のため、アイコン導出には代表的な一覧パスを使う
+            AddListsIcon.Glyph         = UrlHelper.GetTimelineGlyph(BuildListsUrl("_"));
 
             SearchBox.PlaceholderText = R.Get("Search_Placeholder");
             ToolTipService.SetToolTip(SearchBox, R.Get("Search_Tooltip"));

--- a/XTimelineViewer.Tests/Services/UrlHelperTests.cs
+++ b/XTimelineViewer.Tests/Services/UrlHelperTests.cs
@@ -37,7 +37,8 @@ public class UrlHelperTests
     [InlineData("https://x.com/search?q=test",     "\uE71E")] // Search
     [InlineData("https://x.com/explore",           "\uE71E")] // Search
     [InlineData("https://x.com/i/bookmarks",       "\uE734")] // Bookmark
-    [InlineData("https://x.com/i/lists/123",       "\uE71D")] // BulletedList
+    [InlineData("https://x.com/daruyanagi/lists",  "\uE71D")] // BulletedList (per-user lists index)
+    [InlineData("https://x.com/i/lists/123",       "\uE71D")] // BulletedList (individual list)
     [InlineData("https://x.com/messages",          "\uE8BD")] // Chat
     [InlineData("https://x.com/daruyanagi",        "\uE77B")] // Contact
     [InlineData("https://x.com/i/grok",            "\uE774")] // Globe (fallback)
@@ -60,6 +61,18 @@ public class UrlHelperTests
     [InlineData("not-a-url",                    false)]
     public void IsListHeaderApplicable_Works(string url, bool expected)
         => Assert.Equal(expected, UrlHelper.IsListHeaderApplicable(url));
+
+    // ── IsPerUserListsUrl ─────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("https://x.com/daruyanagi/lists", true)]
+    [InlineData("https://x.com/i/lists",          true)]   // /<seg>/lists にマッチ
+    [InlineData("https://x.com/i/lists/123",      false)]  // 個別リストは対象外
+    [InlineData("https://x.com/daruyanagi",       false)]  // プロフィール
+    [InlineData("https://x.com/home",             false)]
+    [InlineData("not-a-url",                      false)]
+    public void IsPerUserListsUrl_Works(string url, bool expected)
+        => Assert.Equal(expected, UrlHelper.IsPerUserListsUrl(url));
 
     // ── ParseUrlShortcut ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
「タイムラインを追加」メニュー（ホーム/通知/ブックマーク）に **リスト** を追加。リスト一覧はアカウント依存の URL（`https://x.com/<handle>/lists`）のため、ハンドルの扱いを整備した。

### 変更点
- メニュー項目「リスト」＋リソース `Timeline_Lists`（リスト / Lists）
- **`ProfileConfig.ScreenName` を追加** — `Name` はユーザーが自由に編集できるため、X のハンドルは別フィールドで管理
  - プロファイル作成時に検出した screen_name を保存
  - 既存プロファイル救済: ペイン読み込み時に未取得なら、ログイン中セッションの `AppTabBar_Profile_Link` から実ハンドルを補完・保存
- **取得タイミング対策**: `AppTabBar_Profile_Link` は SPA のため `NavigationCompleted` 後に描画される。`/home` 以外（検索・`/<user>/lists`）では 1 回読みでは間に合わないため、要素が現れるまで最大 6 回リトライ
- リスト URL は `ResolveProfileHandle`（`ScreenName` 優先・無ければ `Name`）で組み立て、ペインのプロファイル切り替え時はハンドルも差し替え（#189 のベース URL 反映ロジックを再利用）
- `UrlHelper.GetTimelineGlyph` を `/<handle>/lists` に対応、`IsPerUserListsUrl` を追加

### レビュー時の補足
- `Name` の信頼性問題（カスタム表示名は screen_name と一致しない）への対応が本 PR の肝。検証で、表示名を "T" にカスタムしたプロファイルでも実ハンドル `TaruiHideto` が補完されることを確認済み
- 既存の壊れた lists URL（`/<表示名>/lists`）は、ScreenName 補完後にプロファイルを再選択すると正しい URL に再構築される

## Test plan
- [x] ビルド 0 警告 0 エラー
- [x] ユニットテスト 113 件全パス（IsPerUserListsUrl / glyph 追加）
- [x] メニュー「リスト」で `/<handle>/lists` が開く
- [x] 表示名をカスタムしたプロファイルでも ScreenName が実ハンドルに解決
- [x] `/home` ペインを持たないプロファイル（検索/lists のみ）でも ScreenName が補完される
- [x] プロファイル切り替えでリスト URL のハンドルが追従

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)