### PR TITLE
feat(#261): アプリ表示名を「XTimelineViewer (xTV)」に

### DIFF
--- a/Package.appxmanifest
+++ b/Package.appxmanifest
@@ -13,7 +13,7 @@
     ProcessorArchitecture="neutral" />
 
   <Properties>
-    <DisplayName>XTimelineViewer</DisplayName>
+    <DisplayName>XTimelineViewer (xTV)</DisplayName>
     <PublisherDisplayName>だるやなぎ</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
@@ -36,7 +36,7 @@
       Executable="$targetnametoken$.exe"
       EntryPoint="$targetentrypoint$">
       <uap:VisualElements
-        DisplayName="XTimelineViewer"
+        DisplayName="XTimelineViewer (xTV)"
         Description="X のタイムラインを横並びで表示するビューアー"
         BackgroundColor="transparent"
         Square150x150Logo="Assets\Square150x150Logo.png"

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -250,7 +250,7 @@ namespace XTimelineViewer.Views
             AppWindow.Resize(new SizeInt32(1400, 900));
             var iconPath = Path.Combine(AppContext.BaseDirectory, "Assets", "AppIcon.ico");
             if (File.Exists(iconPath)) AppWindow.SetIcon(iconPath);
-            Title = "XTimelineViewer";
+            Title = "XTimelineViewer (xTV)";
             RefreshUIText();
             Closed += async (s, e) =>
             {

--- a/Views/Settings/AboutPage.xaml.cs
+++ b/Views/Settings/AboutPage.xaml.cs
@@ -34,7 +34,7 @@ namespace XTimelineViewer.Views.Settings
             var versionStr = currentVersion.ToString(3);
             var edgeChannel = R.Get("EdgeChannel_Runtime");
             var edgeVersion = _parent?.EdgeVersion ?? R.Get("Version_Unknown");
-            var versionInfoText = $"XTimelineViewer v{versionStr}\r\n{edgeChannel} {edgeVersion}";
+            var versionInfoText = $"XTimelineViewer (xTV) v{versionStr}\r\n{edgeChannel} {edgeVersion}";
 
             var repoUrl = "https://github.com/daruyanagi/XTimelineViewer";
             var fallbackUrl = repoUrl + "/releases/latest";
@@ -78,7 +78,7 @@ namespace XTimelineViewer.Views.Settings
             var textStack = new StackPanel { Spacing = 3, VerticalAlignment = VerticalAlignment.Center };
             textStack.Children.Add(new TextBlock
             {
-                Text       = "XTimelineViewer",
+                Text       = "XTimelineViewer (xTV)",
                 FontSize   = 20,
                 FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
             });


### PR DESCRIPTION
## 概要
アプリの表示名に通称 **xTV** を併記し「XTimelineViewer (xTV)」にします。ref #261

## 変更（表示名のみ）
- `Package.appxmanifest`: Properties / VisualElements の DisplayName
- `MainWindow`: ウィンドウタイトル
- `AboutPage`: アプリ名表示＋コピー用バージョン情報

## 据え置き（互換のため変更しない）
- パッケージ Identity（`4275.XTimelineViewer`）、winget ID（`daruyanagi.XTimelineViewer`）
- データ保存先パス `AppData\XTimelineViewer`、名前空間、GitHub URL

## 検証
- ビルド 0 エラー / 0 警告

## 残（#261）
- **アイコン差し替え**は透過 PNG（1024px 級）入手後に別 PR で対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)