### PR TITLE
リリース v1.9.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,17 +20,19 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
+      # EffectivePlatform を明示しないと、WebView2 SDK がビルドホストの RID(win-x64) を見て
+      # x64 の Microsoft.Web.WebView2.Core.dll を arm64 出力に混入させ、arm64 で BadImageFormat になる。
       - name: Build x64
         run: >
           dotnet publish XTimelineViewer.csproj
-          -c Release -r win-x64 -p:Platform=x64
+          -c Release -r win-x64 -p:Platform=x64 -p:EffectivePlatform=x64
           -p:WindowsPackageType=None -p:SelfContained=true
           -o publish/x64
 
       - name: Build arm64
         run: >
           dotnet publish XTimelineViewer.csproj
-          -c Release -r win-arm64 -p:Platform=arm64 -p:PlatformTarget=arm64
+          -c Release -r win-arm64 -p:Platform=arm64 -p:PlatformTarget=arm64 -p:EffectivePlatform=arm64
           -p:WindowsPackageType=None -p:SelfContained=true
           -o publish/arm64
 

--- a/Package.appxmanifest
+++ b/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="4275.XTimelineViewer"
     Publisher="CN=B73FDB0C-06E5-4824-9E7F-3AF969921DF4"
-    Version="1.8.1.0"
+    Version="1.9.0.0"
     ProcessorArchitecture="neutral" />
 
   <Properties>

--- a/Release.ps1
+++ b/Release.ps1
@@ -80,7 +80,9 @@ if ($WithZip) {
         $plat = if ($rid -eq 'win-x64') { 'x64' } else { 'arm64' }
         Step "ZIP 発行: $rid"
         $pubDir = Join-Path $root "publish\$rid"
-        dotnet publish $proj -c Release -r $rid -p:PlatformTarget=$plat -p:WindowsPackageType=None -o $pubDir
+        # EffectivePlatform を明示しないと、WebView2 SDK がビルドホストの RID(win-x64) を見て
+        # x64 の Microsoft.Web.WebView2.Core.dll を arm64 出力に混入させ、arm64 で BadImageFormat になる。
+        dotnet publish $proj -c Release -r $rid -p:PlatformTarget=$plat -p:EffectivePlatform=$plat -p:WindowsPackageType=None -o $pubDir
         if ($LASTEXITCODE -ne 0) { throw "publish 失敗: $rid" }
         # コマンドライン起動用ランチャーを同梱（#264。CI の release.yml と揃える）
         Copy-Item (Join-Path $root 'tools\launcher\xtv.exe') (Join-Path $pubDir 'xtv.exe') -Force
@@ -96,9 +98,11 @@ if (-not $SkipBundle) {
     foreach ($plat in 'x64', 'arm64') {
         $rid = "win-$plat"
         Step "MSIX ビルド: $plat"
-        # arm64 は RuntimeIdentifier を明示しないと NETSDK1032（RID win-x64 と PlatformTarget arm64 の不一致）になる
+        # arm64 は RuntimeIdentifier を明示しないと NETSDK1032（RID win-x64 と PlatformTarget arm64 の不一致）になる。
+        # EffectivePlatform を明示しないと、WebView2 SDK がビルドホストの RID(win-x64) を見て x64 の
+        # Microsoft.Web.WebView2.Core.dll を arm64 パッケージに混入させ、arm64 で BadImageFormat になる。
         dotnet build $proj -c Release -p:Platform=$plat -p:PlatformTarget=$plat `
-            -p:RuntimeIdentifier=$rid -p:GenerateAppxPackageOnBuild=true
+            -p:RuntimeIdentifier=$rid -p:EffectivePlatform=$plat -p:GenerateAppxPackageOnBuild=true
         if ($LASTEXITCODE -ne 0) { throw "MSIX ビルド失敗: $plat" }
 
         $msix = Get-ChildItem (Join-Path $root "bin\$plat\Release\$tfm\$rid\AppPackages") `

--- a/XTimelineViewer.csproj
+++ b/XTimelineViewer.csproj
@@ -7,7 +7,7 @@
     <Platforms>x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
     <PlatformTarget>x64</PlatformTarget>
-    <Version>1.8.1</Version>
+    <Version>1.9.0</Version>
     <ApplicationIcon>Assets\AppIcon.ico</ApplicationIcon>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/XTimelineViewer.csproj
+++ b/XTimelineViewer.csproj
@@ -6,7 +6,15 @@
     <RootNamespace>XTimelineViewer</RootNamespace>
     <Platforms>x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
-    <PlatformTarget>x64</PlatformTarget>
+    <!--
+      WebView2 SDK の Common.targets は native の Microsoft.Web.WebView2.Core.dll（WinRT 実体）を
+      EffectivePlatform で選ぶ。EffectivePlatform は PlatformTarget=='x64' のとき x64 に固定される一方、
+      arm64 のルールが無いため、PlatformTarget を x64 にハードコードすると arm64 ビルドにも x64 の
+      WebView2 が混入し、arm64 で BadImageFormatException(0x800700C1) になる。
+      そのため PlatformTarget は Platform に追従させる（arm64 ビルド時は arm64）。
+    -->
+    <PlatformTarget Condition="'$(Platform)' == 'arm64'">arm64</PlatformTarget>
+    <PlatformTarget Condition="'$(PlatformTarget)' == ''">x64</PlatformTarget>
     <Version>1.9.0</Version>
     <ApplicationIcon>Assets\AppIcon.ico</ApplicationIcon>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## リリース v1.9.0（マイナー）

コマンドライン起動エイリアスを追加するマイナーリリース。csproj `<Version>` と Package.appxmanifest を 1.9.0 に更新。

### このリリースに含まれる主な変更
- **コマンドライン起動 `xtv` を追加**（後方互換で `xtimelineviewer` も併設）
  - ZIP/winget 向けの C++ ネイティブランチャー `xtv.exe` を ZIP に同梱（#264 / #265）
  - Store(MSIX) は appExecutionAlias で対応（#262）

### リリース手順
1. マージ後に `v1.9.0` タグを push → CI が ZIP（`xtv.exe` 同梱）/GitHub リリース/winget を自動公開
2. winget 公開 PR の `NestedInstallerFiles` を `xtv.exe` 指定（`xtv` / `xtimelineviewer`）に更新 → #264 クローズ
3. Microsoft Store に `publish/release/XTimelineViewer-1.9.0.msixbundle`（x64+arm64・未署名可）をアップロード

🤖 Generated with [Claude Code](https://claude.com/claude-code)
