### PR TITLE
リリース v1.7.0

### DIFF
--- a/Package.appxmanifest
+++ b/Package.appxmanifest
@@ -8,7 +8,7 @@
   <Identity
     Name="4275.XTimelineViewer"
     Publisher="CN=B73FDB0C-06E5-4824-9E7F-3AF969921DF4"
-    Version="1.6.1.0"
+    Version="1.7.0.0"
     ProcessorArchitecture="neutral" />
 
   <Properties>

--- a/XTimelineViewer.csproj
+++ b/XTimelineViewer.csproj
@@ -7,7 +7,7 @@
     <Platforms>x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
     <PlatformTarget>x64</PlatformTarget>
-    <Version>1.6.1</Version>
+    <Version>1.7.0</Version>
     <ApplicationIcon>Assets\AppIcon.ico</ApplicationIcon>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
## リリース v1.7.0（マイナー）

v1.6.1 以降のユーザー向け変更をまとめたリリース。csproj `<Version>` と Package.appxmanifest を 1.7.0 に更新。

### 主な変更
- **ホームタイムラインの自動更新を内製化**（拡張機能不要）。ON/OFF・更新間隔を設定でき、ヘッダーに状態インジケーターを表示。リプライ入力中・検索中は更新を控える（#207）
- **マウスホイールで操作したタイムラインをアクティブ化**（#221）
- **タイムラインに番号バッジ＋Ctrl+数字でフォーカス切り替え**。ホバーでホットキーのツールチップ表示、視界外なら横スクロールして表示（#225 #237 #231）
- **Ctrl+←/→・F3 などをウィンドウ全体で有効化**（検索ボックス等にフォーカスがあっても効く）（#227 #228）
- **リポスト/いいね後に自動更新が止まる不具合を修正**（#232）
- **「ホームを定期的にアクティブ化」を非推奨化**（自動更新に一本化、次期バージョンで削除予定）（#222）
- 内部: キーボードショートカットの二重管理ドリフトを検出するテストを追加（#229）

### リリース手順
- マージ後に `v1.7.0` タグを push → CI が ZIP/GitHub リリース/winget を自動公開
- Microsoft Store には `publish/release/XTimelineViewer-1.7.0.msixbundle`（x64+arm64・未署名可）をアップロード

🤖 Generated with [Claude Code](https://claude.com/claude-code)
