### PR TITLE
ホームでアクション後に自動更新が停止する不具合を修正 (#232)

### DIFF
--- a/Views/MainWindow.WebView2.cs
+++ b/Views/MainWindow.WebView2.cs
@@ -140,11 +140,12 @@ namespace XTimelineViewer.Views
                 function suppressReason() {
                     var searchCandidate = document.body.querySelectorAll('div[class="css-1dbjc4n r-13awgt0 r-bnwqim"]');
                     if (searchCandidate.length > 0 && searchCandidate[0].innerHTML != "") return 'search';
+                    // 返信/引用/投稿などのモーダルが開いている間は下書き消失防止のため止める
+                    if (document.querySelector('[aria-modal="true"]')) return 'input';
+                    // 実際に編集可能な要素にフォーカスがあるときだけ止める（#232）。
+                    // リポスト/いいね等のボタンにフォーカスが移っても止めないようにする。
                     var fe = document.activeElement;
-                    if (fe && fe.tagName != "BODY") {
-                        var a = fe.getAttribute("data-testid");
-                        if (a != "tweet" && a != "AppTabBar_Home_Link") return 'input';
-                    }
+                    if (fe && (fe.isContentEditable || fe.tagName === 'TEXTAREA' || fe.tagName === 'INPUT')) return 'input';
                     return null;
                 }
 


### PR DESCRIPTION
## 概要
ホームでリポスト・お気に入り等のアクションを行うとホーム自動更新（#207）が停止する不具合を修正します。Closes #232

## 原因
`suppressReason`（`HomeAutoLoadScript`）が「フォーカスが BODY 以外なら（tweet / AppTabBar_Home_Link を除き）一律で入力中」と判定していたため、リポスト/いいねを押すとそのボタン（`data-testid="like"`/`"retweet"` 等）にフォーカスが移り、自動更新が一時停止していた（フォーカスが戻るまで継続）。

## 変更点
抑止条件を見直し:
- **実際に編集可能な要素**（`contenteditable` / `TEXTAREA` / `INPUT`）にフォーカスがあるときだけ「入力中」とみなす。アクションボタンへのフォーカスでは止めない。
- **返信/引用/投稿モーダル**（`[aria-modal="true"]`）が開いている間は止める（下書き消失防止。#207 の保護をより堅牢化）。
- 検索ボックス展開中の抑止は従来どおり。

## テスト
- ビルド 0 警告 / 0 エラー、ユニットテスト 125 件パス。
- 手動確認: リポスト/いいね後も自動更新が継続（インジケーター「稼働中」維持）／リプライ入力中・検索展開中は従来どおり停止。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
