### PR TITLE
ci: PR/main で本体ビルドとテストを自動実行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
+      # 本体（WinUI 3）の x64 ビルド。XAML/コンパイルのリグレッションを PR で検知する。
+      - name: Build app (x64)
+        run: >
+          dotnet build XTimelineViewer.csproj
+          -c Release -p:Platform=x64 -p:EffectivePlatform=x64 --nologo
+
+      # ユニットテスト（UI 非依存の net8.0 テストプロジェクト）。
+      - name: Test
+        run: dotnet test XTimelineViewer.Tests/XTimelineViewer.Tests.csproj -c Release --nologo


### PR DESCRIPTION
## 概要
ユニットテスト（`XTimelineViewer.Tests`）がこれまで**手動実行のみ**だったため、CI を追加します（v2.0 クリーンアップ クラスタ D）。AutoActivate 削除（#274）ではテストがリグレッション検知に有効だったため、自動化して以降の作業を安全にします。

## 追加
- **`.github/workflows/ci.yml`**: `push`(main) と `pull_request` をトリガーに、`windows-latest` で
  - 本体（WinUI 3）の **x64 ビルド**（XAML/コンパイルのリグレッション検知）
  - **`dotnet test`**（UI 非依存の net8.0 テストプロジェクト、xUnit 123 件）

## 備考
- テストプロジェクトは WinUI に依存せず必要な `Models`/`Services`/`ViewModels` をリンクする構成のため軽量に回る。
- 既存の `release.yml`（`v*` タグで ZIP+winget 公開）とは独立。
- この PR 自体で CI が走るので、初回動作を確認できる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
