### PR TITLE
refactor(#271): 未使用リソースキーと using を除去

### DIFF
--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -157,11 +157,9 @@
   <data name="ExtSettings_Homepage" xml:space="preserve"><value>Open Homepage</value></data>
   <data name="ExtSettings_StoreLink" xml:space="preserve"><value>Open in Chrome Web Store</value></data>
   <data name="ExtSettings_OpenSettings" xml:space="preserve"><value>Open Settings</value></data>
-  <data name="Extensions_Empty" xml:space="preserve"><value>No extensions installed</value></data>
   <data name="Extensions_InfoBar_Empty" xml:space="preserve"><value>No extensions are installed. Place an unpacked extension in the extensions folder to load it at startup.</value></data>
   <data name="Extensions_InfoBar_Installed" xml:space="preserve"><value>Place an unpacked extension in the extensions folder to load it at startup.</value></data>
   <data name="Extensions_OpenFolder" xml:space="preserve"><value>Open extensions folder</value></data>
-  <data name="Extensions_Empty_Description" xml:space="preserve"><value>Place extension folders in the "extensions" directory to add them.</value></data>
 
   <!-- Update check -->
   <data name="CheckUpdate_Btn" xml:space="preserve"><value>Check for Updates</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -157,11 +157,9 @@
   <data name="ExtSettings_Homepage" xml:space="preserve"><value>ホームページを開く</value></data>
   <data name="ExtSettings_StoreLink" xml:space="preserve"><value>Chrome Web Store で開く</value></data>
   <data name="ExtSettings_OpenSettings" xml:space="preserve"><value>設定を開く</value></data>
-  <data name="Extensions_Empty" xml:space="preserve"><value>拡張機能がインストールされていません</value></data>
   <data name="Extensions_InfoBar_Empty" xml:space="preserve"><value>拡張機能はインストールされていません。extensions フォルダーに展開済みの拡張機能を置くと、起動時に読み込まれます。</value></data>
   <data name="Extensions_InfoBar_Installed" xml:space="preserve"><value>extensions フォルダーに展開済みの拡張機能を置くと、起動時に読み込まれます。</value></data>
   <data name="Extensions_OpenFolder" xml:space="preserve"><value>extensions フォルダーを開く</value></data>
-  <data name="Extensions_Empty_Description" xml:space="preserve"><value>"extensions" フォルダーに拡張機能を配置してください。</value></data>
 
   <!-- Update check -->
   <data name="CheckUpdate_Btn" xml:space="preserve"><value>更新を確認</value></data>

--- a/Views/MainWindow.WebView2.cs
+++ b/Views/MainWindow.WebView2.cs
@@ -5,18 +5,14 @@ using Microsoft.UI.Xaml.Media;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.Linq;
 using System.Net.Http;
-using System.Net.NetworkInformation;
-using System.Reflection;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.Web.WebView2.Core;
 using Windows.ApplicationModel.DataTransfer;
-using Windows.Graphics;
 using Windows.Storage;
 using Windows.UI;
 


### PR DESCRIPTION
## 概要
#271 の 2 回目クリーンアップ監査で確認できた、**確実に安全な残骸のみ**を除去します。ref #271

## 変更
- **未使用リソースキー削除**（両言語）: `Extensions_Empty` / `Extensions_Empty_Description`。コード・XAML から参照ゼロを grep で確認（実使用は `Extensions_InfoBar_Empty` / `_Installed`）。
- **未使用 using 削除**（`MainWindow.WebView2.cs`）: `System.Globalization` / `System.Net.NetworkInformation` / `System.Reflection` / `Windows.Graphics`。

## 見送った監査指摘（誤り/リスク過大）
- `DispatcherTimer.Dispose()` 追加 → WinUI の `DispatcherTimer` は **IDisposable 非対応**でコンパイル不可。
- `CoreWebView2` のイベント購読解除 → ハンドラがラムダで `-=` 困難、`webView.Close()` で破棄済み、効果に対しリスク過大。
- 空 catch へのログ追加 → 主観的・低価値。

## 検証
- ビルド **0 エラー / 0 警告**（using が実際に未使用であることを確定）
- テスト **123/123 合格**

## 監査の総合判定
コードベースは前回の AutoActivate・Store 除去後、相当クリーン。今回は微細な加点項目のみで、大きなデッドコードや有害な握りつぶしは無し。

🤖 Generated with [Claude Code](https://claude.com/claude-code)