### PR TITLE
feat(#287): 画像表示中のペインをウィンドウ全体へ一時拡大する試験機能

### DIFF
--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -20,5 +20,6 @@ namespace XTimelineViewer.Models
         public int     HomeAutoLoadIntervalSeconds { get; set; } = 8;    // ホーム自動更新の間隔（秒, 最小 5）
         public bool    ComposePreloadEnabled { get; set; } = false;     // 投稿ウィンドウのプリロード（試験機能 #244 案B）
         public bool    ComposeResetToPrimaryEnabled { get; set; } = false; // 投稿後にプライマリへ戻す（試験機能 #285）
+        public bool    MediaEnlargeEnabled   { get; set; } = false;     // 画像表示中のペインを一時拡大（試験機能 #287）
     }
 }

--- a/Services/UrlHelper.cs
+++ b/Services/UrlHelper.cs
@@ -27,6 +27,14 @@ namespace XTimelineViewer.Services
             => Uri.TryCreate(url, UriKind.Absolute, out var u)
                && Regex.IsMatch(u.AbsolutePath, @"^/[^/]+/lists$");
 
+        /// <summary>
+        /// 個別ツイートの画像表示 URL（https://x.com/&lt;handle&gt;/status/&lt;id&gt;/photo/&lt;n&gt;）かどうか。
+        /// クリックでライトボックスが開いた状態を検知し、ペインの一時拡大（#287）のトリガーに使う。
+        /// </summary>
+        internal static bool IsMediaPhotoUrl(string url)
+            => Uri.TryCreate(url, UriKind.Absolute, out var u)
+               && Regex.IsMatch(u.AbsolutePath, @"^/[^/]+/status/\d+/photo/\d+/?$");
+
         // グリフは Segoe Fluent Icons の私用領域(PUA)コードポイント。
         // 生の PUA 文字を直書きするとエンコーディング事故で欠落するため (#122)、
         // 必ず "\uXXXX" エスケープ表記で記述すること。

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -111,6 +111,8 @@
   <data name="Settings_ComposePreload_Description" xml:space="preserve"><value>Loads the compose page in the background so there is less wait between pressing Post and being able to type (last used profile). Uses more memory.</value></data>
   <data name="Settings_ComposeResetToPrimary" xml:space="preserve"><value>Return to primary profile after posting</value></data>
   <data name="Settings_ComposeResetToPrimary_Description" xml:space="preserve"><value>After you switch accounts and post, the compose window returns to your primary profile next time. Helps avoid posting from the wrong account. Set the primary profile on the Profiles page.</value></data>
+  <data name="Settings_MediaEnlarge" xml:space="preserve"><value>Enlarge pane when viewing a photo</value></data>
+  <data name="Settings_MediaEnlarge_Description" xml:space="preserve"><value>When a timeline navigates to a photo (e.g. .../status/&lt;id&gt;/photo/1), temporarily enlarges that pane to fill the window. Returns to normal when you leave the photo.</value></data>
   <data name="Nav_Extensions" xml:space="preserve"><value>Extensions</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>Profiles</value></data>
   <data name="Nav_Data" xml:space="preserve"><value>User Data</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -111,6 +111,8 @@
   <data name="Settings_ComposePreload_Description" xml:space="preserve"><value>バックグラウンドで投稿画面を事前に読み込み、投稿ボタンを押してから入力できるまでの待ち時間を短縮します（最後に使ったプロファイル）。メモリ消費が増えます。</value></data>
   <data name="Settings_ComposeResetToPrimary" xml:space="preserve"><value>投稿後にプライマリプロフィールへ戻す</value></data>
   <data name="Settings_ComposeResetToPrimary_Description" xml:space="preserve"><value>アカウントを切り替えて投稿したあと、次回の投稿ウィンドウをプライマリプロフィールに戻します。誤ったアカウントでの投稿を防ぎます。プライマリは［プロファイル］ページで指定します。</value></data>
+  <data name="Settings_MediaEnlarge" xml:space="preserve"><value>画像表示中はペインを拡大する</value></data>
+  <data name="Settings_MediaEnlarge_Description" xml:space="preserve"><value>タイムラインが画像（.../status/&lt;id&gt;/photo/1 など）へ遷移したとき、そのペインを一時的にウィンドウいっぱいに拡大します。画像から離れると元に戻ります。</value></data>
   <data name="Nav_Extensions" xml:space="preserve"><value>拡張機能</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>プロファイル</value></data>
   <data name="Nav_Data" xml:space="preserve"><value>ユーザーデータ管理</value></data>

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -177,6 +177,18 @@ namespace XTimelineViewer.ViewModels
             }
         }
 
+        /// <summary>画像表示中のペインを一時拡大する（試験機能 #287）。</summary>
+        public bool MediaEnlargeEnabled
+        {
+            get => _settings.MediaEnlargeEnabled;
+            set
+            {
+                if (_settings.MediaEnlargeEnabled == value) return;
+                _settings.MediaEnlargeEnabled = value;
+                Notify(nameof(MediaEnlargeEnabled));
+            }
+        }
+
         public int BrowserIndex
         {
             get => Math.Max(0, Array.IndexOf(BrowserValues, _settings.ExternalBrowser));

--- a/Views/MainWindow.MediaEnlarge.cs
+++ b/Views/MainWindow.MediaEnlarge.cs
@@ -1,0 +1,59 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using System.Linq;
+
+namespace XTimelineViewer.Views
+{
+    public sealed partial class MainWindow : Window
+    {
+        // 画像表示中のペインの一時拡大（試験機能 #287）。
+        //
+        // WebView2 の親要素（ペイン）は変更しない。visual tree を移し替えると
+        // CoreWebView2 が作り直され、開いていたライトボックスや再生中の動画が
+        // リセットされてしまう（#32 の失敗と同じ問題）。代わりに、対象ペインが
+        // 属する横並び StackPanel（TimelinePanel）内で、他のペインを一時的に
+        // 隠し、対象ペインの幅だけ表示領域いっぱいに広げる。
+
+        /// <summary>対象ペインを一時拡大する。他のペインは一時的に非表示になる。</summary>
+        private void EnlargePane(Grid pane)
+        {
+            if (_enlargedPane == pane) return;
+
+            _enlargedPane = pane;
+            foreach (var p in TimelinePanel.Children.OfType<Grid>())
+                p.Visibility = p == pane ? Visibility.Visible : Visibility.Collapsed;
+
+            UpdateEnlargedPaneWidth();
+        }
+
+        /// <summary>拡大表示を解除し、全ペインの表示状態と幅を元に戻す。</summary>
+        private void RestorePaneSize()
+        {
+            if (_enlargedPane is null) return;
+
+            var pane = _enlargedPane;
+            _enlargedPane = null;
+
+            foreach (var p in TimelinePanel.Children.OfType<Grid>())
+                p.Visibility = Visibility.Visible;
+
+            if (_paneToConfig.TryGetValue(pane, out var cfg))
+                pane.Width = cfg.Width;
+        }
+
+        /// <summary>拡大中のペイン幅を、表示領域（TimelineScroll のビューポート）いっぱいに合わせる。</summary>
+        private void UpdateEnlargedPaneWidth()
+        {
+            if (_enlargedPane is null) return;
+
+            var target = TimelineScroll.ActualWidth
+                         - TimelinePanel.Padding.Left - TimelinePanel.Padding.Right
+                         - _enlargedPane.Margin.Left - _enlargedPane.Margin.Right;
+            if (target > 0)
+                _enlargedPane.Width = target;
+        }
+
+        private void TimelineScroll_SizeChanged(object sender, SizeChangedEventArgs e)
+            => UpdateEnlargedPaneWidth();
+    }
+}

--- a/Views/MainWindow.Profiles.cs
+++ b/Views/MainWindow.Profiles.cs
@@ -42,6 +42,7 @@ namespace XTimelineViewer.Views
                 var idx = indices[i];
                 if (idx >= TimelinePanel.Children.Count) continue;
                 var pane = (Grid)TimelinePanel.Children[idx];
+                if (_enlargedPane == pane) RestorePaneSize();  // 拡大中のペイン削除に備える（#287）
                 var wv = pane.Children.OfType<WebView2>().FirstOrDefault();
                 if (wv != null)
                 {
@@ -55,6 +56,7 @@ namespace XTimelineViewer.Views
                 }
                 _paneToSetFocus.Remove(pane);
                 _paneUrlUpdaters.Remove(_configs[idx]);
+                _paneToConfig.Remove(pane);
                 TimelinePanel.Children.RemoveAt(idx);
                 _configs.RemoveAt(idx);
             }

--- a/Views/MainWindow.Settings.cs
+++ b/Views/MainWindow.Settings.cs
@@ -127,6 +127,7 @@ namespace XTimelineViewer.Views
                 ApplySavedTheme();
                 UpdateThemeRadioState();
                 _ = WarmUpComposeAsync();  // 投稿プリロードの ON/OFF を即時反映（#244 案B）
+                if (!_appSettings.MediaEnlargeEnabled) RestorePaneSize();  // トグル OFF を即時反映（#287）
 
                 // WebView のタイムスタンプ設定を即時反映
                 var tsFlag = _appSettings.OpenTimestampInBrowser ? "true" : "false";

--- a/Views/MainWindow.Timeline.cs
+++ b/Views/MainWindow.Timeline.cs
@@ -392,6 +392,7 @@ namespace XTimelineViewer.Views
             _webViews.Add(webView);
             _webViewToPane[webView] = pane;
             _headerGridToPane[headerGrid] = pane;  // アクティブ判定用（#227）
+            _paneToConfig[pane] = cfg;  // ペイン一時拡大からの幅復元用（#287）
             RefreshTimelineNumbers();  // 番号バッジを振り直す（#225）
 
             // cfg.Url の変更をヘッダーへ反映する更新子（ベース URL 変更・リスト URL ライブ解決で再利用）
@@ -652,6 +653,7 @@ namespace XTimelineViewer.Views
 
                 if (shouldDelete)
                 {
+                    if (_enlargedPane == pane) RestorePaneSize();  // 拡大中のペイン削除に備える（#287）
                     CleanupWebView(webView);
                     if (_hardReloadUiUpdaters.Count == 0)
                     {
@@ -664,6 +666,7 @@ namespace XTimelineViewer.Views
                     _autoLoadIndicators.Remove(pane);
                     _paneNumberLabels.Remove(pane);
                     _headerGridToPane.Remove(headerGrid);
+                    _paneToConfig.Remove(pane);
                     _headerRefreshers.Remove(refreshHeader);
                     if (_focusedHeaderGrid == headerGrid)
                     {

--- a/Views/MainWindow.WebView2.cs
+++ b/Views/MainWindow.WebView2.cs
@@ -523,6 +523,16 @@ namespace XTimelineViewer.Views
                         _urlDivergedWebViews.Remove(webView);
                     }
                     EvaluateHardReloadPause(webView);
+
+                    // 画像表示中はペインを一時拡大する（試験機能 #287）
+                    if (_appSettings.MediaEnlargeEnabled &&
+                        _webViewToPane.TryGetValue(webView, out var pane))
+                    {
+                        if (UrlHelper.IsMediaPhotoUrl(webView.CoreWebView2.Source))
+                            EnlargePane(pane);
+                        else if (_enlargedPane == pane)
+                            RestorePaneSize();
+                    }
                 };
                 await LoadExtensionsAsync(webView);
                 ApplyThemeToWebViews();

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -178,7 +178,8 @@
                           HorizontalScrollMode="Enabled"
                           HorizontalScrollBarVisibility="Auto"
                           VerticalScrollMode="Disabled"
-                          VerticalScrollBarVisibility="Hidden">
+                          VerticalScrollBarVisibility="Hidden"
+                          SizeChanged="TimelineScroll_SizeChanged">
                 <StackPanel x:Name="TimelinePanel"
                             Orientation="Horizontal"
                             Padding="4"/>

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -123,6 +123,10 @@ namespace XTimelineViewer.Views
         // headerGrid → pane の対応（#227）。アクティブな headerGrid からペインを引くのに使う。
         private readonly Dictionary<Grid, Grid> _headerGridToPane = [];
 
+        // 画像表示中のペインの一時拡大（試験機能 #287）。ペイン → 元の TimelineConfig（幅の復元用）。
+        private readonly Dictionary<Grid, TimelineConfig> _paneToConfig = [];
+        private Grid? _enlargedPane;
+
         // キーボードショートカット処理スクリプト（各 WebView2 に注入）
         private static readonly string KeyboardShortcutScript = """
             (function() {

--- a/Views/Settings/ExperimentalPage.xaml
+++ b/Views/Settings/ExperimentalPage.xaml
@@ -34,6 +34,15 @@
                 <ToggleSwitch x:Name="ComposeResetToPrimaryToggle"
                               IsOn="{x:Bind VM.ComposeResetToPrimaryEnabled, Mode=TwoWay}"/>
             </controls:SettingsCard>
+
+            <!-- 画像表示中のペインを一時拡大（#287）-->
+            <controls:SettingsCard x:Name="MediaEnlargeCard">
+                <controls:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE740;" FontFamily="Segoe Fluent Icons"/>
+                </controls:SettingsCard.HeaderIcon>
+                <ToggleSwitch x:Name="MediaEnlargeToggle"
+                              IsOn="{x:Bind VM.MediaEnlargeEnabled, Mode=TwoWay}"/>
+            </controls:SettingsCard>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/Views/Settings/ExperimentalPage.xaml.cs
+++ b/Views/Settings/ExperimentalPage.xaml.cs
@@ -57,6 +57,12 @@ namespace XTimelineViewer.Views.Settings
             ComposeResetToPrimaryToggle.OnContent  = R.Get("Toggle_On");
             ComposeResetToPrimaryToggle.OffContent = R.Get("Toggle_Off");
 
+            // 画像表示中のペインを一時拡大（#287）
+            MediaEnlargeCard.Header      = R.Get("Settings_MediaEnlarge");
+            MediaEnlargeCard.Description = R.Get("Settings_MediaEnlarge_Description");
+            MediaEnlargeToggle.OnContent  = R.Get("Toggle_On");
+            MediaEnlargeToggle.OffContent = R.Get("Toggle_Off");
+
             // ItemsSource 再設定で SelectedIndex が失われるため、バインディングを再評価する
             Bindings.Update();
         }

--- a/XTimelineViewer.Tests/Services/UrlHelperTests.cs
+++ b/XTimelineViewer.Tests/Services/UrlHelperTests.cs
@@ -74,6 +74,19 @@ public class UrlHelperTests
     public void IsPerUserListsUrl_Works(string url, bool expected)
         => Assert.Equal(expected, UrlHelper.IsPerUserListsUrl(url));
 
+    // ── IsMediaPhotoUrl ───────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("https://x.com/shibayan/status/2075804532337172744/photo/1",  true)]
+    [InlineData("https://x.com/shibayan/status/2075804532337172744/photo/4/", true)]  // 末尾スラッシュ許容
+    [InlineData("https://twitter.com/foo/status/123/photo/1",                 true)]
+    [InlineData("https://x.com/shibayan/status/2075804532337172744",          false)] // 個別ツイート本体
+    [InlineData("https://x.com/shibayan/status/2075804532337172744/video/1",  false)] // 動画は対象外（#287 段階1）
+    [InlineData("https://x.com/home",                                        false)]
+    [InlineData("not-a-url",                                                 false)]
+    public void IsMediaPhotoUrl_Works(string url, bool expected)
+        => Assert.Equal(expected, UrlHelper.IsMediaPhotoUrl(url));
+
     // ── ParseUrlShortcut ──────────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## 概要
画像（例: `x.com/<user>/status/<id>/photo/1`）を表示しているとき、そのペインを**ウィンドウ全体に一時拡大**する試験機能（既定 OFF）を追加します。ref #287

## #32 との違い（過去の断念を踏まえた新方針）
過去 #32 では「別ウィンドウ＋画像 URL 抽出」を試み、X の photo 直アクセスでライトボックスが開かない・オリジン制限で画像が読めない、という理由で断念しました。

今回は**画像を抽出せず、WebView2 の親要素（ペイン）も変更しません**。ユーザーがタイムライン内で画像をクリックする操作は**同じ WebView2 上の SPA 遷移**なので、ライトボックスは正しく開きます。その**同じペインをレイアウトだけ変えて大きくする**方式です：

- 拡大時: 他ペインを一時 `Collapsed`、対象ペインの幅を表示領域いっぱいに
- `CoreWebView2` は作り直さない（reparent しない）→ セッション・ライトボックス・動画再生が維持される
- 原理的に画像・動画を同一機構で扱える（今回は段階1として画像の自動検知のみ実装）

## 変更
- **`Services/UrlHelper.cs`**: `IsMediaPhotoUrl` — `.../status/<id>/photo/<n>` 形式の URL 判定（純粋関数）。ユニットテスト追加。
- **`Views/MainWindow.MediaEnlarge.cs`**（新規）: `EnlargePane` / `RestorePaneSize` / `UpdateEnlargedPaneWidth`。`TimelineScroll.SizeChanged` でウィンドウリサイズにも追従。
- **`MainWindow.WebView2.cs`**: 既存の `SourceChanged` ハンドラで画像 URL を検知 → 自動拡大。画像から離脱 → 自動復元（試験機能 ON 時のみ）。
- **ペイン削除経路**（`MainWindow.Timeline.cs` の削除フロー、`MainWindow.Profiles.cs` の `RemoveTimelinesForProfile`）: 拡大中のペインが削除される場合は先に復元してから、他ペインの再表示・ディクショナリ整理を行う（ダングリング参照防止）。
- **`AppSettings.MediaEnlargeEnabled`** ＋ `SettingsViewModel` バインディング。試験機能ページにトグル追加（既定 OFF）。トグルを OFF にすると即座に復元。
- resw（ja/en）: `Settings_MediaEnlarge(_Description)`。

## 段階
1. **今回**: 画像の URL 自動検知・自動拡大/復元
2. **今後（別途）**: 動画は URL が変わらないため、手動トグル（ショートカット/ボタン）での拡大に対応

## 検証
- ビルド **0 エラー / 0 警告**
- テスト **130/130 合格**（`IsMediaPhotoUrl` の新規 7 件を含む）
- resw 両言語キー数一致（各 153）
- クリーンビルド後の起動スモーク OK

## 手動確認のおすすめ
起動中のアプリで、設定 →［試験機能］→「画像表示中はペインを拡大する」を ON にし、タイムライン内の画像付きポストをクリックして、そのペインがウィンドウいっぱいに拡大されること・画像から離れると元に戻ることを確認してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
