### PR TITLE
投稿ダイアログで Ctrl+P によるアカウント切替 (#247)

### DIFF
--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -149,7 +149,7 @@
   <data name="Button_Skip" xml:space="preserve"><value>Skip and exit</value></data>
 
   <!-- Compose profile selector -->
-  <data name="Compose_Profile" xml:space="preserve"><value>Post as</value></data>
+  <data name="Compose_Profile" xml:space="preserve"><value>Post as (Ctrl+P to switch)</value></data>
   <data name="Compose_Cancel" xml:space="preserve"><value>Cancel &amp; close</value></data>
   <data name="Compose_Post" xml:space="preserve"><value>Post (Ctrl+Enter)</value></data>
 

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -149,7 +149,7 @@
   <data name="Button_Skip" xml:space="preserve"><value>スキップしてアプリを終了</value></data>
 
   <!-- Compose profile selector -->
-  <data name="Compose_Profile" xml:space="preserve"><value>投稿アカウント</value></data>
+  <data name="Compose_Profile" xml:space="preserve"><value>投稿アカウント（Ctrl+P で切り替え）</value></data>
   <data name="Compose_Cancel" xml:space="preserve"><value>キャンセルして閉じる</value></data>
   <data name="Compose_Post" xml:space="preserve"><value>投稿する（Ctrl+Enter）</value></data>
 

--- a/Views/MainWindow.Post.cs
+++ b/Views/MainWindow.Post.cs
@@ -30,6 +30,7 @@ namespace XTimelineViewer.Views
         private WebView2? _composeWarmWebView;
         private string?   _composeWarmProfileId;
         private ContentDialog? _activeComposeDialog;             // 現在開いている投稿ダイアログ（自動クローズ用）
+        private Action? _composeCycleProfile;                     // 次の投稿アカウントへ切り替える（#247。Ctrl+P）
         private readonly HashSet<WebView2> _composeReadyViews = []; // compose/post ロード完了済みのビュー
 
         internal async Task WarmUpComposeAsync()
@@ -111,6 +112,14 @@ namespace XTimelineViewer.Views
             var profileCombo = BuildProfileComboBox(selectedProfileId);
             var rootPanel = new StackPanel { Spacing = 8 };
             rootPanel.Children.Add(profileCombo);
+
+            // Ctrl+P（#247）：次の投稿アカウントへ巡回。コンボの選択を進めると SelectionChanged が
+            // 発火してプロファイルが切り替わる。
+            _composeCycleProfile = () =>
+            {
+                if (profileCombo.Items.Count <= 1) return;
+                profileCombo.SelectedIndex = (profileCombo.SelectedIndex + 1) % profileCombo.Items.Count;
+            };
 
             // プリロード済み（warm）が同じプロファイルで使えるなら、移し替えて即表示（#244 案A）
             WebView2 webView;
@@ -206,6 +215,7 @@ namespace XTimelineViewer.Views
             finally
             {
                 _activeComposeDialog = null;
+                _composeCycleProfile = null;
 
                 // 後始末：warm はホストへ戻して再利用、オンデマンドは破棄
                 if (currentIsWarm) ReturnWarmToHost(webView, rootPanel, selectedProfileId);
@@ -362,11 +372,21 @@ namespace XTimelineViewer.Views
             var env = await GetOrCreateProfileEnvAsync(profileId);
             await webView.EnsureCoreWebView2Async(env);
 
-            // ESC でダイアログを閉じる（WebView 内 JS からの通知。#246）
+            // ブラウザー既定アクセラレータ（Ctrl+P の印刷など）を無効化し、JS で拾えるようにする（#247）
+            webView.CoreWebView2.Settings.AreBrowserAcceleratorKeysEnabled = false;
+
+            // WebView 内 JS からの通知を処理（#246 ESC / #247 アカウント切替）
             webView.CoreWebView2.WebMessageReceived += (s, e) =>
             {
-                if (e.TryGetWebMessageAsString() == "composeCancel")
-                    DispatcherQueue.TryEnqueue(() => _activeComposeDialog?.Hide());
+                switch (e.TryGetWebMessageAsString())
+                {
+                    case "composeCancel":
+                        DispatcherQueue.TryEnqueue(() => _activeComposeDialog?.Hide());
+                        break;
+                    case "composeNextProfile":
+                        DispatcherQueue.TryEnqueue(() => _composeCycleProfile?.Invoke());
+                        break;
+                }
             };
 
             // テーマを適用
@@ -395,6 +415,13 @@ namespace XTimelineViewer.Views
                             e.preventDefault();
                             e.stopImmediatePropagation();
                             try { window.chrome.webview.postMessage('composeCancel'); } catch (_) {}
+                            return;
+                        }
+                        // Ctrl+P で次の投稿アカウントへ切り替える（#247）。印刷ダイアログは抑止。
+                        if (e.ctrlKey && !e.shiftKey && !e.altKey && (e.key === 'p' || e.key === 'P')) {
+                            e.preventDefault();
+                            e.stopImmediatePropagation();
+                            try { window.chrome.webview.postMessage('composeNextProfile'); } catch (_) {}
                         }
                     }, true);
                 })();


### PR DESCRIPTION
## 概要
投稿ダイアログでキーボードショートカット **Ctrl+P** により投稿アカウントを切り替えられるようにします。Closes #247

## 変更点
- compose の WebView 内 JS で **Ctrl+P を捕捉**（capture・`preventDefault` で印刷ダイアログを抑止）し `postMessage('composeNextProfile')`。compose webview は `AreBrowserAcceleratorKeysEnabled=false` で印刷ショートカットを無効化。
- C# 側で **プロファイルコンボの選択を次へ巡回**（`SelectionChanged` 経由で切替）。切替後は #246 の仕組みで編集ボックスへフォーカスが戻る。
- 「投稿アカウント」ラベルに **「（Ctrl+P で切り替え）」** を併記して発見しやすく。

## 補足
- 割り当ては暫定（Ctrl+P）。印刷との競合はダイアログ内で無効化済みのため実害なし（必要なら後で Ctrl+Shift+P 等に変更可）。
- 切替時は WebView を作り直すため、入力中の下書きはリセットされる（既存のプロファイル切替仕様）。

## テスト
- ビルド 0 警告 / 0 エラー、ユニットテスト 125 件パス。
- 手動確認: Ctrl+P で次アカウントへ巡回、切替後フォーカス復帰、印刷ダイアログが出ない、プロファイル 1 つのとき無効、ラベル表記（ja/en）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
