### PR TITLE
定期アクティブ化を非推奨化（無効化＋グレーアウト）(#222)

### DIFF
--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -55,6 +55,7 @@
   <data name="Settings_OpenTimestampInBrowser_Description" xml:space="preserve"><value>Open timestamp links in an external browser instead of navigating in the timeline</value></data>
   <data name="Settings_AutoActivate" xml:space="preserve"><value>Auto-activate Home Timeline (min, 0 to disable)</value></data>
   <data name="Settings_AutoActivate_Description" xml:space="preserve"><value>Periodically bring the Home timeline to the foreground</value></data>
+  <data name="Settings_Deprecated_Note" xml:space="preserve"><value>⚠ Deprecated: will be removed in a future version (use Home timeline auto-refresh instead).</value></data>
   <data name="Settings_HomeAutoLoad" xml:space="preserve"><value>Auto-refresh Home timeline</value></data>
   <data name="Settings_HomeAutoLoad_Description" xml:space="preserve"><value>When on, new posts are loaded automatically at regular intervals while you are at the top of Home. Loading is skipped while you are composing a reply/quote or searching. This is separate from Auto-Reload, which reloads the whole page.</value></data>
   <data name="Settings_HomeAutoLoad_Interval" xml:space="preserve"><value>Refresh interval (sec)</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -55,6 +55,7 @@
   <data name="Settings_OpenTimestampInBrowser_Description" xml:space="preserve"><value>タイムライン内で移動せず、外部ブラウザーでタイムスタンプリンクを開きます</value></data>
   <data name="Settings_AutoActivate" xml:space="preserve"><value>ホームタイムラインを定期的にアクティブ化（分、0 で無効）</value></data>
   <data name="Settings_AutoActivate_Description" xml:space="preserve"><value>定期的にホームタイムラインを前面に表示します</value></data>
+  <data name="Settings_Deprecated_Note" xml:space="preserve"><value>⚠ 非推奨: 次期バージョンで削除予定です（ホームタイムラインの自動更新をご利用ください）。</value></data>
   <data name="Settings_HomeAutoLoad" xml:space="preserve"><value>ホームタイムラインの自動更新</value></data>
   <data name="Settings_HomeAutoLoad_Description" xml:space="preserve"><value>オンにすると、ホームの先頭にいるとき新着ポストを定期的に自動で読み込みます。リプライや引用の入力中・検索中は読み込みを控えます。ページ全体を再読み込みする「定期ハードリロード」とは別の機能です。</value></data>
   <data name="Settings_HomeAutoLoad_Interval" xml:space="preserve"><value>更新間隔（秒）</value></data>

--- a/Views/MainWindow.HardReload.cs
+++ b/Views/MainWindow.HardReload.cs
@@ -34,9 +34,14 @@ namespace XTimelineViewer.Views
             _autoActivateTimer.Start();
         }
 
+        // #222 非推奨: 定期アクティブ化はホーム自動更新（#207）で役目を終えたため無効化。
+        // v2.0 でタイマー関連コードごと削除予定。それまでは保存値があっても発火させない。
+        private static readonly bool AutoActivateEnabled = false;
+
         private void ApplyAutoActivateTimer()
         {
             _autoActivateTimer?.Stop();
+            if (!AutoActivateEnabled) return;  // #222 非推奨
             if (_appSettings.AutoActivateMinutes <= 0) return;
 
             _autoActivateTimer = new DispatcherTimer
@@ -166,7 +171,7 @@ namespace XTimelineViewer.Views
 
         private void UpdateAutoActivateLabel()
         {
-            if (!_appSettings.ShowAutoActivateLabel)
+            if (!AutoActivateEnabled || !_appSettings.ShowAutoActivateLabel)  // #222 非推奨: ラベルを常に非表示
             {
                 AutoActivateLabel.Visibility = Visibility.Collapsed;
                 return;

--- a/Views/Settings/ExperimentalPage.xaml.cs
+++ b/Views/Settings/ExperimentalPage.xaml.cs
@@ -69,13 +69,16 @@ namespace XTimelineViewer.Views.Settings
             OpenTimestampToggle.OnContent  = R.Get("Toggle_On");
             OpenTimestampToggle.OffContent = R.Get("Toggle_Off");
 
+            // #222 非推奨: 定期アクティブ化と関連オプションを無効化＋グレーアウト（v2.0 で削除予定）
             AutoActivateCard.Header      = R.Get("Settings_AutoActivate");
-            AutoActivateCard.Description = R.Get("Settings_AutoActivate_Description");
+            AutoActivateCard.Description = R.Get("Settings_AutoActivate_Description") + "\n" + R.Get("Settings_Deprecated_Note");
+            AutoActivateCard.IsEnabled   = false;
 
             ShowAutoActivateLabelCard.Header      = R.Get("Settings_ShowAutoActivateLabel");
-            ShowAutoActivateLabelCard.Description = R.Get("Settings_ShowAutoActivateLabel_Description");
+            ShowAutoActivateLabelCard.Description = R.Get("Settings_ShowAutoActivateLabel_Description") + "\n" + R.Get("Settings_Deprecated_Note");
             ShowAutoActivateLabelToggle.OnContent  = R.Get("Toggle_On");
             ShowAutoActivateLabelToggle.OffContent = R.Get("Toggle_Off");
+            ShowAutoActivateLabelCard.IsEnabled   = false;
 
             ExternalBrowserHeader.Text = R.Get("Section_ExternalBrowser");
 


### PR DESCRIPTION
## 概要
ホーム自動更新の内製化（#207）で役目を終えた「ホームタイムラインを定期的にアクティブ化」と関連オプション（ツールバー状態表示）を**非推奨化（無効化＋グレーアウト）**します。Closes #222

v2.0 でタイマー関連コードごと削除予定のため、本 PR ではコードは残置します（削除を容易にするためのマーキングのみ）。

## 変更点
- **無効化**: `AutoActivateEnabled = false`（`static readonly`）を導入。
  - `ApplyAutoActivateTimer` を no-op 化 → タイマーが起動しない。**保存値が残っていても発火しない**。
  - `UpdateAutoActivateLabel` でツールバーのラベルを常に非表示。
- **グレーアウト**: `AutoActivateCard` / `ShowAutoActivateLabelCard` を `IsEnabled=false`。説明に非推奨注記（`Settings_Deprecated_Note`、ja/en）を付与。
- **関連オプション** `ShowAutoActivateLabel`（ツールバー状態表示）も一緒に非推奨化。
- 各箇所に `// #222 非推奨` コメントを付与し、v2.0 での一括削除を容易にする。

## テスト
- ビルド 0 警告 / 0 エラー、ユニットテスト 125 件パス。
- 手動確認: 設定が非推奨注記つきでグレーアウト／旧設定値があってもホームが前面化しない／ツールバーラベル非表示／他機能（ハードリロード等）に影響なし。

## 補足
- v2.0 での削除対象は `// #222 非推奨` で grep できる（タイマー `ApplyAutoActivateTimer`/`RestartAutoActivateTimer`/`_autoActivateTimer`、`AutoActivateLabel` 周り、設定 `AutoActivateMinutes`/`ShowAutoActivateLabel`、関連リソース）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
