### PR TITLE
投稿ウィンドウのプリロード（試験機能・案A）(#244)

### DIFF
--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -20,5 +20,6 @@ namespace XTimelineViewer.Models
         public List<string> SavedSearchQueries { get; set; } = [];        // 検索ボックスのサジェスト用
         public bool    HomeAutoLoadEnabled   { get; set; } = true;       // ホーム自動更新（#207）の ON/OFF
         public int     HomeAutoLoadIntervalSeconds { get; set; } = 8;    // ホーム自動更新の間隔（秒, 最小 5）
+        public bool    ComposePreloadEnabled { get; set; } = false;     // 投稿ウィンドウのプリロード（試験機能 #244 案B）
     }
 }

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -116,6 +116,8 @@
   <data name="Nav_UserInterface" xml:space="preserve"><value>User Interface</value></data>
   <data name="Nav_Experimental" xml:space="preserve"><value>Experimental</value></data>
   <data name="Experimental_Caution" xml:space="preserve"><value>Features listed here may change, be deprecated, or be removed without notice.</value></data>
+  <data name="Settings_ComposePreload" xml:space="preserve"><value>Preload the compose window</value></data>
+  <data name="Settings_ComposePreload_Description" xml:space="preserve"><value>Loads the compose page in the background so there is less wait between pressing Post and being able to type (last used profile). Uses more memory.</value></data>
   <data name="Nav_Extensions" xml:space="preserve"><value>Extensions</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>Profiles</value></data>
   <data name="Nav_Data" xml:space="preserve"><value>User Data</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -116,6 +116,8 @@
   <data name="Nav_UserInterface" xml:space="preserve"><value>ユーザーインターフェイス</value></data>
   <data name="Nav_Experimental" xml:space="preserve"><value>試験機能</value></data>
   <data name="Experimental_Caution" xml:space="preserve"><value>ここにリストアップされる機能は予告なく変更されたり、非推奨・削除されることがあります。</value></data>
+  <data name="Settings_ComposePreload" xml:space="preserve"><value>投稿ウィンドウをプリロードする</value></data>
+  <data name="Settings_ComposePreload_Description" xml:space="preserve"><value>バックグラウンドで投稿画面を事前に読み込み、投稿ボタンを押してから入力できるまでの待ち時間を短縮します（最後に使ったプロファイル）。メモリ消費が増えます。</value></data>
   <data name="Nav_Extensions" xml:space="preserve"><value>拡張機能</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>プロファイル</value></data>
   <data name="Nav_Data" xml:space="preserve"><value>ユーザーデータ管理</value></data>

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -167,6 +167,18 @@ namespace XTimelineViewer.ViewModels
             }
         }
 
+        /// <summary>投稿ウィンドウのプリロード（試験機能 #244 案B）。</summary>
+        public bool ComposePreloadEnabled
+        {
+            get => _settings.ComposePreloadEnabled;
+            set
+            {
+                if (_settings.ComposePreloadEnabled == value) return;
+                _settings.ComposePreloadEnabled = value;
+                Notify(nameof(ComposePreloadEnabled));
+            }
+        }
+
         public bool ShowAutoActivateLabel
         {
             get => _settings.ShowAutoActivateLabel;

--- a/Views/MainWindow.Onboarding.cs
+++ b/Views/MainWindow.Onboarding.cs
@@ -17,6 +17,9 @@ namespace XTimelineViewer.Views
             await RestoreTimelinesAsync();
             UpdateHasNamedProfiles();
 
+            // 投稿ウィンドウのプリロード（#244 案B）。設定 OFF のときは内部で何もしない。
+            _ = WarmUpComposeAsync();
+
             if (!HasNamedProfiles())
             {
                 // XamlRoot が利用可能になるまで待つ（Content.Loaded は Activate() 後に発火）

--- a/Views/MainWindow.Post.cs
+++ b/Views/MainWindow.Post.cs
@@ -23,16 +23,117 @@ namespace XTimelineViewer.Views
                 await OpenPostDialogAsync();
         }
 
+        // ── 投稿ウィンドウのプリロード（試験機能 #244 案A）─────────────────────────
+        // 最後に使ったプロファイルの compose 画面を非表示ホストで実サイズまで完成させておき、
+        // 投稿ボタン押下時はその「生成済みインスタンス」をダイアログへ移し替えて即表示する。
+        // 閉じたらホストへ戻し、compose/post へ再ナビゲートして下書きをリセットし次回に備える。
+        private WebView2? _composeWarmWebView;
+        private string?   _composeWarmProfileId;
+        private ContentDialog? _activeComposeDialog;             // 現在開いている投稿ダイアログ（自動クローズ用）
+        private readonly HashSet<WebView2> _composeReadyViews = []; // compose/post ロード完了済みのビュー
+
+        internal async Task WarmUpComposeAsync()
+        {
+            if (!_appSettings.ComposePreloadEnabled) { DisposeComposeWarm(); return; }
+
+            var profileId = ResolveComposeProfileId();
+            // 同じプロファイルで準備済みなら何もしない
+            if (_composeWarmWebView is not null && _composeWarmProfileId == profileId) return;
+            DisposeComposeWarm();
+
+            try
+            {
+                var wv = CreateHiddenComposeHost();
+                ((Grid)Content).Children.Add(wv);
+                await AttachComposeBehavior(wv, profileId);  // env 生成 + ハンドラ + compose/post ナビゲート
+                _composeWarmWebView   = wv;
+                _composeWarmProfileId = profileId;
+            }
+            catch (Exception ex)
+            {
+                LogError("WarmUpComposeAsync", ex);
+            }
+        }
+
+        // 非表示ホスト用に compose 実サイズで生成（表示時の再レイアウトを避けるため 1x1 にはしない）
+        private static WebView2 CreateHiddenComposeHost()
+        {
+            var wv = new WebView2
+            {
+                Width  = 500,
+                MinHeight = 520,
+                Opacity = 0,
+                IsHitTestVisible = false,
+                HorizontalAlignment = HorizontalAlignment.Left,
+                VerticalAlignment   = VerticalAlignment.Top,
+            };
+            Canvas.SetZIndex(wv, -1);
+            Grid.SetRow(wv, 1);  // コンテンツ行（Star）に置き、Auto 高のツールバー行を押し広げないようにする
+            return wv;
+        }
+
+        private void DisposeComposeWarm()
+        {
+            if (_composeWarmWebView is null) return;
+            try
+            {
+                _composeReadyViews.Remove(_composeWarmWebView);
+                ((Grid)Content).Children.Remove(_composeWarmWebView);
+                _composeWarmWebView.Close();
+            }
+            catch { /* 破棄失敗は無視 */ }
+            _composeWarmWebView   = null;
+            _composeWarmProfileId = null;
+        }
+
+        // 借りていた warm WebView2 を非表示ホストへ戻し、下書きをリセットして次回に備える
+        private void ReturnWarmToHost(WebView2 wv, StackPanel rootPanel, string profileId)
+        {
+            try { rootPanel.Children.Remove(wv); } catch { }
+            wv.Opacity             = 0;
+            wv.IsHitTestVisible    = false;
+            wv.HorizontalAlignment = HorizontalAlignment.Left;
+            wv.VerticalAlignment   = VerticalAlignment.Top;
+            Canvas.SetZIndex(wv, -1);
+            Grid.SetRow(wv, 1);
+            ((Grid)Content).Children.Add(wv);
+            _composeReadyViews.Remove(wv);
+            try { wv.Source = new Uri("https://x.com/compose/post"); } catch { }  // 下書きリセット
+            _composeWarmWebView   = wv;
+            _composeWarmProfileId = profileId;
+        }
+
         private async Task OpenPostDialogAsync(WebView2? senderWebView = null)
         {
             // ── プロファイルセレクターの構築 ──
             var selectedProfileId = ResolveComposeProfileId();
 
             var profileCombo = BuildProfileComboBox(selectedProfileId);
-            var webView = new WebView2 { Width = 500, MinHeight = 520 };
             var rootPanel = new StackPanel { Spacing = 8 };
             rootPanel.Children.Add(profileCombo);
-            rootPanel.Children.Add(webView);
+
+            // プリロード済み（warm）が同じプロファイルで使えるなら、移し替えて即表示（#244 案A）
+            WebView2 webView;
+            bool currentIsWarm;
+            if (_appSettings.ComposePreloadEnabled &&
+                _composeWarmWebView is not null &&
+                _composeWarmProfileId == selectedProfileId)
+            {
+                webView = _composeWarmWebView;
+                _composeWarmWebView = null;        // 借用中（閉じる時にホストへ戻す）
+                currentIsWarm = true;
+                ((Grid)Content).Children.Remove(webView);
+                webView.Opacity          = 1;
+                webView.IsHitTestVisible = true;
+                Canvas.SetZIndex(webView, 0);
+                rootPanel.Children.Add(webView);
+            }
+            else
+            {
+                webView = new WebView2 { Width = 500, MinHeight = 520 };
+                currentIsWarm = false;
+                rootPanel.Children.Add(webView);
+            }
 
             var dlg = new ContentDialog
             {
@@ -40,26 +141,28 @@ namespace XTimelineViewer.Views
                 CloseButtonText = R.Get("Button_Close"),
                 XamlRoot        = Content.XamlRoot,
             };
+            _activeComposeDialog = dlg;
 
-            // ── WebView2 初期化 ──
-            await InitComposeWebView(webView, selectedProfileId, dlg);
+            if (!currentIsWarm)
+                await AttachComposeBehavior(webView, selectedProfileId);
 
-            // ── プロファイル切り替え ──
+            // ── プロファイル切り替え（切替後は常にオンデマンド生成）──
             profileCombo.SelectionChanged += async (s, args) =>
             {
                 if (profileCombo.SelectedItem is not ComboBoxItem item) return;
                 var newProfileId = item.Tag as string ?? "default";
                 if (newProfileId == selectedProfileId) return;
+                var prevProfileId = selectedProfileId;
                 selectedProfileId = newProfileId;
 
-                // 古い WebView2 を破棄して新しいものに差し替え
-                var oldWebView = webView;
-                webView = new WebView2 { Width = 500, MinHeight = 520 };
-                rootPanel.Children.Remove(oldWebView);
-                rootPanel.Children.Add(webView);
-                try { oldWebView.Close(); } catch { }
+                // 現在の WebView2 を退避：warm は破棄せずホストへ戻す／オンデマンドは破棄
+                if (currentIsWarm) ReturnWarmToHost(webView, rootPanel, prevProfileId);
+                else { rootPanel.Children.Remove(webView); try { webView.Close(); } catch { } }
 
-                await InitComposeWebView(webView, selectedProfileId, dlg);
+                webView = new WebView2 { Width = 500, MinHeight = 520 };
+                currentIsWarm = false;
+                rootPanel.Children.Add(webView);
+                await AttachComposeBehavior(webView, selectedProfileId);
             };
 
             // WebView2 の Win32 HWND は XAML Popup より常に前面に描画されるため、
@@ -72,6 +175,12 @@ namespace XTimelineViewer.Views
             }
             finally
             {
+                _activeComposeDialog = null;
+
+                // 後始末：warm はホストへ戻して再利用、オンデマンドは破棄
+                if (currentIsWarm) ReturnWarmToHost(webView, rootPanel, selectedProfileId);
+                else { try { rootPanel.Children.Remove(webView); webView.Close(); } catch { } }
+
                 foreach (var wv in _webViews)
                     wv.Visibility = Visibility.Visible;
 
@@ -90,6 +199,9 @@ namespace XTimelineViewer.Views
                 {
                     setFocus();
                 }
+
+                // 次回に備えて再プリロード（設定 ON のとき。同プロファイルなら no-op）
+                _ = WarmUpComposeAsync();
             }
         }
 
@@ -159,8 +271,12 @@ namespace XTimelineViewer.Views
             return combo;
         }
 
-        /// <summary>投稿用 WebView2 を初期化して compose/post へナビゲートする。</summary>
-        private async Task InitComposeWebView(WebView2 webView, string profileId, ContentDialog dlg)
+        /// <summary>
+        /// 投稿用 WebView2 を初期化してハンドラを取り付け、compose/post へナビゲートする。
+        /// 自動クローズは現在開いている投稿ダイアログ（<see cref="_activeComposeDialog"/>）に対して行う。
+        /// プリロード（warm）でも投稿ダイアログでも同じ振る舞いを共有する（#244 案A）。
+        /// </summary>
+        private async Task AttachComposeBehavior(WebView2 webView, string profileId)
         {
             var env = await GetOrCreateProfileEnvAsync(profileId);
             await webView.EnsureCoreWebView2Async(env);
@@ -175,12 +291,12 @@ namespace XTimelineViewer.Views
             };
             webView.CoreWebView2.Profile.PreferredColorScheme = scheme;
 
-            bool composerReady = false;
+            _composeReadyViews.Remove(webView);
 
             webView.CoreWebView2.NavigationCompleted += async (s, args) =>
             {
                 if (!args.IsSuccess) return;
-                composerReady = true;
+                _composeReadyViews.Add(webView);
                 await webView.CoreWebView2.ExecuteScriptAsync("""
                     (function() {
                         var id = 'xtv-compose-style';
@@ -200,20 +316,20 @@ namespace XTimelineViewer.Views
 
             webView.CoreWebView2.NavigationStarting += (s, args) =>
             {
-                if (composerReady && !args.Uri.Contains("/compose/post"))
-                    dlg.Hide();
+                if (_composeReadyViews.Contains(webView) && !args.Uri.Contains("/compose/post"))
+                    _activeComposeDialog?.Hide();
             };
 
             // SPA 遷移では NavigationStarting が発火しないため、
             // 投稿 API のレスポンスを監視して自動で閉じる (#180)
             webView.CoreWebView2.WebResourceResponseReceived += (s, args) =>
             {
-                if (!composerReady) return;
+                if (!_composeReadyViews.Contains(webView)) return;
                 var uri = args.Request.Uri;
                 if (uri.Contains("/CreateTweet", StringComparison.OrdinalIgnoreCase) &&
                     args.Response.StatusCode >= 200 && args.Response.StatusCode < 300)
                 {
-                    dlg.DispatcherQueue.TryEnqueue(() => dlg.Hide());
+                    DispatcherQueue.TryEnqueue(() => _activeComposeDialog?.Hide());
                 }
             };
 

--- a/Views/MainWindow.Settings.cs
+++ b/Views/MainWindow.Settings.cs
@@ -127,6 +127,7 @@ namespace XTimelineViewer.Views
                 ApplySavedTheme();
                 UpdateThemeRadioState();
                 ApplyAutoActivateTimer();
+                _ = WarmUpComposeAsync();  // 投稿プリロードの ON/OFF を即時反映（#244 案B）
 
                 // WebView のタイムスタンプ設定を即時反映
                 var tsFlag = _appSettings.OpenTimestampInBrowser ? "true" : "false";

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -250,6 +250,7 @@ namespace XTimelineViewer.Views
             {
                 _hardReloadUiTimer?.Stop();
                 _autoActivateTimer?.Stop();
+                DisposeComposeWarm();  // 投稿プリロードの後始末（#244 案B）
                 foreach (var wv in _webViews.ToList())
                     CleanupWebView(wv);
                 await SaveTimelinesAsync();

--- a/Views/Settings/ExperimentalPage.xaml
+++ b/Views/Settings/ExperimentalPage.xaml
@@ -17,6 +17,15 @@
                      IsClosable="False"
                      Margin="0,0,0,8"/>
 
+            <!-- Compose Window Preload（#244 案B）-->
+            <controls:SettingsCard x:Name="ComposePreloadCard">
+                <controls:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE70F;" FontFamily="Segoe Fluent Icons"/>
+                </controls:SettingsCard.HeaderIcon>
+                <ToggleSwitch x:Name="ComposePreloadToggle"
+                              IsOn="{x:Bind VM.ComposePreloadEnabled, Mode=TwoWay}"/>
+            </controls:SettingsCard>
+
             <!-- Auto-Activate Home Timeline -->
             <controls:SettingsCard x:Name="AutoActivateCard">
                 <controls:SettingsCard.HeaderIcon>

--- a/Views/Settings/ExperimentalPage.xaml.cs
+++ b/Views/Settings/ExperimentalPage.xaml.cs
@@ -45,6 +45,12 @@ namespace XTimelineViewer.Views.Settings
             PageTitle.Text = R.Get("Nav_Experimental");
             CautionBar.Message = R.Get("Experimental_Caution");  // #242
 
+            // 投稿ウィンドウのプリロード（#244 案B）
+            ComposePreloadCard.Header      = R.Get("Settings_ComposePreload");
+            ComposePreloadCard.Description = R.Get("Settings_ComposePreload_Description");
+            ComposePreloadToggle.OnContent  = R.Get("Toggle_On");
+            ComposePreloadToggle.OffContent = R.Get("Toggle_Off");
+
             // #222 非推奨: 定期アクティブ化と関連オプションを無効化＋グレーアウト（v2.0 で削除予定）
             AutoActivateCard.Header      = R.Get("Settings_AutoActivate");
             AutoActivateCard.Description = R.Get("Settings_AutoActivate_Description") + "\n" + R.Get("Settings_Deprecated_Note");


### PR DESCRIPTION
## 概要
投稿ウィンドウ（コンポーザー）をプリロードして、投稿ボタン押下から入力可能になるまでの待ち時間を大幅に短縮します。**試験機能**として実装。Closes #244

当初は案B（キャッシュ暖機）を試したが体感差が小さかったため、**案A（生成済みインスタンスの即時表示）**を採用。

## 仕組み
- 最後に使ったプロファイル（`ResolveComposeProfileId`）の compose 画面を、非表示ホスト（コンテンツ行・Opacity 0・ヒットテスト無効・ZIndex -1）で**実サイズ 500×520 まで完成**させて常駐。
- 投稿ボタン押下時、プロファイルが一致すれば warm WebView2 を**ダイアログへ reparent して即時表示**（新規 CoreWebView2 生成なし）。
- 閉じたらホストへ戻し、`compose/post` へ再ナビゲートして**下書きをリセット**、次回に備えて再 warm。
- プロファイル切替時はオンデマンド生成にフォールバック（warm は破棄せず退避）。warm は常に「直近使用の 1 プロファイル」のみ（メモリ節約）。

## 実装
- 試験機能トグル `ComposePreloadEnabled`（既定 OFF）。`AppSettings` / `SettingsViewModel` / 試験機能ページ。
- compose の挙動（スタイル注入・自動クローズ #180）を `AttachComposeBehavior` に共通化。準備完了はビュー単位（`_composeReadyViews`）で管理し、パーク中 warm との競合を回避。
- 起動後・設定変更時に warm 更新。OFF／ウィンドウクローズで破棄。
- リソース `Settings_ComposePreload`（ja/en）。

## テスト
- ビルド 0 警告 / 0 エラー、ユニットテスト 125 件パス。
- 手動確認: ON で投稿ウィンドウが即時表示（体感大幅改善）、投稿後の自動クローズ・下書きリセット・再プリロード、プロファイル切替、OFF 時の回帰なし、レイアウト崩れなし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
