### PR TITLE
別ペインで編集中はホーム自動更新を一時停止する (#258)

### DIFF
--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -65,6 +65,7 @@
   <data name="AutoLoad_Paused_Scroll" xml:space="preserve"><value>Home auto-refresh: Paused (scrolled down; resumes at top)</value></data>
   <data name="AutoLoad_Paused_Search" xml:space="preserve"><value>Home auto-refresh: Paused (searching)</value></data>
   <data name="AutoLoad_Paused_Away" xml:space="preserve"><value>Home auto-refresh: Paused (not on Home)</value></data>
+  <data name="AutoLoad_Paused_Elsewhere" xml:space="preserve"><value>Home auto-refresh: Paused (editing in another timeline)</value></data>
   <data name="AutoLoad_Off" xml:space="preserve"><value>Home auto-refresh: Off</value></data>
   <data name="Settings_ShowAutoActivateLabel_Description" xml:space="preserve"><value>Show the auto-activate countdown timer in the toolbar</value></data>
   <data name="Settings_ExternalBrowser_Description" xml:space="preserve"><value>Choose which browser to use for opening external links</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -65,6 +65,7 @@
   <data name="AutoLoad_Paused_Scroll" xml:space="preserve"><value>ホーム自動更新: 一時停止中（スクロール中。先頭に戻ると再開します）</value></data>
   <data name="AutoLoad_Paused_Search" xml:space="preserve"><value>ホーム自動更新: 一時停止中（検索中）</value></data>
   <data name="AutoLoad_Paused_Away" xml:space="preserve"><value>ホーム自動更新: 一時停止中（ホーム以外を表示中）</value></data>
+  <data name="AutoLoad_Paused_Elsewhere" xml:space="preserve"><value>ホーム自動更新: 一時停止中（他のタイムラインで編集中）</value></data>
   <data name="AutoLoad_Off" xml:space="preserve"><value>ホーム自動更新: オフ</value></data>
   <data name="Settings_ShowAutoActivateLabel_Description" xml:space="preserve"><value>ツールバーに自動アクティブ化のカウントダウンタイマーを表示します</value></data>
   <data name="Settings_ExternalBrowser_Description" xml:space="preserve"><value>外部リンクを開くブラウザーを選択します</value></data>

--- a/Views/MainWindow.HardReload.cs
+++ b/Views/MainWindow.HardReload.cs
@@ -109,6 +109,7 @@ namespace XTimelineViewer.Views
             _urlDivergedWebViews.Remove(wv);
             _webViews.Remove(wv);
             _webViewToPane.Remove(wv);
+            if (_composingWebViews.Remove(wv)) UpdateAnyComposing();  // #258: 編集中ペインが消えたら反映
             try
             {
                 wv.Close();

--- a/Views/MainWindow.Post.cs
+++ b/Views/MainWindow.Post.cs
@@ -498,6 +498,15 @@ namespace XTimelineViewer.Views
                 return;
             }
 
+            if (message.StartsWith("editing:"))  // #258: いずれかのペインの編集状態
+            {
+                bool on = message == "editing:true";
+                bool changed = on ? _composingWebViews.Add(senderWebView)
+                                  : _composingWebViews.Remove(senderWebView);
+                if (changed) UpdateAnyComposing();
+                return;
+            }
+
             if (message.StartsWith("focusIndex:") &&
                 int.TryParse(message["focusIndex:".Length..], out var tlIndex))
             {

--- a/Views/MainWindow.Timeline.cs
+++ b/Views/MainWindow.Timeline.cs
@@ -165,6 +165,7 @@ namespace XTimelineViewer.Views
                 case "paused-search": glyph = ""; tipKey = "AutoLoad_Paused_Search"; opacity = 0.5;  break;
                 case "off":           glyph = ""; tipKey = "AutoLoad_Off";           opacity = 0.35; break; // Cancel
                 case "idle":         glyph = ""; tipKey = "AutoLoad_Paused_Away";   opacity = 0.5;  break; // ホーム以外
+                case "paused-elsewhere": glyph = ""; tipKey = "AutoLoad_Paused_Elsewhere"; opacity = 0.5;  break; // 他ペイン編集中
                 default:              glyph = ""; tipKey = "AutoLoad_Paused";         opacity = 0.5;  break; // idle 等
             }
             ind.Icon.Glyph   = glyph;

--- a/Views/MainWindow.WebView2.cs
+++ b/Views/MainWindow.WebView2.cs
@@ -100,6 +100,32 @@ namespace XTimelineViewer.Views
             await webView.CoreWebView2.ExecuteScriptAsync(BuildHideSidebarJs(hide));
         }
 
+        // 編集状態レポーター（#258）。全ペインに注入し、編集中（モーダル表示／編集要素フォーカス）に
+        // なったら postMessage('editing:true'/'editing:false') で C# に通知する。C# 側は「いずれかの
+        // ペインが編集中」を集約してホーム自動更新を一時停止する（別ペインの下書き消失を防ぐ）。
+        private static readonly string EditStateReporterScript = """
+            (function () {
+                if (window._xtvEditWatch) return;
+                window._xtvEditWatch = true;
+                var last = null;
+                function isEditing() {
+                    if (document.querySelector('[aria-modal="true"]')) return true;
+                    var fe = document.activeElement;
+                    return !!(fe && (fe.isContentEditable || fe.tagName === 'TEXTAREA' || fe.tagName === 'INPUT'));
+                }
+                function report() {
+                    var v = isEditing();
+                    if (v === last) return;
+                    last = v;
+                    try { window.chrome.webview.postMessage('editing:' + v); } catch (e) {}
+                }
+                document.addEventListener('focusin', report, true);
+                document.addEventListener('focusout', function () { setTimeout(report, 0); }, true);
+                setInterval(report, 1000);  // モーダル開閉など focus 変化を伴わないケースのバックストップ
+                report();
+            })();
+            """;
+
         /// <summary>cfg がホームタイムラインかどうか。</summary>
         private static bool IsHomeConfig(TimelineConfig cfg)
             => Uri.TryCreate(cfg.Url, UriKind.Absolute, out var u)
@@ -155,6 +181,7 @@ namespace XTimelineViewer.Views
                     if (window.pageYOffset > 5.0) { g_ttlTopCount = intervalMs(); report('paused-scroll'); return; }
                     var reason = suppressReason();
                     if (reason) { report('paused-' + reason); return; }
+                    if (window._xtvAnyComposing) { report('paused-elsewhere'); return; }  // 他ペインで編集中（#258）
                     report('running');
                     if (g_ttlTopCount >= intervalMs()) {
                         var homeButton = document.body.querySelectorAll('a[data-testid="AppTabBar_Home_Link"]');
@@ -181,6 +208,15 @@ namespace XTimelineViewer.Views
         {
             try { await webView.CoreWebView2.ExecuteScriptAsync(BuildHomeAutoLoadConfigJs()); }
             catch { }
+        }
+
+        /// <summary>いずれかのペインが編集中かを全ペインの JS（window._xtvAnyComposing）へ反映する（#258）。</summary>
+        private void UpdateAnyComposing()
+        {
+            var any = _composingWebViews.Count > 0 ? "true" : "false";
+            foreach (var wv in _webViews)
+                if (wv.CoreWebView2 is not null)
+                    _ = wv.CoreWebView2.ExecuteScriptAsync($"window._xtvAnyComposing = {any};");
         }
 
         private static bool EffectiveHideCompose(TimelineConfig cfg, string currentUrl) =>
@@ -537,6 +573,8 @@ namespace XTimelineViewer.Views
             webView.CoreWebView2.Settings.AreBrowserAcceleratorKeysEnabled = false;
             await webView.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(KeyboardShortcutScript);
             await webView.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(TimestampInterceptScript);
+            // 編集状態レポーター（#258）：全ペインに注入し、編集中（リプライ/引用）を C# へ通知する。
+            await webView.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(EditStateReporterScript);
             // ホーム自動更新（#207）。ホームペインにのみ注入し、設定で ON/OFF・間隔を制御する。
             if (IsHomeConfig(cfg))
             {

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -121,6 +121,9 @@ namespace XTimelineViewer.Views
         // タイムライン番号バッジ（#225）。ペイン → 番号 TextBlock。表示順で 1..9 を振り直す。
         private readonly Dictionary<Grid, TextBlock> _paneNumberLabels = [];
 
+        // 編集中（リプライ/引用）の WebView 集合（#258）。いずれかが編集中ならホーム自動更新を止める。
+        private readonly HashSet<WebView2> _composingWebViews = [];
+
         // headerGrid → pane の対応（#227）。アクティブな headerGrid からペインを引くのに使う。
         private readonly Dictionary<Grid, Grid> _headerGridToPane = [];
 


### PR DESCRIPTION
## 概要
ホーム以外のタイムラインでテキスト編集中（リプライ・引用リポスト）に、ホームの自動更新が発火して下書きが失われることがある問題を修正します。Closes #258

## 変更点
- **全ペインに編集状態レポーターを注入**（`EditStateReporterScript`）。モーダル表示（`[aria-modal="true"]`）／編集要素（contenteditable・TEXTAREA・INPUT）フォーカスを検知し、変化時に `postMessage('editing:true' / 'editing:false')`（focusin/focusout＋1秒バックストップ）。
- **C# で集約**: `_composingWebViews` に出し入れし、`UpdateAnyComposing` が全ペインへ `window._xtvAnyComposing` を反映。
- **ホーム自動更新 tick**: `_xtvAnyComposing` が true なら `paused-elsewhere` で一時停止（自ペインの編集は従来の `suppressReason` が先に処理）。
- **インジケーター**: 「ホーム自動更新: 一時停止中（他のタイムラインで編集中）」を追加（ja/en）。
- ペイン破棄時に `_composingWebViews` から除去。

## テスト
- ビルド 0 警告 / 0 エラー、ユニットテスト 125 件パス。
- 手動確認: 別ペインでリプライ/引用編集開始 → ホームのインジケーターが「他のタイムラインで編集中」になり自動更新が止まる／編集終了で再開／下書きが飛ばない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
