### PR TITLE
キーボードショートカットのフォーカス横断対応とドリフト検出 (#227 #228 #229)

### DIFF
--- a/Views/MainWindow.Search.cs
+++ b/Views/MainWindow.Search.cs
@@ -26,6 +26,13 @@ namespace XTimelineViewer.Views
             args.Handled = true;
         }
 
+        // Ctrl+←/→（WebView2 非フォーカス時もカバー）#227
+        private void FocusAdjacentTimeline_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+        {
+            FocusAdjacentFromActive(sender.Key == Windows.System.VirtualKey.Right ? +1 : -1);
+            args.Handled = true;
+        }
+
         private void SearchBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
         {
             if (args.ChosenSuggestion is string chosen)

--- a/Views/MainWindow.Timeline.cs
+++ b/Views/MainWindow.Timeline.cs
@@ -204,6 +204,27 @@ namespace XTimelineViewer.Views
             if (_paneToSetFocus.TryGetValue(panes[i], out var setFocus)) setFocus();
         }
 
+        // Ctrl+←/→（WebView2 非フォーカス時）。現在アクティブなペインを基準に隣へ移動する。
+        // 未フォーカス時は先頭（→）/末尾（←）を基準にフォールバック。端では止まる（ラップしない）。
+        private void FocusAdjacentFromActive(int direction)
+        {
+            var panes = TimelinePanel.Children.OfType<Grid>().ToList();
+            if (panes.Count == 0) return;
+
+            int cur = -1;
+            if (_focusedHeaderGrid is not null &&
+                _headerGridToPane.TryGetValue(_focusedHeaderGrid, out var curPane))
+                cur = panes.IndexOf(curPane);
+
+            int next = cur < 0 ? (direction > 0 ? 0 : panes.Count - 1) : cur + direction;
+            if (next < 0 || next >= panes.Count) return;
+            if (_paneToSetFocus.TryGetValue(panes[next], out var setFocus))
+            {
+                setFocus();
+                panes[next].StartBringIntoView();
+            }
+        }
+
         // ── AddTimeline ───────────────────────────────────────────────────────
 
         private void AddTimeline(TimelineConfig cfg)
@@ -362,6 +383,7 @@ namespace XTimelineViewer.Views
             TimelinePanel.Children.Add(pane);
             _webViews.Add(webView);
             _webViewToPane[webView] = pane;
+            _headerGridToPane[headerGrid] = pane;  // アクティブ判定用（#227）
             RefreshTimelineNumbers();  // 番号バッジを振り直す（#225）
 
             // cfg.Url の変更をヘッダーへ反映する更新子（ベース URL 変更・リスト URL ライブ解決で再利用）
@@ -644,6 +666,7 @@ namespace XTimelineViewer.Views
                     _paneUrlUpdaters.Remove(cfg);
                     _autoLoadIndicators.Remove(pane);
                     _paneNumberLabels.Remove(pane);
+                    _headerGridToPane.Remove(headerGrid);
                     _headerRefreshers.Remove(refreshHeader);
                     if (_focusedHeaderGrid == headerGrid)
                     {

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -13,6 +13,9 @@
         <Grid.KeyboardAccelerators>
             <KeyboardAccelerator Key="F" Modifiers="Control" Invoked="FocusSearchBox_Invoked"/>
             <KeyboardAccelerator Key="F3" Invoked="FocusSearchBox_Invoked"/>
+            <!-- Ctrl+←/→ で隣のタイムラインへフォーカス（WebView2 非フォーカス時もカバー）#227 -->
+            <KeyboardAccelerator Key="Left"  Modifiers="Control" Invoked="FocusAdjacentTimeline_Invoked"/>
+            <KeyboardAccelerator Key="Right" Modifiers="Control" Invoked="FocusAdjacentTimeline_Invoked"/>
             <!-- Ctrl+1〜9 でタイムラインのフォーカス切り替え（WebView2 非フォーカス時もカバー）#225 -->
             <KeyboardAccelerator Key="Number1" Modifiers="Control" Invoked="FocusTimelineByNumber_Invoked"/>
             <KeyboardAccelerator Key="Number2" Modifiers="Control" Invoked="FocusTimelineByNumber_Invoked"/>

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -121,6 +121,9 @@ namespace XTimelineViewer.Views
         // タイムライン番号バッジ（#225）。ペイン → 番号 TextBlock。表示順で 1..9 を振り直す。
         private readonly Dictionary<Grid, TextBlock> _paneNumberLabels = [];
 
+        // headerGrid → pane の対応（#227）。アクティブな headerGrid からペインを引くのに使う。
+        private readonly Dictionary<Grid, Grid> _headerGridToPane = [];
+
         // キーボードショートカット処理スクリプト（各 WebView2 に注入）
         private static readonly string KeyboardShortcutScript = """
             (function() {
@@ -175,6 +178,7 @@ namespace XTimelineViewer.Views
                         if (k === 'l' && ni)    { e.preventDefault(); actOnPost('like',     'unlike');         return; }
                     }
                     if (!c && !s && !a) {
+                        if (k === 'F3')              { e.preventDefault(); window.chrome.webview.postMessage('focusSearch'); return; } // #228
                         if (k === 'Home'      && ni) { window.scrollTo({ top: 0, behavior: 'smooth' }); return; }
                         if (k === 'End'       && ni) { window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'smooth' }); return; }
                         if (k === 'F5')              { e.preventDefault(); location.reload(); return; }

--- a/XTimelineViewer.Tests/KeyboardShortcutDriftTests.cs
+++ b/XTimelineViewer.Tests/KeyboardShortcutDriftTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace XTimelineViewer.Tests
+{
+    /// <summary>
+    /// キーボードショートカットの二重管理（WebView2 内の注入 JS と XAML の KeyboardAccelerator）の
+    /// 不整合（ドリフト）を検出する（#229）。
+    ///
+    /// 「全フォーカスで効くべきショートカット（アプリ横断系）」は、
+    ///   - WebView2 にフォーカスがあるとき … 注入 JS（KeyboardShortcutScript）
+    ///   - メインウィンドウ/検索ボックス等にフォーカスがあるとき … XAML アクセラレータ
+    /// の両経路に定義されていなければ、特定のフォーカス状態でだけ効かなくなる（#225 / #227 / #228）。
+    ///
+    /// 新しいショートカットを足したときの片側追加漏れを CI で自動検出するため、
+    /// 両ソース（MainWindow.xaml / MainWindow.xaml.cs）を文字列スキャンして存在を照合する。
+    /// WebView2 内コンテンツ操作（Ctrl+↑↓ / Ctrl+R・B・L / Home・End / F5 / Backspace）は
+    /// JS 単独管理が正しいため対象外。
+    /// </summary>
+    public class KeyboardShortcutDriftTests
+    {
+        private static string FindRepoFile(string relative)
+        {
+            var rel = relative.Replace('/', Path.DirectorySeparatorChar);
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir is not null)
+            {
+                var candidate = Path.Combine(dir.FullName, rel);
+                if (File.Exists(candidate)) return candidate;
+                dir = dir.Parent;
+            }
+            throw new FileNotFoundException($"リポジトリ内で {relative} が見つかりません");
+        }
+
+        private static readonly string Xaml = File.ReadAllText(FindRepoFile("Views/MainWindow.xaml"));
+        private static readonly string Js   = File.ReadAllText(FindRepoFile("Views/MainWindow.xaml.cs"));
+
+        // 表示名, JS 側トークン, XAML 側トークン（複数指定時は全て必要）
+        public static TheoryData<string, string, string[]> GlobalShortcuts() => new()
+        {
+            { "Ctrl+Left",  "=== 'ArrowLeft'",    new[] { "Key=\"Left\"" } },
+            { "Ctrl+Right", "=== 'ArrowRight'",   new[] { "Key=\"Right\"" } },
+            { "Ctrl+N",     "=== 'n'",            new[] { "Key=\"N\"" } },
+            { "Ctrl+F",     "=== 'f'",            new[] { "Key=\"F\"" } },
+            { "F3",         "=== 'F3'",           new[] { "Key=\"F3\"" } },
+            { "Ctrl+1-9",   ">= '1' && k <= '9'", new[] { "Key=\"Number1\"", "Key=\"Number9\"" } },
+        };
+
+        [Theory]
+        [MemberData(nameof(GlobalShortcuts))]
+        public void GlobalShortcut_IsHandledInInjectedJs(string name, string jsToken, string[] xamlTokens)
+        {
+            _ = xamlTokens;
+            Assert.True(Js.Contains(jsToken),
+                $"{name}: 注入 JS（KeyboardShortcutScript）にハンドラ '{jsToken}' が見つかりません。" +
+                "WebView2 にフォーカスがあるときに効かなくなります。");
+        }
+
+        [Theory]
+        [MemberData(nameof(GlobalShortcuts))]
+        public void GlobalShortcut_HasXamlAccelerator(string name, string jsToken, string[] xamlTokens)
+        {
+            _ = jsToken;
+            foreach (var token in xamlTokens)
+                Assert.True(Xaml.Contains(token),
+                    $"{name}: XAML アクセラレータ '{token}' が見つかりません。" +
+                    "メインウィンドウ/検索ボックス等にフォーカスがあるときに効かなくなります。");
+        }
+    }
+}


### PR DESCRIPTION
## 概要
WebView2 内の注入 JS でしか処理していなかったショートカットを、メインウィンドウや検索ボックスにフォーカスがある状態でも効くようにし、二重管理のドリフトを自動検出するテストを追加します。

Closes #227, Closes #228, Closes #229

## 背景
ショートカットは「WebView2 内の注入 JS（`KeyboardShortcutScript`）」と「XAML の `KeyboardAccelerator`」の二重管理になっており、片側の定義漏れで「特定のフォーカス状態だけ効かない」不具合が出ていた（#225 で表面化）。

## 変更点
- **#228 / F3**: 注入 JS に `F3 → postMessage('focusSearch')` を追加。タイムライン（WebView2）にフォーカスがあっても検索ボックスへ移動できる。
- **#227 / Ctrl+←・→**: root に `Ctrl+Left` / `Ctrl+Right` の `KeyboardAccelerator` を追加。`FocusAdjacentFromActive(dir)` が現在アクティブなペイン（`_focusedHeaderGrid`）を基準に隣へ移動する。未フォーカス時は端からフォールバックし、端では停止（ラップしない）。`_headerGridToPane` 対応を追加。
- **#229 / ドリフト検出テスト**: `KeyboardShortcutDriftTests` を追加。全フォーカスで効くべきショートカット（Ctrl+←/→、Ctrl+N、Ctrl+F、F3、Ctrl+1〜9）が JS と XAML アクセラレータの**両経路に存在すること**を `Views/MainWindow.xaml` / `MainWindow.xaml.cs` の文字列スキャンで検証。片側追加漏れを CI で自動検出する。

## テスト
- ビルド 0 警告 / 0 エラー。ユニットテスト **113 → 125 件**（ドリフト検出 6 ショートカット × 2 経路）全パス。
- 手動確認: 検索ボックス上で Ctrl+←/→ がタイムライン切替／タイムライン上で F3 が検索へ／既存経路も二重発火なし／端で停止。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
