### PR TITLE
マウスホイールで操作したペインをアクティブ化 (#221)

### DIFF
--- a/Views/MainWindow.Post.cs
+++ b/Views/MainWindow.Post.cs
@@ -252,6 +252,12 @@ namespace XTimelineViewer.Views
                 case "focusSearch":
                     SearchBox.Focus(FocusState.Programmatic);
                     break;
+                case "activate":
+                    // ホイール操作したペインをアクティブ化（キーフォーカス移動）#221
+                    if (_webViewToPane.TryGetValue(senderWebView, out var actPane) &&
+                        _paneToSetFocus.TryGetValue(actPane, out var actSetFocus))
+                        actSetFocus();
+                    break;
             }
         }
 

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -176,6 +176,17 @@ namespace XTimelineViewer.Views
                         if (k === 'Backspace' && ni) { e.preventDefault(); history.back(); return; }
                     }
                 }, true);
+
+                // マウスホイールでスクロールしたら、そのペインをアクティブ化する (#221)。
+                // ホイールはキーフォーカスを移さないため、Home/End 等が別ペインに効いてしまうのを防ぐ。
+                // 既にフォーカスがある（hasFocus）ときは何もしない。連打防止に 200ms スロットル。
+                var lastAct = 0;
+                document.addEventListener('wheel', function () {
+                    var now = Date.now();
+                    if (now - lastAct < 200) return;
+                    lastAct = now;
+                    if (!document.hasFocus()) window.chrome.webview.postMessage('activate');
+                }, { passive: true, capture: true });
             })();
             """;
 


### PR DESCRIPTION
## 概要
マウスホイールでスクロールしたペインを自動的にアクティブ化（キーフォーカス移動）します。Closes #221

## 背景
`Home` / `End` / `F5` / `Backspace` などのキー操作は各 WebView2 に注入した JS が処理しており、**キーフォーカスのあるペイン**に作用する。マウスホイールはキーフォーカスを移さないため、「ペインをホイールでスクロール → `Home` で先頭に戻したい → 効かない」状態だった。

## 変更点
- `KeyboardShortcutScript` に `wheel` リスナーを追加。`document.hasFocus()` が false（＝そのペインが未フォーカス）のときだけ `postMessage('activate')`。200ms スロットル、`{ passive: true, capture: true }`。
- `OnWebViewMessageReceived` に `case "activate"` を追加し、送信元 WebView2 → ペイン → `SetFocus()`（既存のアクティブ化機構）を呼ぶ。

## テスト
- ビルド 0 警告 / 0 エラー、ユニットテスト 113 件パス。
- 手動確認: ホイールでスクロール → `Home`/`End` が当該ペインに効く／ヘッダーのアクティブ表示が切り替わる／既にアクティブなペインでは余計な再描画が走らない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
