### PR TITLE
Ctrl+数字で視界外のタイムラインを横スクロール表示 (#231)

### DIFF
--- a/Views/MainWindow.Timeline.cs
+++ b/Views/MainWindow.Timeline.cs
@@ -201,7 +201,11 @@ namespace XTimelineViewer.Views
             var panes = TimelinePanel.Children.OfType<Grid>().ToList();
             int i = oneBased - 1;
             if (i < 0 || i >= panes.Count) return;
-            if (_paneToSetFocus.TryGetValue(panes[i], out var setFocus)) setFocus();
+            if (_paneToSetFocus.TryGetValue(panes[i], out var setFocus))
+            {
+                setFocus();
+                panes[i].StartBringIntoView();  // 視界外なら横スクロールして表示（#231）
+            }
         }
 
         // Ctrl+←/→（WebView2 非フォーカス時）。現在アクティブなペインを基準に隣へ移動する。


### PR DESCRIPTION
## 概要
［Ctrl］＋［数字］で視界外（横スクロールの外）のタイムラインへフォーカスしたとき、そのタイムラインを横スクロールして画面内に表示します。Closes #231

## 変更点
- `FocusTimelineByIndex` で、フォーカス設定後に対象ペインの `StartBringIntoView()` を呼ぶ（Ctrl+←/→ の `FocusAdjacentFromActive` と同じ挙動）。
- Ctrl+数字は JS 経路（`focusIndex:N`）・アクセラレータ経路のいずれも `FocusTimelineByIndex` を通るため、この 1 箇所で両方カバー。

## テスト
- ビルド 0 警告 / 0 エラー、ユニットテスト 125 件パス。
- 手動確認: 視界外のタイムラインを Ctrl+数字で選ぶと横スクロールして表示／視界内では余計なスクロールなし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
