### PR TITLE
リリース v1.8.1

### DIFF
--- a/Package.appxmanifest
+++ b/Package.appxmanifest
@@ -8,7 +8,7 @@
   <Identity
     Name="4275.XTimelineViewer"
     Publisher="CN=B73FDB0C-06E5-4824-9E7F-3AF969921DF4"
-    Version="1.8.0.0"
+    Version="1.8.1.0"
     ProcessorArchitecture="neutral" />
 
   <Properties>

--- a/XTimelineViewer.csproj
+++ b/XTimelineViewer.csproj
@@ -7,7 +7,7 @@
     <Platforms>x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
     <PlatformTarget>x64</PlatformTarget>
-    <Version>1.8.0</Version>
+    <Version>1.8.1</Version>
     <ApplicationIcon>Assets\AppIcon.ico</ApplicationIcon>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
## リリース v1.8.1（パッチ）

バグ修正のみのパッチリリース。Store 申請は不要（`-SkipBundle`）。csproj `<Version>` と Package.appxmanifest を 1.8.1 に更新。

### 変更
- 別ペイン（ホーム以外）でリプライ/引用を編集中に、ホームの自動更新が発火して下書きが失われることがある問題を修正（#258 / #259）

### リリース手順
- マージ後に `v1.8.1` タグを push → CI が ZIP/GitHub リリース/winget を自動公開
- パッチのため Microsoft Store 申請は不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)
