### PR TITLE
chore(#272): Release.ps1・release スキルから Store 手順を削除

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,18 +1,21 @@
 ---
 name: release
-description: XTimelineViewer のリリース手順。バージョンを上げて GitHub リリース（CI）と、マイナー以上は Microsoft Store 申請まで行う。ユーザーが「リリースしよう」「パッチ/マイナーリリース」「バージョンを上げて公開」等と言ったときに使う。
+description: XTimelineViewer のリリース手順。バージョンを上げて GitHub リリース（ZIP）と winget を CI 経由で公開する。ユーザーが「リリースしよう」「パッチ/マイナーリリース」「バージョンを上げて公開」等と言ったときに使う。
 ---
 
 # XTimelineViewer リリース手順
 
 ## 役割分担（重要）
 - **GitHub リリース（ZIP）と winget 公開は CI が自動**で行う（`.github/workflows/release.yml`、`v*` タグ push がトリガー）。手動で ZIP をビルド・添付しない。
-- **`Release.ps1`（リポジトリ直下）は Store 用 `.msixbundle` とバージョン更新を担当**。
+- **`Release.ps1`（リポジトリ直下）はバージョン更新**（`XTimelineViewer.csproj` / `Package.appxmanifest`）を担当。任意で `-WithZip` によりローカル検証用 ZIP も生成できる。
 - **PR のマージはユーザーが行う**。エージェントは self-merge しない。
+- **Microsoft Store 配布は廃止した（#272）**。Store 申請ステップは行わない。
 
-## バージョン種別の判断
-- **パッチ (x.y.Z+1)**: バグ修正のみ。Store 申請は**不要**。
-- **マイナー (x.Y+1.0) 以上**: 新機能あり。Store 申請が**必須**。
+## バージョン種別
+- **パッチ (x.y.Z+1)**: バグ修正のみ。
+- **マイナー (x.Y+1.0) 以上**: 新機能あり。
+
+いずれも配布経路は同じ（GitHub ZIP + winget）。種別はリリースノートの粒度の目安として使う。
 
 ## 手順
 
@@ -22,18 +25,14 @@ git checkout main && git pull
 git checkout -b chore/release-vX.Y.Z
 ```
 
-### 2. バージョン更新（+ パッチは Store ビルドを省略）
+### 2. バージョン更新
 ```powershell
-# パッチ（Store 不要）: バージョンだけ更新
-.\Release.ps1 -Version X.Y.Z -SkipBundle
-
-# マイナー以上（Store 用 .msixbundle も生成）
 .\Release.ps1 -Version X.Y.Z
 ```
 `Release.ps1` が `XTimelineViewer.csproj` の `<Version>` と `Package.appxmanifest` の Identity `Version="X.Y.Z.0"` を更新する。更新後、両ファイルが正しいか確認する（XML 宣言や MinVersion を壊していないこと）。
 
 ### 3. コミット → PR → マージ
-バージョン更新分をコミットし PR を作成。`gh pr view <n>..HEAD` 等で v1.x.0 以降のコミットを拾い、リリースノートの材料にする。**ユーザーがマージするのを待つ**。
+バージョン更新分をコミットし PR を作成。前回リリース以降のコミットを拾い、リリースノートの材料にする。**ユーザーがマージするのを待つ**。
 
 ### 4. タグ push（マージ後）
 ```
@@ -43,13 +42,6 @@ git push origin vX.Y.Z
 ```
 これで CI が ZIP ビルド → GitHub リリース作成（generate-notes）→ winget 公開を自動実行する。`gh run watch <id>` で完了を確認し、`gh release view vX.Y.Z` で公開を確認する。
 
-### 5. （マイナー以上のみ）Microsoft Store 申請
-- `Release.ps1`（手順2でフル実行）が `publish\release\XTimelineViewer-X.Y.Z.msixbundle` を生成済み（未署名・そのままアップロード可、x64+arm64 内包）。
-- パートナーセンターにアップロード:
-  - アプリ ID `9P308HB5BLJ1`
-  - URL `https://partner.microsoft.com/dashboard/products/9P308HB5BLJ1/overview`
-- Store のリリースノートは、前回 Store 申請バージョン以降の**ユーザー向け**変更を ja / en で用意する（内部リファクタリングは 1 行に集約してよい）。
-
 ## 注意
 - バージョンは csproj（3桁）と appxmanifest（4桁 `X.Y.Z.0`）で食い違わせない。過去 v1.3.1 で更新漏れによりタグを打ち直した。
-- パッチで誤って Store にフルビルドする必要はない（`-SkipBundle`）。
+- arm64 の ZIP に x64 の WebView2 が混入すると arm64 端末で `BadImageFormatException` になる。`Release.ps1` / CI は `-p:EffectivePlatform=<arch>` を指定済み（#267）。手を入れる場合は崩さないこと。

--- a/Release.ps1
+++ b/Release.ps1
@@ -1,50 +1,37 @@
 <#
 .SYNOPSIS
-    XTimelineViewer の Microsoft Store 用リリース成果物を生成する（#216）。
+    XTimelineViewer のリリース用にバージョンを更新する（+ 任意でローカル検証用 ZIP を生成）。
 
 .DESCRIPTION
-    役割分担:
-      - GitHub 配布（ZIP）と winget 公開は CI（.github/workflows/release.yml）が
-        v* タグの push をトリガーに自動で行う。本スクリプトでは扱わない。
-      - 本スクリプトは CI が扱わない Microsoft Store 用の成果物を担当する。
-
-    手作業フローで発生したミス（arm64 の RuntimeIdentifier 明示漏れ、
-    x64/arm64 の並行ビルドによる obj 衝突）を防ぐため、逐次・自動で行う:
-
-      1. （任意）csproj と Package.appxmanifest のバージョンを一括更新
-      2. Store 用 MSIX を x64 / arm64 で生成（GenerateAppxPackageOnBuild）し、
-         winapp（makeappx）で 1 つの .msixbundle に束ねる（#216 経路B：小サイズ）
-
-    成果物は publish\release\ に集約する。
+    配布は GitHub リリース（ZIP）と winget のみで、どちらも CI
+    （.github/workflows/release.yml）が v* タグの push をトリガーに自動で行う。
+    本スクリプトは CI を起動する前のバージョン更新
+    （csproj / Package.appxmanifest）を担当する。
+    Microsoft Store 配布は廃止した（#272）ため、MSIX / .msixbundle は生成しない。
 
 .PARAMETER Version
-    新しいバージョン（例 1.6.1）。指定すると csproj と appxmanifest を更新する。
+    新しいバージョン（例 1.9.1）。指定すると csproj と appxmanifest を更新する。
     省略時は csproj の現在値を使う（ファイルは変更しない）。
 
 .PARAMETER WithZip
-    ローカル検証用に GitHub 配布相当の ZIP（自己完結・アンパッケージド）も生成する。
+    ローカル検証用に GitHub 配布相当の ZIP（自己完結・アンパッケージド）を生成する。
     本番の GitHub リリース ZIP は CI が作るため通常は不要。
 
-.PARAMETER SkipBundle
-    Store 用 MSIX / バンドルの生成をスキップする（バージョン更新や ZIP だけ行いたい場合）。
-
 .EXAMPLE
-    .\Release.ps1 -Version 1.6.1   # バージョン更新 + Store 用 .msixbundle を生成
-    .\Release.ps1                  # 現行バージョンのまま .msixbundle を生成
-    .\Release.ps1 -WithZip         # ローカル検証用に ZIP も生成
+    .\Release.ps1 -Version 1.9.1           # バージョン更新のみ
+    .\Release.ps1 -Version 1.9.1 -WithZip  # 更新 + ローカル検証用 ZIP も生成
+    .\Release.ps1 -WithZip                 # 現行バージョンのまま ZIP を生成
 #>
 [CmdletBinding()]
 param(
     [string] $Version,
-    [switch] $WithZip,
-    [switch] $SkipBundle
+    [switch] $WithZip
 )
 
 $ErrorActionPreference = 'Stop'
 $root    = $PSScriptRoot
 $proj    = Join-Path $root 'XTimelineViewer.csproj'
 $manifest= Join-Path $root 'Package.appxmanifest'
-$tfm     = 'net8.0-windows10.0.19041.0'
 $outDir  = Join-Path $root 'publish\release'
 
 function Step($msg) { Write-Host "`n=== $msg ===" -ForegroundColor Cyan }
@@ -64,24 +51,21 @@ if ($Version) {
     if ((Get-Content $proj -Raw) -match '<Version>([\d.]+)</Version>') { $Version = $Matches[1] }
     else { throw 'csproj から Version を読み取れませんでした' }
 }
-$msixVer = "$Version.0"
-Write-Host "対象バージョン: $Version (MSIX: $msixVer)"
-
-# 出力先を初期化
-Remove-Item $outDir -Recurse -Force -ErrorAction SilentlyContinue
-New-Item -ItemType Directory -Force $outDir | Out-Null
-
-# 実行中インスタンスがあるとビルドがファイルロックで失敗するため止める
-try { Stop-Process -Name XTimelineViewer -Force -ErrorAction Stop } catch {}
+Write-Host "対象バージョン: $Version"
 
 # ── ローカル検証用 ZIP（自己完結・アンパッケージド。本番は CI が生成） ─────────────
 if ($WithZip) {
+    Remove-Item $outDir -Recurse -Force -ErrorAction SilentlyContinue
+    New-Item -ItemType Directory -Force $outDir | Out-Null
+    # 実行中インスタンスがあるとビルドがファイルロックで失敗するため止める
+    try { Stop-Process -Name XTimelineViewer -Force -ErrorAction Stop } catch {}
+
     foreach ($rid in 'win-x64', 'win-arm64') {
         $plat = if ($rid -eq 'win-x64') { 'x64' } else { 'arm64' }
         Step "ZIP 発行: $rid"
         $pubDir = Join-Path $root "publish\$rid"
         # EffectivePlatform を明示しないと、WebView2 SDK がビルドホストの RID(win-x64) を見て
-        # x64 の Microsoft.Web.WebView2.Core.dll を arm64 出力に混入させ、arm64 で BadImageFormat になる。
+        # x64 の Microsoft.Web.WebView2.Core.dll を arm64 出力に混入させ、arm64 で BadImageFormat になる（#267）。
         dotnet publish $proj -c Release -r $rid -p:PlatformTarget=$plat -p:EffectivePlatform=$plat -p:WindowsPackageType=None -o $pubDir
         if ($LASTEXITCODE -ne 0) { throw "publish 失敗: $rid" }
         # コマンドライン起動用ランチャーを同梱（#264。CI の release.yml と揃える）
@@ -90,53 +74,14 @@ if ($WithZip) {
         Compress-Archive -Path "$pubDir\*" -DestinationPath $zip -Force
         Write-Host "→ $zip"
     }
+
+    Step '完了：成果物'
+    Get-ChildItem $outDir | Select-Object Name, @{N='MB';E={[math]::Round($_.Length/1MB,1)}} | Format-Table -AutoSize
 }
-
-# ── Store 用 MSIX → .msixbundle（#216 経路B） ──────────────────────────────────
-if (-not $SkipBundle) {
-    $msixPaths = @()
-    foreach ($plat in 'x64', 'arm64') {
-        $rid = "win-$plat"
-        Step "MSIX ビルド: $plat"
-        # arm64 は RuntimeIdentifier を明示しないと NETSDK1032（RID win-x64 と PlatformTarget arm64 の不一致）になる。
-        # EffectivePlatform を明示しないと、WebView2 SDK がビルドホストの RID(win-x64) を見て x64 の
-        # Microsoft.Web.WebView2.Core.dll を arm64 パッケージに混入させ、arm64 で BadImageFormat になる。
-        dotnet build $proj -c Release -p:Platform=$plat -p:PlatformTarget=$plat `
-            -p:RuntimeIdentifier=$rid -p:EffectivePlatform=$plat -p:GenerateAppxPackageOnBuild=true
-        if ($LASTEXITCODE -ne 0) { throw "MSIX ビルド失敗: $plat" }
-
-        $msix = Get-ChildItem (Join-Path $root "bin\$plat\Release\$tfm\$rid\AppPackages") `
-            -Recurse -Filter "XTimelineViewer_${msixVer}_$plat.msix" -ErrorAction SilentlyContinue |
-            Select-Object -First 1
-        if (-not $msix) { throw "生成された MSIX が見つかりません: $plat ($msixVer)" }
-        Copy-Item $msix.FullName $outDir
-        $msixPaths += (Join-Path $outDir $msix.Name)
-        Write-Host "→ $($msix.Name)"
-    }
-
-    Step 'MSIX バンドル生成'
-    # 既存のキュレート済み .msix を束ねるだけ（再パッケージしないので小サイズ）
-    $stage = Join-Path $root 'publish\_bundle'
-    Remove-Item $stage -Recurse -Force -ErrorAction SilentlyContinue
-    New-Item -ItemType Directory -Force $stage | Out-Null
-    $msixPaths | ForEach-Object { Copy-Item $_ $stage }
-
-    $bundle = Join-Path $outDir "XTimelineViewer-$Version.msixbundle"
-    winapp tool makeappx bundle /d $stage /p $bundle /o
-    if ($LASTEXITCODE -ne 0) { throw 'makeappx bundle 失敗' }
-    Remove-Item $stage -Recurse -Force -ErrorAction SilentlyContinue
-    Write-Host "→ $bundle（未署名。Store はこのままアップロード可）"
-}
-
-# ── まとめ ──────────────────────────────────────────────────────────────────────
-Step '完了：成果物'
-Get-ChildItem $outDir | Select-Object Name, @{N='MB';E={[math]::Round($_.Length/1MB,1)}} | Format-Table -AutoSize
 
 Write-Host @"
 次の手順（手動）:
   1. バージョン更新分をコミット & PR → main にマージ
   2. v$Version タグを push（または gh release create v$Version）
      → CI が GitHub リリースの ZIP と winget 公開を自動で行う
-  3. （マイナー以上）Microsoft Store パートナーセンターに
-     publish\release\XTimelineViewer-$Version.msixbundle をアップロード
 "@ -ForegroundColor Yellow


### PR DESCRIPTION
## 概要
Store 配布廃止（#272）に伴い、リポジトリに残っていた **Store 前提の記述・処理**を除去します。ref #272

## 変更
- **`Release.ps1`**: Store 用 MSIX / `.msixbundle` 生成ロジックと `-SkipBundle` を削除。バージョン更新（+ 任意 `-WithZip` でローカル検証 ZIP）のみに簡素化。SYNOPSIS も更新。
- **`.claude/skills/release/SKILL.md`**: 「マイナー以上は Store 申請が**必須**」等の矛盾記述と Store 申請ステップ（セクション5）を削除。ZIP + winget の CI 公開に統一。EffectivePlatform（#267）の注意を追記。

## 据え置き（削除しない）
- **`Package.appxmanifest` の `<Logo>StoreLogo.png</Logo>`**: appx マニフェストの**必須要素**であり、かつ `AboutPage.xaml.cs` でアプリ画像として使用中。削除するとビルド/表示が壊れるため据え置き（監査の「削除候補」は誤り）。

## 検証
- `Release.ps1`（引数なし）を実行 → バージョン読取のみ・**ファイル無変更**・出力に Store 記述なしを確認。

## 補足
- README の Store 記述削除は別 PR #273 で対応中。#272 は README・本 PR の両方がマージされたらクローズ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
