### PR TITLE
ホイールでアクティブ化したペインがショートカットを受け付けない問題を修正 (#251)

### DIFF
--- a/Views/MainWindow.Post.cs
+++ b/Views/MainWindow.Post.cs
@@ -530,8 +530,31 @@ namespace XTimelineViewer.Views
                     if (_webViewToPane.TryGetValue(senderWebView, out var actPane) &&
                         _paneToSetFocus.TryGetValue(actPane, out var actSetFocus))
                         actSetFocus();
+                    // webView.Focus() だけでは document に実フォーカスが移らず Home 等が効かない
+                    // ことがあるため、document.hasFocus が立つまでリトライして確実にする（#251）
+                    EnsureWebViewKeyboardFocus(senderWebView);
                     break;
             }
+        }
+
+        // WebView2 コンテンツに実際のキーボードフォーカスを確実に当てる（#251）。
+        // webView.Focus() は true を返しても document.hasFocus が立たないことがあるため、
+        // window.focus() と併せて document.hasFocus が true になるまで短時間リトライする。
+        private void EnsureWebViewKeyboardFocus(WebView2 webView)
+        {
+            DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, async () =>
+            {
+                if (webView.CoreWebView2 is null) return;
+                for (int i = 0; i < 10; i++)
+                {
+                    webView.Focus(FocusState.Programmatic);
+                    string r;
+                    try { r = await webView.CoreWebView2.ExecuteScriptAsync("(function(){try{window.focus();}catch(e){} return document.hasFocus();})()"); }
+                    catch { return; }
+                    if (r == "true") return;  // フォーカス確定
+                    await Task.Delay(60);
+                }
+            });
         }
 
         private void FocusAdjacentTimeline(WebView2 senderWebView, int direction)


### PR DESCRIPTION
## 概要
ホイールでアクティブ化（#221）したタイムラインで [Home] 等のショートカットが効かない問題を修正します。Closes #251

## 原因
Home/End 等は WebView 内 JS の keydown で処理されるため、その WebView がキーボードフォーカスを持つ必要がある。activate 経路は `SetFocus()` → `webView.Focus()` を呼ぶが、`webView.Focus()` は true を返しても **document に実フォーカスが移らない**ことがある（#246 で判明）。

## 変更点
- activate 受信時に `EnsureWebViewKeyboardFocus` を呼び、`webView.Focus()` + `window.focus()` を **`document.hasFocus()` が true になるまで**最大 10 回（60ms 間隔）リトライして確実にフォーカスを当てる。

## テスト
- ビルド 0 警告 / 0 エラー、ユニットテスト 125 件パス。
- 手動確認: ホイールでアクティブ化 → Home/End/F5 等が当該ペインに効く。連続して別ペインをホイールしても切り替わる。

## 補足
- Ctrl+R/B/L（ポスト操作）はフォーカス中ポストが無いと no-op になる別原因のため、本 PR の対象外。[#254](https://github.com/daruyanagi/XTimelineViewer/issues/254) で対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
