### PR TITLE
chore: v1.6.1（#214 修正の取り込み + Release.ps1 バグ修正）

### DIFF
--- a/Package.appxmanifest
+++ b/Package.appxmanifest
@@ -8,7 +8,7 @@
   <Identity
     Name="4275.XTimelineViewer"
     Publisher="CN=B73FDB0C-06E5-4824-9E7F-3AF969921DF4"
-    Version="1.6.0.0"
+    Version="1.6.1.0"
     ProcessorArchitecture="neutral" />
 
   <Properties>

--- a/Release.ps1
+++ b/Release.ps1
@@ -55,7 +55,9 @@ if ($Version) {
     if ($Version -notmatch '^\d+\.\d+\.\d+$') { throw "Version は x.y.z 形式で指定してください: $Version" }
     (Get-Content $proj -Raw) -replace '<Version>[\d.]+</Version>', "<Version>$Version</Version>" |
         Set-Content $proj -Encoding utf8 -NoNewline
-    (Get-Content $manifest -Raw) -replace 'Version="[\d.]+"', "Version=`"$Version.0`"" |
+    # Identity の Version のみを置換する。-creplace（大文字小文字を区別）で XML 宣言の
+    # 小文字 version="1.0" を除外し、ProcessorArchitecture への先読みで MinVersion 等を除外する。
+    (Get-Content $manifest -Raw) -creplace 'Version="[\d.]+"(?=\s+ProcessorArchitecture)', "Version=`"$Version.0`"" |
         Set-Content $manifest -Encoding utf8 -NoNewline
     Write-Host "csproj / appxmanifest を $Version に更新しました"
 } else {

--- a/XTimelineViewer.csproj
+++ b/XTimelineViewer.csproj
@@ -7,7 +7,7 @@
     <Platforms>x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
     <PlatformTarget>x64</PlatformTarget>
-    <Version>1.6.0</Version>
+    <Version>1.6.1</Version>
     <ApplicationIcon>Assets\AppIcon.ico</ApplicationIcon>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
パッチリリース v1.6.1。

## 内容
- **bump version to 1.6.1**（csproj + Package.appxmanifest）
- **fix: Release.ps1 のバージョン置換バグ** — `-replace` が大小無視＆貪欲で、Identity の `Version` 以外（XML 宣言 `version="1.0"`、`MinVersion="10.0.17763.0"`）まで書き換えていた。`-creplace` + `ProcessorArchitecture` への先読みで Identity の Version のみ対象に修正。`-Version` 経路の初実行で顕在化したため本リリースで同梱

## v1.6.0 からの変更（リリースノート用）
- fix: Ctrl+F / F3 のアクセラレータツールチップが UI 全体に出るのを抑止 (#214)

（`Release.ps1` 整備の chore は開発用のためアプリ動作には影響なし）

## リリース手順（パッチ＝Store 申請不要）
マージ後に `v1.6.1` タグを push → CI（release.yml）が ZIP ビルド + GitHub リリース作成 + winget 公開を自動実行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)