### PR TITLE
feat(#285): 投稿後にプライマリプロフィールへ戻す試験機能

### DIFF
--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -19,5 +19,6 @@ namespace XTimelineViewer.Models
         public bool    HomeAutoLoadEnabled   { get; set; } = true;       // ホーム自動更新（#207）の ON/OFF
         public int     HomeAutoLoadIntervalSeconds { get; set; } = 8;    // ホーム自動更新の間隔（秒, 最小 5）
         public bool    ComposePreloadEnabled { get; set; } = false;     // 投稿ウィンドウのプリロード（試験機能 #244 案B）
+        public bool    ComposeResetToPrimaryEnabled { get; set; } = false; // 投稿後にプライマリへ戻す（試験機能 #285）
     }
 }

--- a/Models/ProfileConfig.cs
+++ b/Models/ProfileConfig.cs
@@ -15,5 +15,8 @@ namespace XTimelineViewer.Models
         /// 作成時に検出し、ペイン読み込み時にも補完する。
         /// </summary>
         public string? ScreenName     { get; set; }
+
+        /// <summary>投稿ダイアログの既定（プライマリ）プロフィール（#285）。単一のみ true にする。</summary>
+        public bool    IsPrimary       { get; set; }
     }
 }

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -109,6 +109,8 @@
   <data name="Experimental_Caution" xml:space="preserve"><value>Features listed here may change, be deprecated, or be removed without notice.</value></data>
   <data name="Settings_ComposePreload" xml:space="preserve"><value>Preload the compose window</value></data>
   <data name="Settings_ComposePreload_Description" xml:space="preserve"><value>Loads the compose page in the background so there is less wait between pressing Post and being able to type (last used profile). Uses more memory.</value></data>
+  <data name="Settings_ComposeResetToPrimary" xml:space="preserve"><value>Return to primary profile after posting</value></data>
+  <data name="Settings_ComposeResetToPrimary_Description" xml:space="preserve"><value>After you switch accounts and post, the compose window returns to your primary profile next time. Helps avoid posting from the wrong account. Set the primary profile on the Profiles page.</value></data>
   <data name="Nav_Extensions" xml:space="preserve"><value>Extensions</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>Profiles</value></data>
   <data name="Nav_Data" xml:space="preserve"><value>User Data</value></data>
@@ -125,6 +127,8 @@
   <data name="Profile_DeleteConfirmBody" xml:space="preserve"><value>{0} timeline(s) using this profile will also be removed.</value></data>
   <data name="Profile_DeleteConfirm" xml:space="preserve"><value>Delete</value></data>
   <data name="Profiles_Name" xml:space="preserve"><value>Name</value></data>
+  <data name="Profiles_Primary" xml:space="preserve"><value>Primary profile</value></data>
+  <data name="Profiles_Primary_Description" xml:space="preserve"><value>Use this account as the default in the compose window.</value></data>
   <data name="Profiles_BadgeColor" xml:space="preserve"><value>Badge Color</value></data>
   <data name="Profiles_BadgeText" xml:space="preserve"><value>Badge Text</value></data>
   <data name="Profiles_DefaultDescription" xml:space="preserve"><value>Internal profile used by the application</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -109,6 +109,8 @@
   <data name="Experimental_Caution" xml:space="preserve"><value>ここにリストアップされる機能は予告なく変更されたり、非推奨・削除されることがあります。</value></data>
   <data name="Settings_ComposePreload" xml:space="preserve"><value>投稿ウィンドウをプリロードする</value></data>
   <data name="Settings_ComposePreload_Description" xml:space="preserve"><value>バックグラウンドで投稿画面を事前に読み込み、投稿ボタンを押してから入力できるまでの待ち時間を短縮します（最後に使ったプロファイル）。メモリ消費が増えます。</value></data>
+  <data name="Settings_ComposeResetToPrimary" xml:space="preserve"><value>投稿後にプライマリプロフィールへ戻す</value></data>
+  <data name="Settings_ComposeResetToPrimary_Description" xml:space="preserve"><value>アカウントを切り替えて投稿したあと、次回の投稿ウィンドウをプライマリプロフィールに戻します。誤ったアカウントでの投稿を防ぎます。プライマリは［プロファイル］ページで指定します。</value></data>
   <data name="Nav_Extensions" xml:space="preserve"><value>拡張機能</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>プロファイル</value></data>
   <data name="Nav_Data" xml:space="preserve"><value>ユーザーデータ管理</value></data>
@@ -125,6 +127,8 @@
   <data name="Profile_DeleteConfirmBody" xml:space="preserve"><value>このプロファイルを使用している {0} 個のタイムラインも削除されます。</value></data>
   <data name="Profile_DeleteConfirm" xml:space="preserve"><value>削除する</value></data>
   <data name="Profiles_Name" xml:space="preserve"><value>名前</value></data>
+  <data name="Profiles_Primary" xml:space="preserve"><value>プライマリプロフィール</value></data>
+  <data name="Profiles_Primary_Description" xml:space="preserve"><value>投稿ウィンドウの既定アカウントとして使います。</value></data>
   <data name="Profiles_BadgeColor" xml:space="preserve"><value>バッジの色</value></data>
   <data name="Profiles_BadgeText" xml:space="preserve"><value>バッジテキスト</value></data>
   <data name="Profiles_DefaultDescription" xml:space="preserve"><value>アプリケーションが利用する内部プロファイルです</value></data>

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -165,6 +165,18 @@ namespace XTimelineViewer.ViewModels
             }
         }
 
+        /// <summary>投稿後にプライマリプロフィールへ戻す（試験機能 #285）。</summary>
+        public bool ComposeResetToPrimaryEnabled
+        {
+            get => _settings.ComposeResetToPrimaryEnabled;
+            set
+            {
+                if (_settings.ComposeResetToPrimaryEnabled == value) return;
+                _settings.ComposeResetToPrimaryEnabled = value;
+                Notify(nameof(ComposeResetToPrimaryEnabled));
+            }
+        }
+
         public int BrowserIndex
         {
             get => Math.Max(0, Array.IndexOf(BrowserValues, _settings.ExternalBrowser));

--- a/Views/MainWindow.Post.cs
+++ b/Views/MainWindow.Post.cs
@@ -225,10 +225,17 @@ namespace XTimelineViewer.Views
                 foreach (var wv in _webViews)
                     wv.Visibility = Visibility.Visible;
 
-                // 選択プロファイルを保存
-                if (_appSettings.LastUsedProfileId != selectedProfileId)
+                // 投稿アカウントの記憶。#285: 有効時は誤爆防止のため、次回はプライマリへ戻す。
+                var nextProfileId = selectedProfileId;
+                if (_appSettings.ComposeResetToPrimaryEnabled)
                 {
-                    _appSettings.LastUsedProfileId = selectedProfileId;
+                    var primary = _profiles.FirstOrDefault(p => p.IsPrimary)
+                                  ?? _profiles.FirstOrDefault(p => p.Id != "default");
+                    if (primary is not null) nextProfileId = primary.Id;
+                }
+                if (_appSettings.LastUsedProfileId != nextProfileId)
+                {
+                    _appSettings.LastUsedProfileId = nextProfileId;
                     SaveSettings();
                 }
 

--- a/Views/Settings/ExperimentalPage.xaml
+++ b/Views/Settings/ExperimentalPage.xaml
@@ -25,6 +25,15 @@
                 <ToggleSwitch x:Name="ComposePreloadToggle"
                               IsOn="{x:Bind VM.ComposePreloadEnabled, Mode=TwoWay}"/>
             </controls:SettingsCard>
+
+            <!-- 投稿後にプライマリプロフィールへ戻す（#285）-->
+            <controls:SettingsCard x:Name="ComposeResetToPrimaryCard">
+                <controls:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE77B;" FontFamily="Segoe Fluent Icons"/>
+                </controls:SettingsCard.HeaderIcon>
+                <ToggleSwitch x:Name="ComposeResetToPrimaryToggle"
+                              IsOn="{x:Bind VM.ComposeResetToPrimaryEnabled, Mode=TwoWay}"/>
+            </controls:SettingsCard>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/Views/Settings/ExperimentalPage.xaml.cs
+++ b/Views/Settings/ExperimentalPage.xaml.cs
@@ -51,6 +51,12 @@ namespace XTimelineViewer.Views.Settings
             ComposePreloadToggle.OnContent  = R.Get("Toggle_On");
             ComposePreloadToggle.OffContent = R.Get("Toggle_Off");
 
+            // 投稿後にプライマリプロフィールへ戻す（#285）
+            ComposeResetToPrimaryCard.Header      = R.Get("Settings_ComposeResetToPrimary");
+            ComposeResetToPrimaryCard.Description = R.Get("Settings_ComposeResetToPrimary_Description");
+            ComposeResetToPrimaryToggle.OnContent  = R.Get("Toggle_On");
+            ComposeResetToPrimaryToggle.OffContent = R.Get("Toggle_Off");
+
             // ItemsSource 再設定で SelectedIndex が失われるため、バインディングを再評価する
             Bindings.Update();
         }

--- a/Views/Settings/ProfilesPage.xaml.cs
+++ b/Views/Settings/ProfilesPage.xaml.cs
@@ -146,9 +146,42 @@ namespace XTimelineViewer.Views.Settings
                 Content = badgeTextBox,
             };
 
+            // ── プライマリプロフィール（#285）──
+            var primaryToggle = new ToggleSwitch
+            {
+                IsOn       = profile.IsPrimary,
+                OnContent  = R.Get("Toggle_On"),
+                OffContent = R.Get("Toggle_Off"),
+            };
+            var capturedForPrimary = profile;
+            primaryToggle.Toggled += (_, _) =>
+            {
+                if (primaryToggle.IsOn)
+                {
+                    // 単一プライマリ制約: 他プロフィールの指定を解除する
+                    foreach (var p in _parent?.Profiles ?? []) p.IsPrimary = false;
+                    capturedForPrimary.IsPrimary = true;
+                    _parent?.ProfilesModified?.Invoke();
+                    // 他カードのトグル表示を同期（イベント中の再入を避けて遅延実行）
+                    DispatcherQueue.TryEnqueue(PopulateUI);
+                }
+                else
+                {
+                    capturedForPrimary.IsPrimary = false;
+                    _parent?.ProfilesModified?.Invoke();
+                }
+            };
+            var primaryCard = new CommunityToolkit.WinUI.Controls.SettingsCard
+            {
+                Header      = R.Get("Profiles_Primary"),
+                Description = R.Get("Profiles_Primary_Description"),
+                Content     = primaryToggle,
+            };
+
             expander.Items.Add(nameCard);
             expander.Items.Add(colorCard);
             expander.Items.Add(badgeTextCard);
+            expander.Items.Add(primaryCard);
 
             // ── 削除ボタン（Expander 内の末尾に配置 #178） ──
             var deleteBtn = new Button


### PR DESCRIPTION
## 概要
誤ったアカウントでの投稿を防ぐため、投稿ダイアログを閉じたときに投稿アカウントを**プライマリプロフィールへ戻す**試験機能（既定 OFF）を追加します。Closes #285

## 変更
- **`ProfileConfig.IsPrimary`**: プロファイルに「プライマリ」指定を追加（単一のみ true）。［プロファイル］ページの各カードにトグルを追加（ON にすると他を自動解除）。
- **`AppSettings.ComposeResetToPrimaryEnabled`** ＋ `SettingsViewModel` バインディング。**試験機能**ページにトグルを追加。
- **`MainWindow.Post.cs`**: 投稿ダイアログを閉じたとき、有効なら `LastUsedProfileId` をプライマリ（未指定時は先頭の名前付きプロファイル）に戻す。次回はプライマリで開く。
- **resw（ja/en）**: `Settings_ComposeResetToPrimary(_Description)` / `Profiles_Primary(_Description)`。

## 設計メモ
- `SettingsWindow` は `_profiles` / `_appSettings` を**共有参照**で受け取るため、プライマリ指定・トグルは即時反映（`ProfilesModified`/`SettingsChanged` で永続化）。
- 戻すタイミングは「ダイアログを閉じたとき」（投稿・キャンセル問わず）。投稿成功の確実な検知は難しいため、まずは単純で誤爆防止に有効なこの方式を採用（イシューの方針どおり）。将来 postMessage で投稿成功検知に精緻化可能。

## 検証
- ビルド 0 エラー / 0 警告、テスト **123/123**、resw 両言語キー数一致（各 151）、起動スモーク OK。
- 手動確認推奨: ［プロファイル］でプライマリ指定 → 試験機能でトグル ON → サブで投稿 → 次回投稿ダイアログがプライマリで開くこと。

🤖 Generated with [Claude Code](https://claude.com/claude-code)