### PR TITLE
リリース v1.9.0

### DIFF
--- a/Package.appxmanifest
+++ b/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="4275.XTimelineViewer"
     Publisher="CN=B73FDB0C-06E5-4824-9E7F-3AF969921DF4"
-    Version="1.8.1.0"
+    Version="1.9.0.0"
     ProcessorArchitecture="neutral" />
 
   <Properties>

--- a/XTimelineViewer.csproj
+++ b/XTimelineViewer.csproj
@@ -15,7 +15,7 @@
     -->
     <PlatformTarget Condition="'$(Platform)' == 'arm64'">arm64</PlatformTarget>
     <PlatformTarget Condition="'$(PlatformTarget)' == ''">x64</PlatformTarget>
-    <Version>1.8.1</Version>
+    <Version>1.9.0</Version>
     <ApplicationIcon>Assets\AppIcon.ico</ApplicationIcon>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
## リリース v1.9.0（マイナー）

csproj `<Version>` と Package.appxmanifest を 1.9.0 に更新。

### このリリースの主な変更
- **arm64 で WebView2 が BadImageFormat になる不具合を修正**（#267 / #268）。arm64 端末（Surface Pro 11 等）で起動できなかった問題を解消。arm64 実機で確認済み。
- **コマンドライン起動 `xtv` を追加**（後方互換で `xtimelineviewer` も併設）。ZIP/winget 向け C++ ランチャー `xtv.exe` を同梱（#264 / #265）、Store は appExecutionAlias（#262）。

### リリース手順
1. マージ後に `v1.9.0` タグを push → CI が ZIP（arm64 修正済み・`xtv.exe` 同梱）/GitHub リリース/winget を自動公開
2. winget 公開 PR の `NestedInstallerFiles` を `xtv.exe` 指定に更新 → #264 クローズ
3. Microsoft Store に `publish/release/XTimelineViewer-1.9.0.msixbundle`（arm64 修正済み・x64+arm64）をアップロード

🤖 Generated with [Claude Code](https://claude.com/claude-code)
