### PR TITLE
リリース v1.9.0

### DIFF
--- a/Package.appxmanifest
+++ b/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="4275.XTimelineViewer"
     Publisher="CN=B73FDB0C-06E5-4824-9E7F-3AF969921DF4"
-    Version="1.8.1.0"
+    Version="1.9.0.0"
     ProcessorArchitecture="neutral" />
 
   <Properties>

--- a/XTimelineViewer.csproj
+++ b/XTimelineViewer.csproj
@@ -7,7 +7,7 @@
     <Platforms>x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
     <PlatformTarget>x64</PlatformTarget>
-    <Version>1.8.1</Version>
+    <Version>1.9.0</Version>
     <ApplicationIcon>Assets\AppIcon.ico</ApplicationIcon>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
## リリース v1.9.0（マイナー）

コマンドライン起動エイリアス追加を含むマイナーリリース。csproj `<Version>` と Package.appxmanifest を 1.9.0 に更新。

### 変更
- コマンドライン起動エイリアスを追加（#170）：`xtv` を主、後方互換で `xtimelineviewer` も併設。
  - 本リリースで **MSIX/Store 版**に appExecutionAlias が入る（#262）。
  - **winget（ZIP）版**は、本リリースで winget-releaser が作る winget-pkgs PR に `xtv` の NestedInstallerFiles エントリを追加して対応（#170 の残作業）。

### リリース手順
- マージ後に `v1.9.0` タグを push → CI が ZIP/GitHub リリース/winget を自動公開
- Microsoft Store に `publish/release/XTimelineViewer-1.9.0.msixbundle`（x64+arm64・未署名可）をアップロード
- winget 公開 PR に `xtv` エイリアスを追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)
