### PR TITLE
MSIX に xtv / xtimelineviewer のコマンドエイリアスを追加 (ref #170)

### DIFF
--- a/Package.appxmanifest
+++ b/Package.appxmanifest
@@ -3,7 +3,8 @@
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-  IgnorableNamespaces="uap rescap">
+  xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
+  IgnorableNamespaces="uap uap5 rescap">
 
   <Identity
     Name="4275.XTimelineViewer"
@@ -43,6 +44,15 @@
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" />
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
       </uap:VisualElements>
+      <!-- コマンドライン起動のエイリアス（#170）。xtv を主とし、後方互換で xtimelineviewer も残す。 -->
+      <Extensions>
+        <uap5:Extension Category="windows.appExecutionAlias">
+          <uap5:AppExecutionAlias>
+            <uap5:ExecutionAlias Alias="xtv.exe" />
+            <uap5:ExecutionAlias Alias="xtimelineviewer.exe" />
+          </uap5:AppExecutionAlias>
+        </uap5:Extension>
+      </Extensions>
     </Application>
   </Applications>
 


### PR DESCRIPTION
## 概要
コマンドライン起動用エイリアスを整備します。**`xtv` を主**とし、後方互換で **`xtimelineviewer` も残す**（両方共存）。本 PR は **MSIX / Store 版**を対象（このリポジトリで完結する部分）。ref #170

## 変更点
- `Package.appxmanifest` に `windows.appExecutionAlias` 拡張を追加し、`xtv.exe` と `xtimelineviewer.exe` を登録。
- MSIX ビルドでマニフェストを検証済み（0 エラー）。
- これで **Store 版インストールでも `xtv` / `xtimelineviewer` でコマンド起動可能**に（従来 Store 版はコマンドエイリアス無し）。

## 残作業（別経路・本 PR 対象外）
- **winget（ZIP/portable）版**: microsoft/winget-pkgs のマニフェストで `NestedInstallerFiles` に `xtv` エントリを追加（同 exe・別 alias）。次回 winget 提出時に対応。詳細は #170 のコメント参照。本 issue は winget 側完了までオープンのまま。

## テスト
- MSIX（x64）ビルド成功・0 エラー（appExecutionAlias スキーマ検証）。ユニットテスト 125 件パスは別途 Debug ビルドで確認可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
