### PR TITLE
fix: Ctrl+F / F3 のアクセラレータツールチップが UI 全体に出るのを抑止 (#214)

### DIFF
--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -5,7 +5,11 @@
     xmlns:local="using:XTimelineViewer.Views"
     Title="XTimelineViewer">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <!-- KeyboardAcceleratorPlacementMode=Hidden: ルート Grid のグローバルアクセラレータ
+         （Ctrl+F / F3）の自動ツールチップが UI のあちこちに出るのを抑止する (#214)。
+         ショートカット自体は引き続き機能する。 -->
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+          KeyboardAcceleratorPlacementMode="Hidden">
         <Grid.KeyboardAccelerators>
             <KeyboardAccelerator Key="F" Modifiers="Control" Invoked="FocusSearchBox_Invoked"/>
             <KeyboardAccelerator Key="F3" Invoked="FocusSearchBox_Invoked"/>


### PR DESCRIPTION
## Summary
ルートの `Grid` に `KeyboardAcceleratorPlacementMode="Hidden"` を設定し、Ctrl+F / F3 のグローバルアクセラレータの自動ツールチップが UI のあちこちに「Ctrl+F」として表示される問題を修正。

## 背景
WinUI は Windows 10 1803 以降、`KeyboardAccelerator` を宣言した要素にキー組み合わせのツールチップを既定（`Auto`）で自動表示する。#182 のフォローで Ctrl+F / F3 をウィンドウ全体を覆うルート `Grid`（グローバルスコープ）に配置したため、ツールチップが広範囲に出ていた。`Hidden` で自動ツールチップのみ抑止し、ショートカット自体は維持する。検索ボックスは別途自前のツールチップを持つため発見性も損なわれない。

調査の詳細は #214 のコメント参照。

## Test plan
- [x] ビルド 0 警告 0 エラー
- [x] UI のどこをホバーしても「Ctrl+F」ツールチップが出ない
- [x] Ctrl+F / F3 で検索ボックスにフォーカスが移る（WebView2 操作中も含む）

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)