### PR TITLE
fix(#267): arm64 で WebView2 が BadImageFormat になる不具合を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,17 +20,19 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
+      # EffectivePlatform を明示しないと、WebView2 SDK がビルドホストの RID(win-x64) を見て
+      # x64 の Microsoft.Web.WebView2.Core.dll を arm64 出力に混入させ、arm64 で BadImageFormat になる。
       - name: Build x64
         run: >
           dotnet publish XTimelineViewer.csproj
-          -c Release -r win-x64 -p:Platform=x64
+          -c Release -r win-x64 -p:Platform=x64 -p:EffectivePlatform=x64
           -p:WindowsPackageType=None -p:SelfContained=true
           -o publish/x64
 
       - name: Build arm64
         run: >
           dotnet publish XTimelineViewer.csproj
-          -c Release -r win-arm64 -p:Platform=arm64 -p:PlatformTarget=arm64
+          -c Release -r win-arm64 -p:Platform=arm64 -p:PlatformTarget=arm64 -p:EffectivePlatform=arm64
           -p:WindowsPackageType=None -p:SelfContained=true
           -o publish/arm64
 

--- a/Release.ps1
+++ b/Release.ps1
@@ -80,7 +80,9 @@ if ($WithZip) {
         $plat = if ($rid -eq 'win-x64') { 'x64' } else { 'arm64' }
         Step "ZIP 発行: $rid"
         $pubDir = Join-Path $root "publish\$rid"
-        dotnet publish $proj -c Release -r $rid -p:PlatformTarget=$plat -p:WindowsPackageType=None -o $pubDir
+        # EffectivePlatform を明示しないと、WebView2 SDK がビルドホストの RID(win-x64) を見て
+        # x64 の Microsoft.Web.WebView2.Core.dll を arm64 出力に混入させ、arm64 で BadImageFormat になる。
+        dotnet publish $proj -c Release -r $rid -p:PlatformTarget=$plat -p:EffectivePlatform=$plat -p:WindowsPackageType=None -o $pubDir
         if ($LASTEXITCODE -ne 0) { throw "publish 失敗: $rid" }
         # コマンドライン起動用ランチャーを同梱（#264。CI の release.yml と揃える）
         Copy-Item (Join-Path $root 'tools\launcher\xtv.exe') (Join-Path $pubDir 'xtv.exe') -Force
@@ -96,9 +98,11 @@ if (-not $SkipBundle) {
     foreach ($plat in 'x64', 'arm64') {
         $rid = "win-$plat"
         Step "MSIX ビルド: $plat"
-        # arm64 は RuntimeIdentifier を明示しないと NETSDK1032（RID win-x64 と PlatformTarget arm64 の不一致）になる
+        # arm64 は RuntimeIdentifier を明示しないと NETSDK1032（RID win-x64 と PlatformTarget arm64 の不一致）になる。
+        # EffectivePlatform を明示しないと、WebView2 SDK がビルドホストの RID(win-x64) を見て x64 の
+        # Microsoft.Web.WebView2.Core.dll を arm64 パッケージに混入させ、arm64 で BadImageFormat になる。
         dotnet build $proj -c Release -p:Platform=$plat -p:PlatformTarget=$plat `
-            -p:RuntimeIdentifier=$rid -p:GenerateAppxPackageOnBuild=true
+            -p:RuntimeIdentifier=$rid -p:EffectivePlatform=$plat -p:GenerateAppxPackageOnBuild=true
         if ($LASTEXITCODE -ne 0) { throw "MSIX ビルド失敗: $plat" }
 
         $msix = Get-ChildItem (Join-Path $root "bin\$plat\Release\$tfm\$rid\AppPackages") `

--- a/XTimelineViewer.csproj
+++ b/XTimelineViewer.csproj
@@ -6,7 +6,15 @@
     <RootNamespace>XTimelineViewer</RootNamespace>
     <Platforms>x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
-    <PlatformTarget>x64</PlatformTarget>
+    <!--
+      WebView2 SDK の Common.targets は native の Microsoft.Web.WebView2.Core.dll（WinRT 実体）を
+      EffectivePlatform で選ぶ。EffectivePlatform は PlatformTarget=='x64' のとき x64 に固定される一方、
+      arm64 のルールが無いため、PlatformTarget を x64 にハードコードすると arm64 ビルドにも x64 の
+      WebView2 が混入し、arm64 で BadImageFormatException(0x800700C1) になる。
+      そのため PlatformTarget は Platform に追従させる（arm64 ビルド時は arm64）。
+    -->
+    <PlatformTarget Condition="'$(Platform)' == 'arm64'">arm64</PlatformTarget>
+    <PlatformTarget Condition="'$(PlatformTarget)' == ''">x64</PlatformTarget>
     <Version>1.8.1</Version>
     <ApplicationIcon>Assets\AppIcon.ico</ApplicationIcon>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## 概要
arm64 端末（Surface Pro 11 等）で **WebView2 初期化が `BadImageFormatException (0x800700C1)` で失敗**し起動できない不具合を修正します。Closes #267

## 原因
arm64 パッケージに **x64 の `Microsoft.Web.WebView2.Core.dll`（WinRT 実体）が混入**していた。WebView2 SDK の `build/Common.targets` はこの native DLL を `EffectivePlatform` で選ぶが、その算出が
```
NETCoreSdkRuntimeIdentifier == 'win-x64' → EffectivePlatform = x64
```
と **ビルドホスト（x64）の RID** で x64 に固定する。targets に arm64 ルールが無く `PlatformTarget=arm64` でも上書きできず、arm64 クロスビルドでも x64 の Core.dll が出力・パッケージされていた。ZIP(winget)/MSIX(Store) の arm64 両方が影響（既存リリース含む）。

## 修正
- arm64/x64 ビルドに **`-p:EffectivePlatform=$plat` をグローバルプロパティで明示**（グローバル指定は targets の代入に勝つ）。`Release.ps1`（MSIX/ZIP）と `.github/workflows/release.yml` に適用。
- `XTimelineViewer.csproj` の `PlatformTarget` を Platform 追従に変更（ハードコードの x64 を廃止）。
- バージョンは据え置き（リリースは別 PR）。

## 検証
- クリーンビルドした arm64 publish / MSIX で `Microsoft.Web.WebView2.Core.dll`・`WebView2Loader.dll`・本体 exe がすべて **arm64**（PE ヘッダー確認、x64 混入ゼロ）。
- **arm64 実機で ZIP 版の起動・WebView2 表示を確認済み**。
- x64 ビルドは従来どおり x64。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
