### PR TITLE
番号バッジのツールチップにアクティブ化ホットキーを表示 (#237)

### DIFF
--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -120,6 +120,7 @@
   <data name="Settings_RelatedSettings" xml:space="preserve"><value>Related settings</value></data>
   <data name="Nav_About" xml:space="preserve"><value>About</value></data>
   <data name="Pane_Settings_Tooltip" xml:space="preserve"><value>Settings</value></data>
+  <data name="Tooltip_ActivateHotkey" xml:space="preserve"><value>Activate with Ctrl+{0}</value></data>
   <data name="Pane_Delete" xml:space="preserve"><value>Remove This Timeline</value></data>
   <data name="DragCaption" xml:space="preserve"><value>Add Timeline</value></data>
 

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -120,6 +120,7 @@
   <data name="Settings_RelatedSettings" xml:space="preserve"><value>関連する設定</value></data>
   <data name="Nav_About" xml:space="preserve"><value>バージョン情報</value></data>
   <data name="Pane_Settings_Tooltip" xml:space="preserve"><value>設定</value></data>
+  <data name="Tooltip_ActivateHotkey" xml:space="preserve"><value>Ctrl+{0} でアクティブ化</value></data>
   <data name="Pane_Delete" xml:space="preserve"><value>このタイムラインを削除</value></data>
   <data name="DragCaption" xml:space="preserve"><value>タイムラインを追加</value></data>
 

--- a/Views/MainWindow.Timeline.cs
+++ b/Views/MainWindow.Timeline.cs
@@ -185,11 +185,14 @@ namespace XTimelineViewer.Views
                 {
                     label.Text       = $"{n}.";
                     label.Visibility = Visibility.Visible;
+                    // ツールチップにアクティブ化ホットキーを表示（#237）
+                    ToolTipService.SetToolTip(label, string.Format(R.Get("Tooltip_ActivateHotkey"), n));
                 }
                 else
                 {
                     label.Text       = string.Empty;
                     label.Visibility = Visibility.Collapsed;
+                    ToolTipService.SetToolTip(label, null);
                 }
                 n++;
             }


### PR DESCRIPTION
## 概要
番号バッジ（#225）のツールチップに、アクティブ化ホットキー（Ctrl+数字）を表示します。Closes #237

## 変更点
- `RefreshTimelineNumbers` で番号設定と同時にツールチップを更新（`ToolTipService.SetToolTip`）。
  - 1〜9: 「Ctrl+N でアクティブ化」/「Activate with Ctrl+N」
  - 10 以上（バッジ非表示）: ツールチップ解除
  - 並び替え・追加・削除でも番号と連動。
- リソース `Tooltip_ActivateHotkey`（ja/en）を追加。

## テスト
- ビルド 0 警告 / 0 エラー、ユニットテスト 125 件パス。
- 手動確認: 番号バッジのホバーでホットキー表示／並び替え後に数字追従／言語切替で文言追従。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
