### PR TITLE
設定の再編: UI ページ新設と試験機能の卒業 (#236)

### DIFF
--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -113,6 +113,7 @@
 
   <!-- Settings window navigation -->
   <data name="Nav_General" xml:space="preserve"><value>General</value></data>
+  <data name="Nav_UserInterface" xml:space="preserve"><value>User Interface</value></data>
   <data name="Nav_Experimental" xml:space="preserve"><value>Experimental</value></data>
   <data name="Nav_Extensions" xml:space="preserve"><value>Extensions</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>Profiles</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -113,6 +113,7 @@
 
   <!-- Settings window navigation -->
   <data name="Nav_General" xml:space="preserve"><value>全般</value></data>
+  <data name="Nav_UserInterface" xml:space="preserve"><value>ユーザーインターフェイス</value></data>
   <data name="Nav_Experimental" xml:space="preserve"><value>試験機能</value></data>
   <data name="Nav_Extensions" xml:space="preserve"><value>拡張機能</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>プロファイル</value></data>

--- a/Views/Settings/ExperimentalPage.xaml
+++ b/Views/Settings/ExperimentalPage.xaml
@@ -10,24 +10,6 @@
                        Style="{StaticResource TitleTextBlockStyle}"
                        Margin="0,0,0,16"/>
 
-            <!-- Open Composer in External Browser -->
-            <controls:SettingsCard x:Name="OpenComposerCard">
-                <controls:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE70F;" FontFamily="Segoe Fluent Icons"/>
-                </controls:SettingsCard.HeaderIcon>
-                <ToggleSwitch x:Name="OpenComposerToggle"
-                              IsOn="{x:Bind VM.OpenComposerInBrowser, Mode=TwoWay}"/>
-            </controls:SettingsCard>
-
-            <!-- Open Timestamp Links in External Browser -->
-            <controls:SettingsCard x:Name="OpenTimestampCard">
-                <controls:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE71B;" FontFamily="Segoe Fluent Icons"/>
-                </controls:SettingsCard.HeaderIcon>
-                <ToggleSwitch x:Name="OpenTimestampToggle"
-                              IsOn="{x:Bind VM.OpenTimestampInBrowser, Mode=TwoWay}"/>
-            </controls:SettingsCard>
-
             <!-- Auto-Activate Home Timeline -->
             <controls:SettingsCard x:Name="AutoActivateCard">
                 <controls:SettingsCard.HeaderIcon>
@@ -48,31 +30,6 @@
                 </controls:SettingsCard.HeaderIcon>
                 <ToggleSwitch x:Name="ShowAutoActivateLabelToggle"
                               IsOn="{x:Bind VM.ShowAutoActivateLabel, Mode=TwoWay}"/>
-            </controls:SettingsCard>
-
-            <!-- External Browser Section Header -->
-            <TextBlock x:Name="ExternalBrowserHeader"
-                       Style="{StaticResource BodyStrongTextBlockStyle}"
-                       Margin="0,20,0,4"/>
-
-            <!-- Browser Selection -->
-            <controls:SettingsCard x:Name="BrowserCard">
-                <controls:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE774;" FontFamily="Segoe Fluent Icons"/>
-                </controls:SettingsCard.HeaderIcon>
-                <ComboBox x:Name="BrowserCombo"
-                          MinWidth="200"
-                          SelectedIndex="{x:Bind VM.BrowserIndex, Mode=TwoWay}"/>
-            </controls:SettingsCard>
-
-            <!-- Edge Profile -->
-            <controls:SettingsCard x:Name="EdgeProfileCard">
-                <controls:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE716;" FontFamily="Segoe Fluent Icons"/>
-                </controls:SettingsCard.HeaderIcon>
-                <ComboBox x:Name="EdgeProfileCombo"
-                          MinWidth="200"
-                          SelectionChanged="EdgeProfileCombo_SelectionChanged"/>
             </controls:SettingsCard>
         </StackPanel>
     </ScrollViewer>

--- a/Views/Settings/ExperimentalPage.xaml.cs
+++ b/Views/Settings/ExperimentalPage.xaml.cs
@@ -1,8 +1,6 @@
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
-using System.Collections.Generic;
 using System.ComponentModel;
-using XTimelineViewer.Services;
 using XTimelineViewer.ViewModels;
 
 namespace XTimelineViewer.Views.Settings
@@ -10,7 +8,6 @@ namespace XTimelineViewer.Views.Settings
     public sealed partial class ExperimentalPage : Page
     {
         private SettingsWindow? _parent;
-        private List<EdgeProfile> _edgeProfiles = [];
 
         /// <summary>x:Bind のバインディングソース。XAML から参照される。</summary>
         public SettingsViewModel? VM { get; private set; }
@@ -39,35 +36,13 @@ namespace XTimelineViewer.Views.Settings
 
         private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
-            switch (e.PropertyName)
-            {
-                case nameof(SettingsViewModel.LanguageIndex):
-                    PopulateUI();
-                    break;
-                case nameof(SettingsViewModel.IsEdgeSelected):
-                    UpdateEdgeProfileComboEnabled();
-                    break;
-            }
+            if (e.PropertyName == nameof(SettingsViewModel.LanguageIndex))
+                PopulateUI();
         }
-
-        private void UpdateEdgeProfileComboEnabled()
-            => EdgeProfileCombo.IsEnabled = (VM?.IsEdgeSelected ?? false) && _edgeProfiles.Count > 0;
 
         private void PopulateUI()
         {
-            var s = _parent?.Settings;
-
             PageTitle.Text = R.Get("Nav_Experimental");
-
-            OpenComposerCard.Header      = R.Get("Settings_OpenComposerInBrowser");
-            OpenComposerCard.Description = R.Get("Settings_OpenComposerInBrowser_Description");
-            OpenComposerToggle.OnContent  = R.Get("Toggle_On");
-            OpenComposerToggle.OffContent = R.Get("Toggle_Off");
-
-            OpenTimestampCard.Header      = R.Get("Settings_OpenTimestampInBrowser");
-            OpenTimestampCard.Description = R.Get("Settings_OpenTimestampInBrowser_Description");
-            OpenTimestampToggle.OnContent  = R.Get("Toggle_On");
-            OpenTimestampToggle.OffContent = R.Get("Toggle_Off");
 
             // #222 非推奨: 定期アクティブ化と関連オプションを無効化＋グレーアウト（v2.0 で削除予定）
             AutoActivateCard.Header      = R.Get("Settings_AutoActivate");
@@ -80,56 +55,8 @@ namespace XTimelineViewer.Views.Settings
             ShowAutoActivateLabelToggle.OffContent = R.Get("Toggle_Off");
             ShowAutoActivateLabelCard.IsEnabled   = false;
 
-            ExternalBrowserHeader.Text = R.Get("Section_ExternalBrowser");
-
-            BrowserCard.Header      = R.Get("Settings_ExternalBrowser");
-            BrowserCard.Description = R.Get("Settings_ExternalBrowser_Description");
-            BrowserCombo.ItemsSource = new List<string> { R.Get("Browser_System"), "Microsoft Edge" };
-
-            // Edge Profile（ファイルシステム列挙に依存するためコードビハインドで構築）
-            EdgeProfileCard.Header      = R.Get("Settings_EdgeProfile");
-            EdgeProfileCard.Description = R.Get("Settings_EdgeProfile_Description");
-            _edgeProfiles = EdgeService.EnumerateProfiles();
-
-            if (_edgeProfiles.Count == 0)
-            {
-                EdgeProfileCombo.ItemsSource   = new List<string> { R.Get("Browser_EdgeNotFound") };
-                EdgeProfileCombo.SelectedIndex = 0;
-            }
-            else
-            {
-                var names = new List<string>();
-                int selectedIdx = 0;
-                for (int i = 0; i < _edgeProfiles.Count; i++)
-                {
-                    var p = _edgeProfiles[i];
-                    var detail = p.UserName.Length > 0 ? p.UserName : p.Directory;
-                    names.Add($"{p.DisplayName}  ({detail})");
-                    if (p.Directory == s?.EdgeProfileDirectory)
-                        selectedIdx = i;
-                }
-                EdgeProfileCombo.ItemsSource   = names;
-                EdgeProfileCombo.SelectedIndex = selectedIdx;
-            }
-            UpdateEdgeProfileComboEnabled();
-
             // ItemsSource 再設定で SelectedIndex が失われるため、バインディングを再評価する
             Bindings.Update();
-        }
-
-        private void EdgeProfileCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            if (_parent is null) return;
-
-            var idx = EdgeProfileCombo.SelectedIndex;
-            if (_edgeProfiles.Count == 0 || idx < 0 || idx >= _edgeProfiles.Count) return;
-
-            // PopulateUI による再設定では値が変わらないため通知しない
-            var dir = _edgeProfiles[idx].Directory;
-            if (_parent.Settings.EdgeProfileDirectory == dir) return;
-
-            _parent.Settings.EdgeProfileDirectory = dir;
-            _parent.NotifySettingsChanged();
         }
     }
 }

--- a/Views/Settings/GeneralPage.xaml
+++ b/Views/Settings/GeneralPage.xaml
@@ -10,26 +10,6 @@
                        Style="{StaticResource TitleTextBlockStyle}"
                        Margin="0,0,0,16"/>
 
-            <!-- Theme -->
-            <controls:SettingsCard x:Name="ThemeCard">
-                <controls:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE771;" FontFamily="Segoe Fluent Icons"/>
-                </controls:SettingsCard.HeaderIcon>
-                <ComboBox x:Name="ThemeCombo"
-                          MinWidth="160"
-                          SelectedIndex="{x:Bind VM.ThemeIndex, Mode=TwoWay}"/>
-            </controls:SettingsCard>
-
-            <!-- Language -->
-            <controls:SettingsCard x:Name="LanguageCard">
-                <controls:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE8C1;" FontFamily="Segoe Fluent Icons"/>
-                </controls:SettingsCard.HeaderIcon>
-                <ComboBox x:Name="LanguageCombo"
-                          MinWidth="160"
-                          SelectedIndex="{x:Bind VM.LanguageIndex, Mode=TwoWay}"/>
-            </controls:SettingsCard>
-
             <!-- Timeline Defaults -->
             <controls:SettingsExpander x:Name="DefaultTimelineExpander">
                 <controls:SettingsExpander.HeaderIcon>
@@ -70,6 +50,46 @@
                                    SpinButtonPlacementMode="Inline"
                                    Width="160"
                                    Value="{x:Bind VM.HomeAutoLoadIntervalSeconds, Mode=TwoWay}"/>
+                    </controls:SettingsCard>
+                </controls:SettingsExpander.Items>
+            </controls:SettingsExpander>
+
+            <!-- External Browser Section（試験機能から卒業した外部ブラウザー関連をすべて集約）-->
+            <TextBlock x:Name="ExternalBrowserHeader"
+                       Style="{StaticResource BodyStrongTextBlockStyle}"
+                       Margin="0,20,0,4"/>
+
+            <!-- Open Composer in External Browser -->
+            <controls:SettingsCard x:Name="OpenComposerCard">
+                <controls:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE70F;" FontFamily="Segoe Fluent Icons"/>
+                </controls:SettingsCard.HeaderIcon>
+                <ToggleSwitch x:Name="OpenComposerToggle"
+                              IsOn="{x:Bind VM.OpenComposerInBrowser, Mode=TwoWay}"/>
+            </controls:SettingsCard>
+
+            <!-- Open Timestamp Links in External Browser -->
+            <controls:SettingsCard x:Name="OpenTimestampCard">
+                <controls:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE71B;" FontFamily="Segoe Fluent Icons"/>
+                </controls:SettingsCard.HeaderIcon>
+                <ToggleSwitch x:Name="OpenTimestampToggle"
+                              IsOn="{x:Bind VM.OpenTimestampInBrowser, Mode=TwoWay}"/>
+            </controls:SettingsCard>
+
+            <!-- Browser Selection（Edge プロファイルは従属オプションとして Expander 内に格納）-->
+            <controls:SettingsExpander x:Name="BrowserCard">
+                <controls:SettingsExpander.HeaderIcon>
+                    <FontIcon Glyph="&#xE774;" FontFamily="Segoe Fluent Icons"/>
+                </controls:SettingsExpander.HeaderIcon>
+                <ComboBox x:Name="BrowserCombo"
+                          MinWidth="200"
+                          SelectedIndex="{x:Bind VM.BrowserIndex, Mode=TwoWay}"/>
+                <controls:SettingsExpander.Items>
+                    <controls:SettingsCard x:Name="EdgeProfileCard">
+                        <ComboBox x:Name="EdgeProfileCombo"
+                                  MinWidth="200"
+                                  SelectionChanged="EdgeProfileCombo_SelectionChanged"/>
                     </controls:SettingsCard>
                 </controls:SettingsExpander.Items>
             </controls:SettingsExpander>

--- a/Views/Settings/GeneralPage.xaml.cs
+++ b/Views/Settings/GeneralPage.xaml.cs
@@ -2,6 +2,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
 using System.Collections.Generic;
 using System.ComponentModel;
+using XTimelineViewer.Services;
 using XTimelineViewer.ViewModels;
 
 namespace XTimelineViewer.Views.Settings
@@ -9,6 +10,7 @@ namespace XTimelineViewer.Views.Settings
     public sealed partial class GeneralPage : Page
     {
         private SettingsWindow? _parent;
+        private List<EdgeProfile> _edgeProfiles = [];
 
         /// <summary>x:Bind のバインディングソース。XAML から参照される。</summary>
         public SettingsViewModel? VM { get; private set; }
@@ -38,34 +40,24 @@ namespace XTimelineViewer.Views.Settings
 
         private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
-            // 言語変更時はこのページ自身の表示も新しい言語で再構築する
-            if (e.PropertyName == nameof(SettingsViewModel.LanguageIndex))
-                PopulateUI();
+            switch (e.PropertyName)
+            {
+                // 言語変更時はこのページ自身の表示も新しい言語で再構築する
+                case nameof(SettingsViewModel.LanguageIndex):
+                    PopulateUI();
+                    break;
+                case nameof(SettingsViewModel.IsEdgeSelected):
+                    UpdateEdgeProfileComboEnabled();
+                    break;
+            }
         }
+
+        private void UpdateEdgeProfileComboEnabled()
+            => EdgeProfileCombo.IsEnabled = (VM?.IsEdgeSelected ?? false) && _edgeProfiles.Count > 0;
 
         private void PopulateUI()
         {
             PageTitle.Text = R.Get("Nav_General");
-
-            // Theme
-            ThemeCard.Header      = R.Get("Settings_Theme");
-            ThemeCard.Description = R.Get("Settings_Theme_Description");
-            ThemeCombo.ItemsSource = new List<string>
-            {
-                R.Get("Theme_System"),
-                R.Get("Theme_Light"),
-                R.Get("Theme_Dark"),
-            };
-
-            // Language
-            LanguageCard.Header      = R.Get("Settings_Language");
-            LanguageCard.Description = R.Get("Settings_Language_Description");
-            LanguageCombo.ItemsSource = new List<string>
-            {
-                R.Get("Language_System"),
-                R.Get("Language_JA"),
-                R.Get("Language_EN"),
-            };
 
             // Timeline Defaults
             DefaultTimelineExpander.Header      = R.Get("Settings_DefaultTimeline");
@@ -88,9 +80,70 @@ namespace XTimelineViewer.Views.Settings
             HomeAutoLoadIntervalCard.Header      = R.Get("Settings_HomeAutoLoad_Interval");
             HomeAutoLoadIntervalCard.Description = R.Get("Settings_HomeAutoLoad_Interval_Description");
 
+            // External Browser（試験機能から卒業した外部ブラウザー関連をすべて集約）
+            var s = _parent?.Settings;
+
+            ExternalBrowserHeader.Text = R.Get("Section_ExternalBrowser");
+
+            OpenComposerCard.Header      = R.Get("Settings_OpenComposerInBrowser");
+            OpenComposerCard.Description = R.Get("Settings_OpenComposerInBrowser_Description");
+            OpenComposerToggle.OnContent  = R.Get("Toggle_On");
+            OpenComposerToggle.OffContent = R.Get("Toggle_Off");
+
+            OpenTimestampCard.Header      = R.Get("Settings_OpenTimestampInBrowser");
+            OpenTimestampCard.Description = R.Get("Settings_OpenTimestampInBrowser_Description");
+            OpenTimestampToggle.OnContent  = R.Get("Toggle_On");
+            OpenTimestampToggle.OffContent = R.Get("Toggle_Off");
+
+            BrowserCard.Header      = R.Get("Settings_ExternalBrowser");
+            BrowserCard.Description = R.Get("Settings_ExternalBrowser_Description");
+            BrowserCombo.ItemsSource = new List<string> { R.Get("Browser_System"), "Microsoft Edge" };
+
+            // Edge Profile（ファイルシステム列挙に依存するためコードビハインドで構築）
+            EdgeProfileCard.Header      = R.Get("Settings_EdgeProfile");
+            EdgeProfileCard.Description = R.Get("Settings_EdgeProfile_Description");
+            _edgeProfiles = EdgeService.EnumerateProfiles();
+
+            if (_edgeProfiles.Count == 0)
+            {
+                EdgeProfileCombo.ItemsSource   = new List<string> { R.Get("Browser_EdgeNotFound") };
+                EdgeProfileCombo.SelectedIndex = 0;
+            }
+            else
+            {
+                var names = new List<string>();
+                int selectedIdx = 0;
+                for (int i = 0; i < _edgeProfiles.Count; i++)
+                {
+                    var p = _edgeProfiles[i];
+                    var detail = p.UserName.Length > 0 ? p.UserName : p.Directory;
+                    names.Add($"{p.DisplayName}  ({detail})");
+                    if (p.Directory == s?.EdgeProfileDirectory)
+                        selectedIdx = i;
+                }
+                EdgeProfileCombo.ItemsSource   = names;
+                EdgeProfileCombo.SelectedIndex = selectedIdx;
+            }
+            UpdateEdgeProfileComboEnabled();
+
             // ItemsSource 再設定で SelectedIndex が失われるため、バインディングを再評価して
             // ViewModel の値を反映し直す
             Bindings.Update();
+        }
+
+        private void EdgeProfileCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_parent is null) return;
+
+            var idx = EdgeProfileCombo.SelectedIndex;
+            if (_edgeProfiles.Count == 0 || idx < 0 || idx >= _edgeProfiles.Count) return;
+
+            // PopulateUI による再設定では値が変わらないため通知しない
+            var dir = _edgeProfiles[idx].Directory;
+            if (_parent.Settings.EdgeProfileDirectory == dir) return;
+
+            _parent.Settings.EdgeProfileDirectory = dir;
+            _parent.NotifySettingsChanged();
         }
     }
 }

--- a/Views/Settings/UserInterfacePage.xaml
+++ b/Views/Settings/UserInterfacePage.xaml
@@ -1,0 +1,34 @@
+<Page
+    x:Class="XTimelineViewer.Views.Settings.UserInterfacePage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls">
+
+    <ScrollViewer Padding="24,16">
+        <StackPanel Spacing="4">
+            <TextBlock x:Name="PageTitle"
+                       Style="{StaticResource TitleTextBlockStyle}"
+                       Margin="0,0,0,16"/>
+
+            <!-- Theme -->
+            <controls:SettingsCard x:Name="ThemeCard">
+                <controls:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE771;" FontFamily="Segoe Fluent Icons"/>
+                </controls:SettingsCard.HeaderIcon>
+                <ComboBox x:Name="ThemeCombo"
+                          MinWidth="160"
+                          SelectedIndex="{x:Bind VM.ThemeIndex, Mode=TwoWay}"/>
+            </controls:SettingsCard>
+
+            <!-- Language -->
+            <controls:SettingsCard x:Name="LanguageCard">
+                <controls:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE8C1;" FontFamily="Segoe Fluent Icons"/>
+                </controls:SettingsCard.HeaderIcon>
+                <ComboBox x:Name="LanguageCombo"
+                          MinWidth="160"
+                          SelectedIndex="{x:Bind VM.LanguageIndex, Mode=TwoWay}"/>
+            </controls:SettingsCard>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/Views/Settings/UserInterfacePage.xaml.cs
+++ b/Views/Settings/UserInterfacePage.xaml.cs
@@ -1,0 +1,76 @@
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Navigation;
+using System.Collections.Generic;
+using System.ComponentModel;
+using XTimelineViewer.ViewModels;
+
+namespace XTimelineViewer.Views.Settings
+{
+    /// <summary>ユーザーインターフェイス設定ページ（#236）。テーマ・言語を扱う。</summary>
+    public sealed partial class UserInterfacePage : Page
+    {
+        private SettingsWindow? _parent;
+
+        /// <summary>x:Bind のバインディングソース。XAML から参照される。</summary>
+        public SettingsViewModel? VM { get; private set; }
+
+        public UserInterfacePage()
+        {
+            this.InitializeComponent();
+        }
+
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            base.OnNavigatedTo(e);
+            _parent = e.Parameter as SettingsWindow;
+            VM      = _parent?.ViewModel;
+            if (VM is not null)
+                VM.PropertyChanged += OnViewModelPropertyChanged;
+            PopulateUI();
+        }
+
+        protected override void OnNavigatedFrom(NavigationEventArgs e)
+        {
+            base.OnNavigatedFrom(e);
+            // VM はウィンドウと同寿命なので、ページ破棄時に購読を解除してリークを防ぐ
+            if (VM is not null)
+                VM.PropertyChanged -= OnViewModelPropertyChanged;
+        }
+
+        private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            // 言語変更時はこのページ自身の表示も新しい言語で再構築する
+            if (e.PropertyName == nameof(SettingsViewModel.LanguageIndex))
+                PopulateUI();
+        }
+
+        private void PopulateUI()
+        {
+            PageTitle.Text = R.Get("Nav_UserInterface");
+
+            // Theme
+            ThemeCard.Header      = R.Get("Settings_Theme");
+            ThemeCard.Description = R.Get("Settings_Theme_Description");
+            ThemeCombo.ItemsSource = new List<string>
+            {
+                R.Get("Theme_System"),
+                R.Get("Theme_Light"),
+                R.Get("Theme_Dark"),
+            };
+
+            // Language
+            LanguageCard.Header      = R.Get("Settings_Language");
+            LanguageCard.Description = R.Get("Settings_Language_Description");
+            LanguageCombo.ItemsSource = new List<string>
+            {
+                R.Get("Language_System"),
+                R.Get("Language_JA"),
+                R.Get("Language_EN"),
+            };
+
+            // ItemsSource 再設定で SelectedIndex が失われるため、バインディングを再評価して
+            // ViewModel の値を反映し直す
+            Bindings.Update();
+        }
+    }
+}

--- a/Views/SettingsWindow.xaml
+++ b/Views/SettingsWindow.xaml
@@ -17,6 +17,11 @@
                         <FontIcon Glyph="&#xE790;" FontFamily="Segoe Fluent Icons"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
+                <NavigationViewItem x:Name="NavUserInterface" Tag="UserInterface">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xE771;" FontFamily="Segoe Fluent Icons"/>
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
                 <NavigationViewItem x:Name="NavData" Tag="Data">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xEDA2;" FontFamily="Segoe Fluent Icons"/>

--- a/Views/SettingsWindow.xaml.cs
+++ b/Views/SettingsWindow.xaml.cs
@@ -129,6 +129,7 @@ namespace XTimelineViewer.Views
         {
             Title                  = R.Get("AppSettings_Title");
             NavGeneral.Content     = R.Get("Nav_General");
+            NavUserInterface.Content = R.Get("Nav_UserInterface");
             NavData.Content        = R.Get("Nav_Data");
             NavExperimental.Content = R.Get("Nav_Experimental");
             NavExtensions.Content  = R.Get("Nav_Extensions");
@@ -157,6 +158,7 @@ namespace XTimelineViewer.Views
             var pageType = tag switch
             {
                 "General"      => typeof(Settings.GeneralPage),
+                "UserInterface" => typeof(Settings.UserInterfacePage),
                 "Data"         => typeof(Settings.UserDataPage),
                 "Experimental" => typeof(Settings.ExperimentalPage),
                 "Extensions"   => typeof(Settings.ExtensionsPage),


### PR DESCRIPTION
## 概要
設定ページを再編します。Closes #236

## 変更点
### テーマ・言語を［ユーザーインターフェイス］ページへ（#236）
- 新規ページ `UserInterfacePage` を追加（ナビは［全般］直後）。テーマ・言語を移設。

### 試験機能の卒業（外部ブラウザー関連を［全般］に集約）
- 試験機能の非推奨以外をすべて［全般］の **［外部ブラウザー］セクション**へ移動:
  - 新規投稿を外部ブラウザーで開く
  - タイムスタンプリンクを外部ブラウザーで開く
  - リンクを開くブラウザー
  - Edge プロファイル ← 「リンクを開くブラウザー」の従属オプションとして **Expander 内に格納**
- ［試験機能］ページには**非推奨項目のみ**（定期アクティブ化・状態表示。#222 でグレーアウト済み）を残す。

### その他
- リソース `Nav_UserInterface`（ja/en）を追加。

## テスト
- ビルド 0 警告 / 0 エラー、ユニットテスト 125 件パス。
- 手動確認: UI ページのテーマ・言語、外部ブラウザー各項目（Edge プロファイルの列挙・選択・有効/無効連動）、試験機能が非推奨 2 項目のみ、言語切替の各ページ追従。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
