### PR TITLE
個別ツイートページで Ctrl+R/B/L を効かせる (#254)

### DIFF
--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -157,8 +157,15 @@ namespace XTimelineViewer.Views
 
                 function actOnPost(id, alt) {
                     var ps = getPosts();
-                    if (fi < 0 || fi >= ps.length) return;
-                    var b = ps[fi].querySelector('[data-testid="' + id + '"]' + (alt ? ',[data-testid="' + alt + '"]' : ''));
+                    if (!ps.length) return;
+                    var idx = fi;
+                    if (idx < 0 || idx >= ps.length) {
+                        // タイムラインでは Ctrl+↑/↓ での選択が必要（案C）。
+                        // ただし個別ツイート（/status/）ページでは未選択でも主ツイート（先頭）に作用する（#254）。
+                        if (/\/status\/\d+/.test(location.pathname)) idx = 0;
+                        else return;
+                    }
+                    var b = ps[idx].querySelector('[data-testid="' + id + '"]' + (alt ? ',[data-testid="' + alt + '"]' : ''));
                     b?.click();
                 }
 


### PR DESCRIPTION
## 概要
個別ツイート（`/status/...`）ページで Ctrl+R（リポスト）/ B（ブックマーク）/ L（いいね）が効かない問題を修正します。Closes #254

## 方針（イシューのコメントに基づく）
- **タイムライン**: 従来どおり Ctrl+↑/↓ でポストを選択してから操作（案C・変更なし）。
- **個別ツイートページ**: 未選択でも**主ツイート（先頭の article）**に作用させる。

## 変更点
- `actOnPost`（`KeyboardShortcutScript`）で、フォーカス中ポストが無い（`fi < 0`）場合に `location.pathname` が `/status/\d+` なら先頭ポストを対象にする。`fi` は変更しないためタイムラインの選択状態に副作用なし。

## テスト
- ビルド 0 警告 / 0 エラー、ユニットテスト 125 件パス。
- 手動確認: 個別ツイート表示中に Ctrl+R/B/L が当該ツイートに効く／タイムラインでは従来どおり（未選択時は無反応、Ctrl+↑↓ 選択後は有効）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
