### PR TITLE
feat: リストタイムラインのハンドルを使用時にライブ取得 (#211)

### DIFF
--- a/Models/TimelineConfig.cs
+++ b/Models/TimelineConfig.cs
@@ -10,5 +10,12 @@ namespace XTimelineViewer.Models
         public bool   HardReloadEnabled { get; set; } = false;
         public int    HardReloadInterval{ get; set; } = 3;
         public string ProfileId         { get; set; } = "default";
+
+        /// <summary>
+        /// 「リスト」メニューから追加した、アクティブアカウントのリスト一覧を追跡するタイムライン。
+        /// X の委任アカウントを考慮し、ハンドルは作成時のキャッシュではなくペイン読み込みごとに
+        /// ライブ取得して URL（https://x.com/&lt;active&gt;/lists）を解決する (#211)。
+        /// </summary>
+        public bool   IsListsIndex      { get; set; } = false;
     }
 }

--- a/Views/MainWindow.Profiles.cs
+++ b/Views/MainWindow.Profiles.cs
@@ -55,6 +55,7 @@ namespace XTimelineViewer.Views
                         _focusedHeaderGrid = null;
                 }
                 _paneToSetFocus.Remove(pane);
+                _paneUrlUpdaters.Remove(_configs[idx]);
                 TimelinePanel.Children.RemoveAt(idx);
                 _configs.RemoveAt(idx);
             }

--- a/Views/MainWindow.Timeline.cs
+++ b/Views/MainWindow.Timeline.cs
@@ -123,13 +123,15 @@ namespace XTimelineViewer.Views
 
         private void AddListsTimelineItem_Click(object _, RoutedEventArgs __)
         {
-            // ハンドルが必要なため、URL を組み立てる名前付きプロファイルを先に決める
-            // （AddTimeline の既定割り当てと同じく最初の名前付きプロファイル）
+            // URL を組み立てる名前付きプロファイルを決める（AddTimeline の既定割り当てと同じ）
             var profile = _profiles.FirstOrDefault(p => p.Id != "default");
             if (profile is null) return;
 
+            // 初期 URL はキャッシュ済みハンドルの推測。実ハンドルはペイン読み込み時に
+            // EnsureListsUrlAsync がアクティブアカウントからライブ解決する (#211)。
             var cfg = CreateDefaultConfig(BuildListsUrl(ResolveProfileHandle(profile)));
-            cfg.ProfileId = profile.Id;
+            cfg.ProfileId    = profile.Id;
+            cfg.IsListsIndex = true;
             AddTimeline(cfg);
         }
 
@@ -273,6 +275,20 @@ namespace XTimelineViewer.Views
             TimelinePanel.Children.Add(pane);
             _webViews.Add(webView);
             _webViewToPane[webView] = pane;
+
+            // cfg.Url の変更をヘッダーへ反映する更新子（ベース URL 変更・リスト URL ライブ解決で再利用）
+            _paneUrlUpdaters[cfg] = () =>
+            {
+                urlLabel.Text = Uri.TryCreate(cfg.Url, UriKind.Absolute, out var u)
+                    ? SearchQueryHelper.DecodeSearchPath(u.Host + u.PathAndQuery)
+                    : cfg.Url;
+                typeIcon.Glyph = UrlHelper.GetTimelineGlyph(cfg.Url);
+                AutomationProperties.SetName(webView, urlLabel.Text);
+                bool nowHome = Uri.TryCreate(cfg.Url, UriKind.Absolute, out var hu)
+                            && hu.AbsolutePath.StartsWith("/home", StringComparison.OrdinalIgnoreCase);
+                if (nowHome) _homeHeaderGrids.Add(headerGrid);
+                else         _homeHeaderGrids.Remove(headerGrid);
+            };
 
             // ── Focus ─────────────────────────────────────────────────────────
 
@@ -535,6 +551,7 @@ namespace XTimelineViewer.Views
                     }
                     _configs.Remove(cfg);
                     _paneToSetFocus.Remove(pane);
+                    _paneUrlUpdaters.Remove(cfg);
                     _headerRefreshers.Remove(refreshHeader);
                     if (_focusedHeaderGrid == headerGrid)
                     {
@@ -548,45 +565,23 @@ namespace XTimelineViewer.Views
                 }
                 else if (result == ContentDialogResult.Primary)
                 {
-                    // ヘッダーの URL 表示・種別アイコン・ホーム判定を cfg.Url に合わせて更新する
-                    void RefreshUrlChrome()
-                    {
-                        urlLabel.Text = Uri.TryCreate(cfg.Url, UriKind.Absolute, out var u)
-                            ? SearchQueryHelper.DecodeSearchPath(u.Host + u.PathAndQuery)
-                            : cfg.Url;
-                        typeIcon.Glyph = UrlHelper.GetTimelineGlyph(cfg.Url);
-
-                        // ホームタイムライン判定を更新（自動アクティブ化の対象が変わる）
-                        bool nowHome = Uri.TryCreate(cfg.Url, UriKind.Absolute, out var hu)
-                                    && hu.AbsolutePath.StartsWith("/home", StringComparison.OrdinalIgnoreCase);
-                        if (nowHome) _homeHeaderGrids.Add(headerGrid);
-                        else         _homeHeaderGrids.Remove(headerGrid);
-                    }
-
                     // ベース URL の変更を反映 (#189)。プロファイル再生成より前に cfg.Url を
                     // 更新しておき、再生成時は新しいベース URL へ遷移させる。
                     bool baseUrlChanged = stagedBaseUrl is not null && stagedBaseUrl != cfg.Url;
                     if (baseUrlChanged)
                     {
                         cfg.Url = stagedBaseUrl!;
-                        RefreshUrlChrome();
-                        AutomationProperties.SetName(webView, urlLabel.Text);
+                        // 具体ページを明示的に固定したので、リスト一覧の自動追従は解除する (#211)
+                        cfg.IsListsIndex = false;
+                        _paneUrlUpdaters[cfg]();
                     }
 
                     var prevProfileId = cfg.ProfileId;
                     cfg.ProfileId = (profileBox.SelectedItem as ComboBoxItem)?.Tag as string ?? "default";
 
-                    // リスト一覧はハンドル依存 URL のため、プロファイル切り替えに合わせて
-                    // URL のハンドルも新しいプロファイルに差し替える (#190)
-                    if (prevProfileId != cfg.ProfileId && UrlHelper.IsPerUserListsUrl(cfg.Url))
-                    {
-                        var newProfile = _profiles.FirstOrDefault(p => p.Id == cfg.ProfileId);
-                        if (newProfile is not null)
-                        {
-                            cfg.Url = BuildListsUrl(ResolveProfileHandle(newProfile));
-                            RefreshUrlChrome();
-                        }
-                    }
+                    // リスト一覧（IsListsIndex）はプロファイル切り替え後、再生成したペインの
+                    // 読み込み時に EnsureListsUrlAsync がアクティブアカウントのハンドルで
+                    // ライブ解決するため、ここでは URL を組み立てない (#211)
 
                     cfg.Width  = Math.Clamp(widthBox.Value, 100, 2000);
                     pane.Width = cfg.Width;

--- a/Views/MainWindow.WebView2.cs
+++ b/Views/MainWindow.WebView2.cs
@@ -348,44 +348,71 @@ namespace XTimelineViewer.Views
         }
 
         /// <summary>
-        /// ログイン中セッションから X のスクリーンネームを読み取り、プロファイルに未保存なら補完する。
-        /// 左ナビの「プロフィール」リンク（AppTabBar_Profile_Link）はセッション所有者のハンドルを指すため、
-        /// どの X ページでも取得できる。既に保存済みのプロファイルは触らない（不要な保存を避ける）。
+        /// 現在アクティブなアカウントの X スクリーンネームをセッションからライブ取得する。
+        /// 左ナビの「プロフィール」リンク（AppTabBar_Profile_Link）は委任アカウント切り替え後も
+        /// アクティブなアカウントを指す。SPA のため NavigationCompleted 後に遅延描画されるので、
+        /// 要素が現れるまで数回リトライする。取得できなければ（ログアウト等）null。
+        /// </summary>
+        private static async Task<string?> TryReadActiveScreenNameAsync(WebView2 webView, int attempts = 6)
+        {
+            for (int i = 0; i < attempts; i++)
+            {
+                try
+                {
+                    var result = await webView.CoreWebView2.ExecuteScriptAsync(
+                        "document.querySelector('[data-testid=\"AppTabBar_Profile_Link\"]')?.href?.split('/').pop() ?? null");
+                    if (result?.Trim('"') is { Length: > 0 } name && name != "null")
+                        return name;
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"[Profile] TryReadActiveScreenNameAsync failed: {ex.Message}");
+                    return null;
+                }
+                await Task.Delay(700);
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// プロファイルの ScreenName が未保存なら、現在のセッションから補完する。
+        /// リスト URL 解決の正の情報源はライブ取得（<see cref="EnsureListsUrlAsync"/>）だが、
+        /// このキャッシュは初回ナビゲーションのちらつき低減用の初期推測として残している (#211)。
         /// </summary>
         private async Task BackfillScreenNameAsync(WebView2 webView, string profileId)
         {
             var profile = _profiles.FirstOrDefault(p => p.Id == profileId);
             if (profile is null || profile.ScreenName is { Length: > 0 }) return;
 
-            // 左ナビ（AppTabBar_Profile_Link）は SPA のため NavigationCompleted の後に描画される。
-            // /home では間に合うが、検索や /&lt;user&gt;/lists などでは遅延するため、
-            // 要素が現れるまで数回リトライする。
-            for (int attempt = 0; attempt < 6; attempt++)
+            var name = await TryReadActiveScreenNameAsync(webView);
+            if (name is { Length: > 0 } && profile.ScreenName is not { Length: > 0 })
             {
-                // 別ペインが先に解決済みなら終了（保存の重複も避ける）
-                if (profile.ScreenName is { Length: > 0 }) return;
-
-                try
-                {
-                    var result = await webView.CoreWebView2.ExecuteScriptAsync(
-                        "document.querySelector('[data-testid=\"AppTabBar_Profile_Link\"]')?.href?.split('/').pop() ?? null");
-                    if (result?.Trim('"') is { Length: > 0 } name && name != "null")
-                    {
-                        profile.ScreenName = name;
-                        SaveProfiles();
-                        Debug.WriteLine($"[Profile] ScreenName backfilled: {profile.Name} -> @{name} (attempt {attempt + 1})");
-                        return;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Debug.WriteLine($"[Profile] BackfillScreenNameAsync failed: {ex.Message}");
-                    return;
-                }
-
-                await Task.Delay(700);
+                profile.ScreenName = name;
+                SaveProfiles();
+                Debug.WriteLine($"[Profile] ScreenName backfilled: {profile.Name} -> @{name}");
             }
-            Debug.WriteLine($"[Profile] ScreenName not found for {profile.Name} (nav link absent — logged out?)");
+        }
+
+        /// <summary>
+        /// リスト一覧タイムライン（<see cref="TimelineConfig.IsListsIndex"/>）の URL を、
+        /// 現在アクティブなアカウントのハンドルでライブ解決する。委任アカウント切り替えにも追従する。
+        /// 既に正しい URL ならナビゲートしない。
+        /// </summary>
+        private async Task EnsureListsUrlAsync(WebView2 webView, TimelineConfig cfg)
+        {
+            if (!cfg.IsListsIndex) return;
+
+            var handle = await TryReadActiveScreenNameAsync(webView);
+            if (handle is not { Length: > 0 }) return;  // ログアウト等は何もしない
+
+            var target = BuildListsUrl(handle);
+            if (UrlHelper.IsOnBaseUrl(webView.CoreWebView2.Source, target)) return;  // 既に正しい
+
+            cfg.Url = target;
+            if (_paneUrlUpdaters.TryGetValue(cfg, out var update)) update();
+            await SaveTimelinesAsync();
+            webView.Source = new Uri(target);
+            Debug.WriteLine($"[Lists] Resolved active lists URL: {target}");
         }
 
         private async Task InitWebViewAsync(WebView2 webView, TimelineConfig cfg)
@@ -496,8 +523,11 @@ namespace XTimelineViewer.Views
                     }
 
                     // プロファイルのスクリーンネームが未取得なら、ログイン中セッションから補完する
-                    // （旧バージョンで作成したプロファイルや、Name を編集したプロファイルの救済）。
+                    // （初期推測用のキャッシュ。リスト URL 解決の正は EnsureListsUrlAsync）。
                     await BackfillScreenNameAsync(webView, cfg.ProfileId);
+
+                    // リスト一覧はアクティブアカウントのハンドルでライブ解決する（委任アカウント対応 #211）
+                    await EnsureListsUrlAsync(webView, cfg);
                 }
             };
 

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -102,6 +102,8 @@ namespace XTimelineViewer.Views
         private List<ProfileConfig> _profiles = [];
         private readonly Dictionary<WebView2, Grid>            _webViewToPane  = [];
         private readonly Dictionary<Grid, Action>              _paneToSetFocus = [];
+        // cfg.Url の変更をヘッダー（URL ラベル・種別アイコン・ホーム判定）へ反映する更新子 (#211)
+        private readonly Dictionary<TimelineConfig, Action>    _paneUrlUpdaters = [];
         private readonly Dictionary<WebView2, DispatcherTimer>  _hardReloadTimers    = [];
         private readonly Dictionary<WebView2, DateTimeOffset>   _hardReloadStartTimes = [];
         private readonly Dictionary<WebView2, Action>           _hardReloadUiUpdaters = [];


### PR DESCRIPTION
## Summary
X の**委任アカウント**では認証アカウントと「現在アクティブなアカウント」が一致せず、セッション途中で切り替わり得る。`AppTabBar_Profile_Link` はアクティブなアカウントを指すため、#190 のように作成時の `ScreenName` をキャッシュして使うと正しいリストを開けないケースがある。本 PR ではリスト URL のハンドルを**ペイン読み込みごとにライブ取得**して解決する。

### 変更点
- `TimelineConfig.IsListsIndex` を追加 — 「リスト」メニューで追加したタイムラインのみ true（アクティブアカウントのリストを追跡）
- `TryReadActiveScreenNameAsync` — 左ナビからアクティブアカウントのハンドルをライブ取得（SPA の遅延描画に対するリトライ付き）。`BackfillScreenNameAsync` もこれを共用
- `EnsureListsUrlAsync` — `IsListsIndex` ペインの読み込み完了時に毎回ライブ解決し、`/<active>/lists` と異なれば URL を補正・ナビゲート・保存
- プロファイル切り替え時のキャッシュベース URL 組み立て（#190）を撤去し、再生成ペインの読み込み時のライブ解決に委ねる
- #189 でベース URL を具体ページに固定したら `IsListsIndex` を解除（意図的に固定したページを上書きしない）
- ヘッダー更新（URL ラベル・種別アイコン・ホーム判定）を `_paneUrlUpdaters` 辞書に集約し、ベース URL 変更とリスト URL ライブ解決で共用
- `ScreenName` キャッシュとログイン時取得（ProfileLoginControl）は将来利用のため**残置**。初期ナビゲーションのちらつき低減用の初期推測としてのみ使用

### レビュー時の補足
- 既存の `/<表示名>/lists`（#190 以前に作成）は `IsListsIndex=false` のため自動追従しない。メニューから追加し直すと新フラグが付く
- ログアウト中のセッションではハンドルを取得できず、URL は補正されない（正しい挙動）

## Test plan
- [x] ビルド 0 警告 0 エラー
- [x] ユニットテスト 113 件全パス
- [x] 「リスト」追加でアクティブアカウントのリストが開く
- [x] 委任アカウントに切り替えた状態でリストペインをリロード → アクティブ側のリストに追従
- [x] プロファイル切り替えでリスト URL のハンドルが追従
- [ ] `/home` ペインを持たないプロファイルでもリストが解決
- [x] ベース URL 固定後はリスト自動追従が無効化される

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)