### PR TITLE
リリース v1.8.0

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -8,3 +8,4 @@
 - [イシューは daruyanagi にアサイン](feedback_assign_issues.md) — gh issue create に毎回 --assignee daruyanagi を付ける。
 - [イシュー解決前にコメントをすべて読む](feedback_read_issue_comments.md) — 実装前に gh issue view <number> --comments でコメントまで確認する。本文だけ読んで着手しない。
 - [デバッグ実行は生成直後の exe を起動](feedback_debug_run_fresh_exe.md) — ビルドした exe と起動する exe を一致させる。更新時刻を検証。debug-run スキルに従う。
+- [Store のバンドル版番号は日付ベースで正常](project_store_bundle_version.md) — Partner Center の 2026.MMDD.HHMM.0 表示はバンドル版。中身は正しい x.y.z.0。セマンティック版に揃えない。

--- a/.claude/memory/project_store_bundle_version.md
+++ b/.claude/memory/project_store_bundle_version.md
@@ -1,0 +1,16 @@
+---
+name: store-bundle-version-date-based
+description: Microsoft Store のパートナーセンターに出る .msixbundle の版番号は日付ベース（2026.MMDD.HHMM.0）で正常。中身のアプリは正しい x.y.z.0
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: b3ca3c76-d26c-4354-92b4-f11707c5396e
+---
+
+`Release.ps1` が作る `.msixbundle` を Partner Center にアップすると、版番号が **`YYYY.MMDD.HHMM.0`（例 `2026.621.143.0`）, Neutral** と表示されるが、**これは正常**。
+
+- 表示されているのは**バンドル（コンテナ）の Identity バージョン**。Release.ps1 の `MakeAppx bundle` が `/bv` を指定しないため、MakeAppx がビルド日時から自動採番する。
+- **中身のアプリパッケージは正しく `x.y.z.0`**（x64/arm64）で、ユーザーに見えるアプリのバージョンはこちら。GitHub リリース（`vX.Y.Z`）/winget と一致する。
+- 日付ベースは常に増加するので Store は毎回受理する。**セマンティック版（例 1.7.0.0）に揃えようとしてはいけない**——Store には既に日付ベースの大きい版番号が登録済みで、`1.7.0.0 < 2026.x` となり**拒否される**。日付ベースのまま運用するのが正解。
+
+確認方法: バンドル内 `AppxMetadata/AppxBundleManifest.xml` の `<Identity Version>` がバンドル版、各 `<Package Version>` がアプリ版。リリース手順は [[x64-arm64]] と release スキル参照。

--- a/Package.appxmanifest
+++ b/Package.appxmanifest
@@ -8,7 +8,7 @@
   <Identity
     Name="4275.XTimelineViewer"
     Publisher="CN=B73FDB0C-06E5-4824-9E7F-3AF969921DF4"
-    Version="1.7.0.0"
+    Version="1.8.0.0"
     ProcessorArchitecture="neutral" />
 
   <Properties>

--- a/XTimelineViewer.csproj
+++ b/XTimelineViewer.csproj
@@ -7,7 +7,7 @@
     <Platforms>x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
     <PlatformTarget>x64</PlatformTarget>
-    <Version>1.7.0</Version>
+    <Version>1.8.0</Version>
     <ApplicationIcon>Assets\AppIcon.ico</ApplicationIcon>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
## リリース v1.8.0（マイナー）

v1.7.0 以降のユーザー向け変更をまとめたリリース。csproj `<Version>` と Package.appxmanifest を 1.8.0 に更新。

### 主な変更
- **設定の再編**: テーマ・言語を新設の［ユーザーインターフェイス］ページへ。試験機能の安定機能（外部ブラウザー関連）を［全般］の［外部ブラウザー］セクションに集約（#240）
- **設定ページに InfoBar**: 拡張機能の状態＋extensions フォルダーを開くボタン、試験機能ページに注意喚起（#243）
- **投稿ウィンドウのプリロード**（試験機能）: 投稿ボタンから即入力できるよう事前ロード（#245）
- **投稿ダイアログの刷新**（#248 / #249 / #253）:
  - ボタン配置を X の作法に（左［キャンセルして閉じる］／右［投稿する（Ctrl+Enter）］）、X 上部バーを非表示、開いたら編集ボックスに即フォーカス、ESC で確実に閉じる
  - Ctrl+P / Ctrl+Shift+P で投稿アカウントを次／前へ切り替え
- **ホーム自動更新インジケーターの一時停止理由を分かりやすく**（ホーム以外を表示中・スクロール中など）（#250）
- **ホイールでアクティブ化したペインがショートカットを受け付けない問題を修正**（#255）／個別ツイートページで Ctrl+R/B/L を効かせる（#256）
- 「ホームを定期的にアクティブ化」を非推奨化（自動更新に一本化、v1.7.0 で対応済）

### リリース手順
- マージ後に `v1.8.0` タグを push → CI が ZIP/GitHub リリース/winget を自動公開
- Microsoft Store には `publish/release/XTimelineViewer-1.8.0.msixbundle`（x64+arm64・未署名可）をアップロード

### 補足
- メモリ（`.claude/memory/`）に Store バンドル版番号の注意書きを同梱コミット。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
