### PR TITLE
refactor(#271): 非推奨の AutoActivate 機能を完全削除

### DIFF
--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -7,13 +7,11 @@ namespace XTimelineViewer.Models
         public bool    OpenComposerInBrowser { get; set; } = false;
         public bool    OpenTimestampInBrowser{ get; set; } = false;
         public string  Theme                 { get; set; } = "Default"; // "Light" | "Dark" | "Default"
-        public int     AutoActivateMinutes   { get; set; } = 0;
         public string  Language              { get; set; } = "system";  // "system" | "ja-JP" | "en-US"
         public string? CachedLatestVersion   { get; set; } = null;      // "v1.4.0" など
         public bool    DefaultHideSidebar   { get; set; } = false;     // 新規タイムラインの既定値
         public bool    DefaultHideCompose   { get; set; } = true;      // 新規タイムラインの既定値
         public bool    DefaultHideListHeader{ get; set; } = false;     // 新規タイムラインの既定値
-        public bool    ShowAutoActivateLabel { get; set; } = false;
         public string  ExternalBrowser       { get; set; } = "system";  // "system" | "edge"
         public string  EdgeProfileDirectory  { get; set; } = "";        // "Default" | "Profile 1" など
         public string? LastUsedProfileId     { get; set; } = null;      // 投稿画面で最後に使ったプロファイル

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -53,9 +53,6 @@
   <data name="Settings_OpenComposerInBrowser_Description" xml:space="preserve"><value>Open new posts in an external browser instead of the built-in composer</value></data>
   <data name="Settings_OpenTimestampInBrowser" xml:space="preserve"><value>Open Timestamp Links in External Browser</value></data>
   <data name="Settings_OpenTimestampInBrowser_Description" xml:space="preserve"><value>Open timestamp links in an external browser instead of navigating in the timeline</value></data>
-  <data name="Settings_AutoActivate" xml:space="preserve"><value>Auto-activate Home Timeline (min, 0 to disable)</value></data>
-  <data name="Settings_AutoActivate_Description" xml:space="preserve"><value>Periodically bring the Home timeline to the foreground</value></data>
-  <data name="Settings_Deprecated_Note" xml:space="preserve"><value>⚠ Deprecated: will be removed in a future version (use Home timeline auto-refresh instead).</value></data>
   <data name="Settings_HomeAutoLoad" xml:space="preserve"><value>Auto-refresh Home timeline</value></data>
   <data name="Settings_HomeAutoLoad_Description" xml:space="preserve"><value>When on, new posts are loaded automatically at regular intervals while you are at the top of Home. Loading is skipped while you are composing a reply/quote or searching. This is separate from Auto-Reload, which reloads the whole page.</value></data>
   <data name="Settings_HomeAutoLoad_Interval" xml:space="preserve"><value>Refresh interval (sec)</value></data>
@@ -67,7 +64,6 @@
   <data name="AutoLoad_Paused_Away" xml:space="preserve"><value>Home auto-refresh: Paused (not on Home)</value></data>
   <data name="AutoLoad_Paused_Elsewhere" xml:space="preserve"><value>Home auto-refresh: Paused (editing in another timeline)</value></data>
   <data name="AutoLoad_Off" xml:space="preserve"><value>Home auto-refresh: Off</value></data>
-  <data name="Settings_ShowAutoActivateLabel_Description" xml:space="preserve"><value>Show the auto-activate countdown timer in the toolbar</value></data>
   <data name="Settings_ExternalBrowser_Description" xml:space="preserve"><value>Choose which browser to use for opening external links</value></data>
   <data name="Settings_EdgeProfile_Description" xml:space="preserve"><value>Select the Edge profile to use when opening links</value></data>
 
@@ -98,12 +94,6 @@
   <data name="HardReload_Paused" xml:space="preserve"><value>⏸ Auto-Reload Paused</value></data>
   <data name="HardReload_Paused_Nav" xml:space="preserve"><value>⏸ Browsing — Auto-Reload Paused</value></data>
   <data name="HardReload_Disabled" xml:space="preserve"><value>⏹ Auto-Reload Off</value></data>
-  <data name="AutoActivate_Active" xml:space="preserve"><value>🏠 On: ⏱ {0}:{1} remaining</value></data>
-  <data name="AutoActivate_Paused" xml:space="preserve"><value>⏸ Paused</value></data>
-  <data name="AutoActivate_Paused_Nav" xml:space="preserve"><value>⏸ Browsing (paused)</value></data>
-  <data name="AutoActivate_Disabled" xml:space="preserve"><value>⏹ Auto-Activate Off</value></data>
-  <data name="AutoActivateLabel_Format" xml:space="preserve"><value>Home Timeline Auto-Activate: {0}</value></data>
-  <data name="Settings_ShowAutoActivateLabel" xml:space="preserve"><value>Show auto-activate status in toolbar</value></data>
 
   <!-- External browser settings -->
   <data name="Section_ExternalBrowser" xml:space="preserve"><value>External Browser</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -53,9 +53,6 @@
   <data name="Settings_OpenComposerInBrowser_Description" xml:space="preserve"><value>内蔵のコンポーザーの代わりに外部ブラウザーで新規投稿を開きます</value></data>
   <data name="Settings_OpenTimestampInBrowser" xml:space="preserve"><value>タイムスタンプリンクを外部ブラウザーで開く</value></data>
   <data name="Settings_OpenTimestampInBrowser_Description" xml:space="preserve"><value>タイムライン内で移動せず、外部ブラウザーでタイムスタンプリンクを開きます</value></data>
-  <data name="Settings_AutoActivate" xml:space="preserve"><value>ホームタイムラインを定期的にアクティブ化（分、0 で無効）</value></data>
-  <data name="Settings_AutoActivate_Description" xml:space="preserve"><value>定期的にホームタイムラインを前面に表示します</value></data>
-  <data name="Settings_Deprecated_Note" xml:space="preserve"><value>⚠ 非推奨: 次期バージョンで削除予定です（ホームタイムラインの自動更新をご利用ください）。</value></data>
   <data name="Settings_HomeAutoLoad" xml:space="preserve"><value>ホームタイムラインの自動更新</value></data>
   <data name="Settings_HomeAutoLoad_Description" xml:space="preserve"><value>オンにすると、ホームの先頭にいるとき新着ポストを定期的に自動で読み込みます。リプライや引用の入力中・検索中は読み込みを控えます。ページ全体を再読み込みする「定期ハードリロード」とは別の機能です。</value></data>
   <data name="Settings_HomeAutoLoad_Interval" xml:space="preserve"><value>更新間隔（秒）</value></data>
@@ -67,7 +64,6 @@
   <data name="AutoLoad_Paused_Away" xml:space="preserve"><value>ホーム自動更新: 一時停止中（ホーム以外を表示中）</value></data>
   <data name="AutoLoad_Paused_Elsewhere" xml:space="preserve"><value>ホーム自動更新: 一時停止中（他のタイムラインで編集中）</value></data>
   <data name="AutoLoad_Off" xml:space="preserve"><value>ホーム自動更新: オフ</value></data>
-  <data name="Settings_ShowAutoActivateLabel_Description" xml:space="preserve"><value>ツールバーに自動アクティブ化のカウントダウンタイマーを表示します</value></data>
   <data name="Settings_ExternalBrowser_Description" xml:space="preserve"><value>外部リンクを開くブラウザーを選択します</value></data>
   <data name="Settings_EdgeProfile_Description" xml:space="preserve"><value>リンクを開く際に使用する Edge プロファイルを選択します</value></data>
 
@@ -98,12 +94,6 @@
   <data name="HardReload_Paused" xml:space="preserve"><value>⏸ 定期ハードリロード一時停止中</value></data>
   <data name="HardReload_Paused_Nav" xml:space="preserve"><value>⏸ ページ閲覧中（定期ハードリロード停止）</value></data>
   <data name="HardReload_Disabled" xml:space="preserve"><value>⏹ 定期ハードリロード無効</value></data>
-  <data name="AutoActivate_Active" xml:space="preserve"><value>🏠 有効: ⏱ 残り {0}:{1}</value></data>
-  <data name="AutoActivate_Paused" xml:space="preserve"><value>⏸ 一時停止中</value></data>
-  <data name="AutoActivate_Paused_Nav" xml:space="preserve"><value>⏸ ページ閲覧中（停止）</value></data>
-  <data name="AutoActivate_Disabled" xml:space="preserve"><value>⏹ 自動アクティブ化 無効</value></data>
-  <data name="AutoActivateLabel_Format" xml:space="preserve"><value>ホームタイムラインの自動アクティブ化: {0}</value></data>
-  <data name="Settings_ShowAutoActivateLabel" xml:space="preserve"><value>ツールバーに自動アクティブ化の状態を表示する</value></data>
 
   <!-- External browser settings -->
   <data name="Section_ExternalBrowser" xml:space="preserve"><value>外部ブラウザー</value></data>

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -127,20 +127,6 @@ namespace XTimelineViewer.ViewModels
             }
         }
 
-        /// <summary>NumberBox.Value（double）にバインドする。NaN（空欄）は無視し、0–60 に丸める。</summary>
-        public double AutoActivateMinutes
-        {
-            get => _settings.AutoActivateMinutes;
-            set
-            {
-                if (double.IsNaN(value)) return;
-                var minutes = (int)Math.Clamp(value, 0, 60);
-                if (_settings.AutoActivateMinutes == minutes) return;
-                _settings.AutoActivateMinutes = minutes;
-                Notify(nameof(AutoActivateMinutes));
-            }
-        }
-
         /// <summary>ホーム自動更新（#207）の ON/OFF。</summary>
         public bool HomeAutoLoadEnabled
         {
@@ -176,17 +162,6 @@ namespace XTimelineViewer.ViewModels
                 if (_settings.ComposePreloadEnabled == value) return;
                 _settings.ComposePreloadEnabled = value;
                 Notify(nameof(ComposePreloadEnabled));
-            }
-        }
-
-        public bool ShowAutoActivateLabel
-        {
-            get => _settings.ShowAutoActivateLabel;
-            set
-            {
-                if (_settings.ShowAutoActivateLabel == value) return;
-                _settings.ShowAutoActivateLabel = value;
-                Notify(nameof(ShowAutoActivateLabel));
             }
         }
 

--- a/Views/MainWindow.HardReload.cs
+++ b/Views/MainWindow.HardReload.cs
@@ -26,54 +26,6 @@ namespace XTimelineViewer.Views
 {
     public sealed partial class MainWindow : Window
     {
-        private void RestartAutoActivateTimer()
-        {
-            if (_autoActivateTimer is null) return;
-            _autoActivateTimer.Stop();
-            _autoActivateStartTime = DateTimeOffset.Now;
-            _autoActivateTimer.Start();
-        }
-
-        // #222 非推奨: 定期アクティブ化はホーム自動更新（#207）で役目を終えたため無効化。
-        // v2.0 でタイマー関連コードごと削除予定。それまでは保存値があっても発火させない。
-        private static readonly bool AutoActivateEnabled = false;
-
-        private void ApplyAutoActivateTimer()
-        {
-            _autoActivateTimer?.Stop();
-            if (!AutoActivateEnabled) return;  // #222 非推奨
-            if (_appSettings.AutoActivateMinutes <= 0) return;
-
-            _autoActivateTimer = new DispatcherTimer
-            {
-                Interval = TimeSpan.FromMinutes(_appSettings.AutoActivateMinutes)
-            };
-            _autoActivateStartTime = DateTimeOffset.Now;
-            _autoActivateTimer.Tick += (_, _) =>
-            {
-                _autoActivateStartTime = DateTimeOffset.Now;
-                if (_pointerOverWebViews.Count > 0)                 return;  // ① ポインターオーバー中
-                if (_dialogOpenCount > 0)                           return;  // ② ダイアログ表示中
-                if (_focusedHeaderGrid is not null && _homeHeaderGrids.Contains(_focusedHeaderGrid))  return;  // ④ ホームにフォーカス中
-
-                foreach (var wv in _webViews)
-                {
-                    if (wv.CoreWebView2 is null) continue;
-                    if (!Uri.TryCreate(wv.CoreWebView2.Source, UriKind.Absolute, out var src)) continue;
-                    if (!src.AbsolutePath.StartsWith("/home", StringComparison.OrdinalIgnoreCase)) continue;
-                    if (_urlDivergedWebViews.Contains(wv)) continue;  // ③ 別ページ閲覧中
-
-                    if (_webViewToPane.TryGetValue(wv, out var pane) &&
-                        _paneToSetFocus.TryGetValue(pane, out var setFocus))
-                    {
-                        setFocus();
-                        break;
-                    }
-                }
-            };
-            _autoActivateTimer.Start();
-        }
-
         private void StartHardReloadTimer(WebView2 wv, TimelineConfig cfg)
         {
             StopHardReloadTimer(wv);
@@ -134,20 +86,6 @@ namespace XTimelineViewer.Views
             }
         }
 
-        private string GetAutoActivateTooltipText(WebView2 wv)
-        {
-            if (_autoActivateTimer is null)
-                return R.Get("AutoActivate_Disabled");
-            if (_pointerOverWebViews.Count > 0 || _dialogOpenCount > 0)
-                return R.Get("AutoActivate_Paused");
-            if (_urlDivergedWebViews.Contains(wv))
-                return R.Get("AutoActivate_Paused_Nav");
-            var remaining = _autoActivateTimer.Interval - (DateTimeOffset.Now - _autoActivateStartTime);
-            return remaining > TimeSpan.Zero
-                ? string.Format(R.Get("AutoActivate_Active"), (int)remaining.TotalMinutes, remaining.Seconds.ToString("D2"))
-                : string.Empty;
-        }
-
         private string GetHardReloadTooltipText(WebView2 wv)
         {
             if (!_hardReloadTimers.TryGetValue(wv, out var t))
@@ -170,36 +108,6 @@ namespace XTimelineViewer.Views
             tooltip.Content = GetHardReloadTooltipText(wv) is { Length: > 0 } text ? text : null;
         }
 
-        private void UpdateAutoActivateLabel()
-        {
-            if (!AutoActivateEnabled || !_appSettings.ShowAutoActivateLabel)  // #222 非推奨: ラベルを常に非表示
-            {
-                AutoActivateLabel.Visibility = Visibility.Collapsed;
-                return;
-            }
-
-            var homeWv = _webViews.FirstOrDefault(wv =>
-                wv.CoreWebView2 is not null &&
-                Uri.TryCreate(wv.CoreWebView2.Source, UriKind.Absolute, out var u) &&
-                u.AbsolutePath.StartsWith("/home", StringComparison.OrdinalIgnoreCase));
-
-            if (homeWv is null)
-            {
-                AutoActivateLabel.Visibility = Visibility.Collapsed;
-                return;
-            }
-
-            var state = GetAutoActivateTooltipText(homeWv);
-            if (string.IsNullOrEmpty(state))
-            {
-                AutoActivateLabel.Visibility = Visibility.Collapsed;
-                return;
-            }
-
-            AutoActivateLabel.Text       = string.Format(R.Get("AutoActivateLabel_Format"), state);
-            AutoActivateLabel.Visibility = Visibility.Visible;
-        }
-
         private void EnsureHardReloadUiTimer()
         {
             if (_hardReloadUiTimer is not null) return;
@@ -207,7 +115,6 @@ namespace XTimelineViewer.Views
             _hardReloadUiTimer.Tick += (_, _) =>
             {
                 foreach (var (wv, update) in _hardReloadUiUpdaters) update();
-                UpdateAutoActivateLabel();
             };
             _hardReloadUiTimer.Start();
         }

--- a/Views/MainWindow.Profiles.cs
+++ b/Views/MainWindow.Profiles.cs
@@ -50,7 +50,6 @@ namespace XTimelineViewer.Views
                 var headerGrid = pane.Children.OfType<Grid>().FirstOrDefault();
                 if (headerGrid != null)
                 {
-                    _homeHeaderGrids.Remove(headerGrid);
                     if (_focusedHeaderGrid == headerGrid)
                         _focusedHeaderGrid = null;
                 }

--- a/Views/MainWindow.Settings.cs
+++ b/Views/MainWindow.Settings.cs
@@ -126,7 +126,6 @@ namespace XTimelineViewer.Views
                 SaveSettings();
                 ApplySavedTheme();
                 UpdateThemeRadioState();
-                ApplyAutoActivateTimer();
                 _ = WarmUpComposeAsync();  // 投稿プリロードの ON/OFF を即時反映（#244 案B）
 
                 // WebView のタイムスタンプ設定を即時反映

--- a/Views/MainWindow.Timeline.cs
+++ b/Views/MainWindow.Timeline.cs
@@ -404,8 +404,6 @@ namespace XTimelineViewer.Views
                 AutomationProperties.SetName(webView, urlLabel.Text);
                 bool nowHome = Uri.TryCreate(cfg.Url, UriKind.Absolute, out var hu)
                             && hu.AbsolutePath.StartsWith("/home", StringComparison.OrdinalIgnoreCase);
-                if (nowHome) _homeHeaderGrids.Add(headerGrid);
-                else         _homeHeaderGrids.Remove(headerGrid);
                 autoLoadIcon.Visibility = nowHome ? Visibility.Visible : Visibility.Collapsed;
             };
 
@@ -416,8 +414,6 @@ namespace XTimelineViewer.Views
 
             void SetFocus()
             {
-                if (_focusedHeaderGrid is not null && _homeHeaderGrids.Contains(_focusedHeaderGrid) && !_homeHeaderGrids.Contains(headerGrid))
-                    RestartAutoActivateTimer();  // ホームから別タイムラインへ
                 _focusedHeaderGrid = headerGrid;
                 foreach (var r in _headerRefreshers) r();
                 webView.Focus(FocusState.Programmatic);
@@ -432,8 +428,6 @@ namespace XTimelineViewer.Views
             };
             webView.GotFocus   += (s, e) =>
             {
-                if (_focusedHeaderGrid is not null && _homeHeaderGrids.Contains(_focusedHeaderGrid) && !_homeHeaderGrids.Contains(headerGrid))
-                    RestartAutoActivateTimer();  // ホームから別タイムラインへ
                 _focusedHeaderGrid = headerGrid;
                 foreach (var r in _headerRefreshers) r();
             };
@@ -442,12 +436,7 @@ namespace XTimelineViewer.Views
             {
                 _pointerOverWebViews.Remove(webView);
                 EvaluateHardReloadPause(webView);
-                if (_pointerOverWebViews.Count == 0) RestartAutoActivateTimer();
             };
-
-            bool isHomeTimeline = Uri.TryCreate(cfg.Url, UriKind.Absolute, out var cfgUri)
-                               && cfgUri.AbsolutePath.StartsWith("/home", StringComparison.OrdinalIgnoreCase);
-            if (isHomeTimeline) _homeHeaderGrids.Add(headerGrid);
 
             _hardReloadUiUpdaters[webView] = () => UpdateHardReloadTooltip(webView, hardReloadTooltip);
             EnsureHardReloadUiTimer();

--- a/Views/MainWindow.WebView2.cs
+++ b/Views/MainWindow.WebView2.cs
@@ -525,9 +525,6 @@ namespace XTimelineViewer.Views
                     else
                     {
                         _urlDivergedWebViews.Remove(webView);
-                        if (Uri.TryCreate(cfg.Url, UriKind.Absolute, out var cfgU) &&
-                            cfgU.AbsolutePath.StartsWith("/home", StringComparison.OrdinalIgnoreCase))
-                            RestartAutoActivateTimer();
                     }
                     EvaluateHardReloadPause(webView);
                 };

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -78,11 +78,6 @@
                         Spacing="4"
                         HorizontalAlignment="Right"
                         VerticalAlignment="Center">
-                <TextBlock x:Name="AutoActivateLabel"
-                           FontSize="11"
-                           VerticalAlignment="Center"
-                           Opacity="0.8"
-                           Visibility="Collapsed"/>
                 <Grid>
                 <Button x:Name="AppMenuBtn" Width="32" Height="32" Padding="0" FontSize="14">
                     <FontIcon Glyph="&#xE700;" FontFamily="Segoe Fluent Icons" FontSize="14"/>

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -110,10 +110,6 @@ namespace XTimelineViewer.Views
         private readonly HashSet<WebView2>                       _pointerOverWebViews  = [];
         private readonly HashSet<WebView2>                       _urlDivergedWebViews  = [];
         private DispatcherTimer?  _hardReloadUiTimer;
-        private DispatcherTimer?  _autoActivateTimer;
-        private int               _dialogOpenCount      = 0;
-        private DateTimeOffset    _autoActivateStartTime;
-        private readonly HashSet<Grid> _homeHeaderGrids = [];
 
         // ホーム自動更新（#207）のヘッダーインジケーター（ペイン → アイコン/ツールチップ）
         private readonly Dictionary<Grid, (FontIcon Icon, ToolTip Tip)> _autoLoadIndicators = [];
@@ -259,7 +255,6 @@ namespace XTimelineViewer.Views
             Closed += async (s, e) =>
             {
                 _hardReloadUiTimer?.Stop();
-                _autoActivateTimer?.Stop();
                 DisposeComposeWarm();  // 投稿プリロードの後始末（#244 案B）
                 foreach (var wv in _webViews.ToList())
                     CleanupWebView(wv);
@@ -270,7 +265,6 @@ namespace XTimelineViewer.Views
             LoadProfiles();
             CleanupOrphanedProfiles();
             ApplySavedTheme();
-            ApplyAutoActivateTimer();
             UpdateMenuUpdateBadge();
             _ = InitializeAsync();
             _ = CheckForUpdatesInBackgroundAsync();
@@ -316,14 +310,7 @@ namespace XTimelineViewer.Views
         {
             // すべてのダイアログに現在のテーマを自動適用して設定漏れを防ぐ (#126)
             dlg.RequestedTheme = ((FrameworkElement)Content).ActualTheme;
-
-            _dialogOpenCount++;
-            try   { return await dlg.ShowAsync(); }
-            finally
-            {
-                _dialogOpenCount--;
-                if (_dialogOpenCount == 0) RestartAutoActivateTimer();
-            }
+            return await dlg.ShowAsync();
         }
 
         /// <summary>

--- a/Views/Settings/ExperimentalPage.xaml
+++ b/Views/Settings/ExperimentalPage.xaml
@@ -25,28 +25,6 @@
                 <ToggleSwitch x:Name="ComposePreloadToggle"
                               IsOn="{x:Bind VM.ComposePreloadEnabled, Mode=TwoWay}"/>
             </controls:SettingsCard>
-
-            <!-- Auto-Activate Home Timeline -->
-            <controls:SettingsCard x:Name="AutoActivateCard">
-                <controls:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE787;" FontFamily="Segoe Fluent Icons"/>
-                </controls:SettingsCard.HeaderIcon>
-                <NumberBox x:Name="AutoActivateBox"
-                           Minimum="0" Maximum="60"
-                           SmallChange="1" LargeChange="5"
-                           SpinButtonPlacementMode="Inline"
-                           Width="160"
-                           Value="{x:Bind VM.AutoActivateMinutes, Mode=TwoWay}"/>
-            </controls:SettingsCard>
-
-            <!-- Show Auto-Activate Status in Toolbar -->
-            <controls:SettingsCard x:Name="ShowAutoActivateLabelCard">
-                <controls:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE7B3;" FontFamily="Segoe Fluent Icons"/>
-                </controls:SettingsCard.HeaderIcon>
-                <ToggleSwitch x:Name="ShowAutoActivateLabelToggle"
-                              IsOn="{x:Bind VM.ShowAutoActivateLabel, Mode=TwoWay}"/>
-            </controls:SettingsCard>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/Views/Settings/ExperimentalPage.xaml.cs
+++ b/Views/Settings/ExperimentalPage.xaml.cs
@@ -51,17 +51,6 @@ namespace XTimelineViewer.Views.Settings
             ComposePreloadToggle.OnContent  = R.Get("Toggle_On");
             ComposePreloadToggle.OffContent = R.Get("Toggle_Off");
 
-            // #222 非推奨: 定期アクティブ化と関連オプションを無効化＋グレーアウト（v2.0 で削除予定）
-            AutoActivateCard.Header      = R.Get("Settings_AutoActivate");
-            AutoActivateCard.Description = R.Get("Settings_AutoActivate_Description") + "\n" + R.Get("Settings_Deprecated_Note");
-            AutoActivateCard.IsEnabled   = false;
-
-            ShowAutoActivateLabelCard.Header      = R.Get("Settings_ShowAutoActivateLabel");
-            ShowAutoActivateLabelCard.Description = R.Get("Settings_ShowAutoActivateLabel_Description") + "\n" + R.Get("Settings_Deprecated_Note");
-            ShowAutoActivateLabelToggle.OnContent  = R.Get("Toggle_On");
-            ShowAutoActivateLabelToggle.OffContent = R.Get("Toggle_Off");
-            ShowAutoActivateLabelCard.IsEnabled   = false;
-
             // ItemsSource 再設定で SelectedIndex が失われるため、バインディングを再評価する
             Bindings.Update();
         }

--- a/XTimelineViewer.Tests/Services/SettingsServiceTests.cs
+++ b/XTimelineViewer.Tests/Services/SettingsServiceTests.cs
@@ -32,12 +32,11 @@ public class SettingsServiceTests : IDisposable
     public void LoadSettings_ValidJson_ReturnsCorrectValues()
     {
         File.WriteAllText(At("settings.json"),
-            """{"Theme":"Dark","Language":"ja-JP","AutoActivateMinutes":5}""");
+            """{"Theme":"Dark","Language":"ja-JP"}""");
 
         var s = SettingsService.LoadSettings(At("settings.json"));
         Assert.Equal("Dark",  s.Theme);
         Assert.Equal("ja-JP", s.Language);
-        Assert.Equal(5,       s.AutoActivateMinutes);
     }
 
     [Fact]
@@ -68,7 +67,7 @@ public class SettingsServiceTests : IDisposable
         var path = At("settings.json");
         var original = new AppSettings
         {
-            Theme = "Light", Language = "en-US", AutoActivateMinutes = 10
+            Theme = "Light", Language = "en-US"
         };
 
         SettingsService.SaveSettings(path, original);
@@ -76,7 +75,6 @@ public class SettingsServiceTests : IDisposable
 
         Assert.Equal("Light",  loaded.Theme);
         Assert.Equal("en-US",  loaded.Language);
-        Assert.Equal(10,       loaded.AutoActivateMinutes);
     }
 
     // ── 後方互換 ──────────────────────────────────────────────────────────────
@@ -122,13 +120,11 @@ public class SettingsServiceTests : IDisposable
             OpenComposerInBrowser  = true,
             OpenTimestampInBrowser = true,
             Theme                  = "Dark",
-            AutoActivateMinutes    = 15,
             Language               = "en-US",
             CachedLatestVersion    = "v9.9.9",
             DefaultHideSidebar     = true,
             DefaultHideCompose     = false,
             DefaultHideListHeader  = true,
-            ShowAutoActivateLabel  = true,
             ExternalBrowser        = "edge",
             EdgeProfileDirectory   = "Profile 1",
             LastUsedProfileId      = "abc123",
@@ -141,13 +137,11 @@ public class SettingsServiceTests : IDisposable
         Assert.True(loaded.OpenComposerInBrowser);
         Assert.True(loaded.OpenTimestampInBrowser);
         Assert.Equal("Dark",      loaded.Theme);
-        Assert.Equal(15,          loaded.AutoActivateMinutes);
         Assert.Equal("en-US",     loaded.Language);
         Assert.Equal("v9.9.9",    loaded.CachedLatestVersion);
         Assert.True(loaded.DefaultHideSidebar);
         Assert.False(loaded.DefaultHideCompose);
         Assert.True(loaded.DefaultHideListHeader);
-        Assert.True(loaded.ShowAutoActivateLabel);
         Assert.Equal("edge",      loaded.ExternalBrowser);
         Assert.Equal("Profile 1", loaded.EdgeProfileDirectory);
         Assert.Equal("abc123",    loaded.LastUsedProfileId);

--- a/XTimelineViewer.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/XTimelineViewer.Tests/ViewModels/SettingsViewModelTests.cs
@@ -135,34 +135,6 @@ public class SettingsViewModelTests
         Assert.True(s.DefaultHideListHeader);
     }
 
-    // ── 試験機能 ──────────────────────────────────────────────────────────────
-
-    [Fact]
-    public void AutoActivateMinutes_ClampsToRange()
-    {
-        var s = new AppSettings();
-        var vm = new SettingsViewModel(s);
-
-        vm.AutoActivateMinutes = 999;
-        Assert.Equal(60, s.AutoActivateMinutes);
-
-        vm.AutoActivateMinutes = -5;
-        Assert.Equal(0, s.AutoActivateMinutes);
-    }
-
-    [Fact]
-    public void AutoActivateMinutes_NaN_Ignored()
-    {
-        var s = new AppSettings { AutoActivateMinutes = 10 };
-        var notified = 0;
-        var vm = new SettingsViewModel(s, () => notified++);
-
-        vm.AutoActivateMinutes = double.NaN;
-
-        Assert.Equal(10, s.AutoActivateMinutes);
-        Assert.Equal(0, notified);
-    }
-
     [Theory]
     [InlineData("system", 0, false)]
     [InlineData("edge",   1, true)]
@@ -198,11 +170,9 @@ public class SettingsViewModelTests
 
         vm.OpenComposerInBrowser  = true;
         vm.OpenTimestampInBrowser = true;
-        vm.ShowAutoActivateLabel  = true;
 
         Assert.True(s.OpenComposerInBrowser);
         Assert.True(s.OpenTimestampInBrowser);
-        Assert.True(s.ShowAutoActivateLabel);
     }
 
     [Fact]


### PR DESCRIPTION
## 概要
非推奨の**定期アクティブ化（AutoActivate）機能**を完全削除します。#207 のホームタイムライン自動更新で役目を終え、#222 で `AutoActivateEnabled = false` に固定されていた死んだコード一式です。ref #271

**エンバグ防止**: ホーム自動更新（#207）・定期ハードリロード（#49、ヘッダーダブルクリック）には一切影響しません。連鎖的に未使用化したフィールドまで追跡して除去しました。

## 削除内容
- **MainWindow.HardReload.cs**: `ApplyAutoActivateTimer` / `RestartAutoActivateTimer` / `GetAutoActivateTooltipText` / `UpdateAutoActivateLabel` / `AutoActivateEnabled`
- **呼び出し側**: Settings.cs / Timeline.cs(SetFocus/GotFocus/PointerExited) / WebView2.cs / xaml.cs の Restart/Apply 呼び出し
- **連鎖デッドコード**: `_autoActivateTimer` / `_autoActivateStartTime` / `_dialogOpenCount`（`ShowDialogAsync` を簡素化）/ `_homeHeaderGrids`（Timeline・Profiles の Add/Remove も）
- **AppSettings**: `AutoActivateMinutes` / `ShowAutoActivateLabel`（旧 settings.json に残っても読み込み時に無視されるだけ）
- **SettingsViewModel**: 対応バインディング 2 件
- **ExperimentalPage(.xaml/.cs)**: 非推奨カード 2 件＋`Settings_Deprecated_Note` 注記（→ 試験機能ページは Caution + 投稿プリロードのみに）
- **MainWindow.xaml**: 未使用 `AutoActivateLabel`
- **resw(en/ja)**: 未使用キー 10 件ずつ
- **テスト**: AutoActivate 参照を除去

## 検証
- ✅ ビルド 0 エラー / 0 警告
- ✅ テスト **123/123 合格**
- ✅ 起動スモーク（クラッシュなし）
- ✅ `AutoActivate` 等の残存参照ゼロ（grep 確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
