### PR TITLE
feat(#289): 動画再生中のペインをウィンドウ全体へ一時拡大する試験機能

### DIFF
--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -21,5 +21,6 @@ namespace XTimelineViewer.Models
         public bool    ComposePreloadEnabled { get; set; } = false;     // 投稿ウィンドウのプリロード（試験機能 #244 案B）
         public bool    ComposeResetToPrimaryEnabled { get; set; } = false; // 投稿後にプライマリへ戻す（試験機能 #285）
         public bool    MediaEnlargeEnabled   { get; set; } = false;     // 画像表示中のペインを一時拡大（試験機能 #287）
+        public bool    VideoEnlargeEnabled   { get; set; } = false;     // 動画再生中のペインを一時拡大（試験機能 #289）
     }
 }

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -113,6 +113,8 @@
   <data name="Settings_ComposeResetToPrimary_Description" xml:space="preserve"><value>After you switch accounts and post, the compose window returns to your primary profile next time. Helps avoid posting from the wrong account. Set the primary profile on the Profiles page.</value></data>
   <data name="Settings_MediaEnlarge" xml:space="preserve"><value>Enlarge pane when viewing a photo</value></data>
   <data name="Settings_MediaEnlarge_Description" xml:space="preserve"><value>When a timeline navigates to a photo (e.g. .../status/&lt;id&gt;/photo/1), temporarily enlarges that pane to fill the window. Returns to normal when you leave the photo.</value></data>
+  <data name="Settings_VideoEnlarge" xml:space="preserve"><value>Enlarge pane when playing a video</value></data>
+  <data name="Settings_VideoEnlarge_Description" xml:space="preserve"><value>When you unmute and play a video in a timeline, temporarily enlarges that pane to fill the window. Returns to normal when playback pauses or ends. Muted autoplay previews while scrolling are ignored.</value></data>
   <data name="Nav_Extensions" xml:space="preserve"><value>Extensions</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>Profiles</value></data>
   <data name="Nav_Data" xml:space="preserve"><value>User Data</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -113,6 +113,8 @@
   <data name="Settings_ComposeResetToPrimary_Description" xml:space="preserve"><value>アカウントを切り替えて投稿したあと、次回の投稿ウィンドウをプライマリプロフィールに戻します。誤ったアカウントでの投稿を防ぎます。プライマリは［プロファイル］ページで指定します。</value></data>
   <data name="Settings_MediaEnlarge" xml:space="preserve"><value>画像表示中はペインを拡大する</value></data>
   <data name="Settings_MediaEnlarge_Description" xml:space="preserve"><value>タイムラインが画像（.../status/&lt;id&gt;/photo/1 など）へ遷移したとき、そのペインを一時的にウィンドウいっぱいに拡大します。画像から離れると元に戻ります。</value></data>
+  <data name="Settings_VideoEnlarge" xml:space="preserve"><value>動画再生中はペインを拡大する</value></data>
+  <data name="Settings_VideoEnlarge_Description" xml:space="preserve"><value>タイムライン内の動画のミュートを解除して再生すると、そのペインを一時的にウィンドウいっぱいに拡大します。一時停止・終了すると元に戻ります。スクロール中のミュート自動プレビューは対象外です。</value></data>
   <data name="Nav_Extensions" xml:space="preserve"><value>拡張機能</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>プロファイル</value></data>
   <data name="Nav_Data" xml:space="preserve"><value>ユーザーデータ管理</value></data>

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -189,6 +189,18 @@ namespace XTimelineViewer.ViewModels
             }
         }
 
+        /// <summary>動画再生中のペインを一時拡大する（試験機能 #289）。</summary>
+        public bool VideoEnlargeEnabled
+        {
+            get => _settings.VideoEnlargeEnabled;
+            set
+            {
+                if (_settings.VideoEnlargeEnabled == value) return;
+                _settings.VideoEnlargeEnabled = value;
+                Notify(nameof(VideoEnlargeEnabled));
+            }
+        }
+
         public int BrowserIndex
         {
             get => Math.Max(0, Array.IndexOf(BrowserValues, _settings.ExternalBrowser));

--- a/Views/MainWindow.Post.cs
+++ b/Views/MainWindow.Post.cs
@@ -514,6 +514,18 @@ namespace XTimelineViewer.Views
                 return;
             }
 
+            if (message.StartsWith("videoPlaying:"))  // 試験機能 #289: 動画視聴中のペインを一時拡大
+            {
+                bool playing = message == "videoPlaying:true";
+                if (_appSettings.VideoEnlargeEnabled &&
+                    _webViewToPane.TryGetValue(senderWebView, out var vPane))
+                {
+                    if (playing) EnlargePane(vPane);
+                    else if (_enlargedPane == vPane) RestorePaneSize();
+                }
+                return;
+            }
+
             if (message.StartsWith("focusIndex:") &&
                 int.TryParse(message["focusIndex:".Length..], out var tlIndex))
             {

--- a/Views/MainWindow.Settings.cs
+++ b/Views/MainWindow.Settings.cs
@@ -127,7 +127,10 @@ namespace XTimelineViewer.Views
                 ApplySavedTheme();
                 UpdateThemeRadioState();
                 _ = WarmUpComposeAsync();  // 投稿プリロードの ON/OFF を即時反映（#244 案B）
-                if (!_appSettings.MediaEnlargeEnabled) RestorePaneSize();  // トグル OFF を即時反映（#287）
+                // 画像・動画拡大（#287/#289）: 両方 OFF になったときだけ即座に復元する
+                // （どちらか一方が有効なままなら、もう片方のトグルだけで現在の拡大表示を消さない）。
+                if (!_appSettings.MediaEnlargeEnabled && !_appSettings.VideoEnlargeEnabled)
+                    RestorePaneSize();
 
                 // WebView のタイムスタンプ設定を即時反映
                 var tsFlag = _appSettings.OpenTimestampInBrowser ? "true" : "false";

--- a/Views/MainWindow.WebView2.cs
+++ b/Views/MainWindow.WebView2.cs
@@ -122,6 +122,39 @@ namespace XTimelineViewer.Views
             })();
             """;
 
+        // 動画再生状態レポーター（試験機能 #289）。全ペインに注入し、動画を「本当に視聴中」と
+        // 判断できたら postMessage('videoPlaying:true'/'videoPlaying:false') で C# に通知する。
+        // X はスクロール中に動画をミュートで自動プレビュー再生するため、素直に play イベントだけを
+        // 見ると誤検知（スクロールしただけで拡大）になる。ブラウザーの仕様上「ミュートされていない
+        // 動画」は自動再生できない（ユーザー操作なしの unmuted autoplay はブロックされる）ため、
+        // 「一時停止しておらず、かつミュートされていない動画が 1 本でもあるか」を判定に使う。
+        private static readonly string VideoStateReporterScript = """
+            (function () {
+                if (window._xtvVideoWatch) return;
+                window._xtvVideoWatch = true;
+                var last = null;
+                function isWatchingVideo() {
+                    var vids = document.querySelectorAll('video');
+                    for (var i = 0; i < vids.length; i++) {
+                        var v = vids[i];
+                        if (!v.paused && !v.muted) return true;
+                    }
+                    return false;
+                }
+                function report() {
+                    var v = isWatchingVideo();
+                    if (v === last) return;
+                    last = v;
+                    try { window.chrome.webview.postMessage('videoPlaying:' + v); } catch (e) {}
+                }
+                // play/pause/volumechange はバブリングしないため capture フェーズで拾う。
+                document.addEventListener('play', report, true);
+                document.addEventListener('pause', report, true);
+                document.addEventListener('volumechange', report, true);
+                document.addEventListener('ended', report, true);
+            })();
+            """;
+
         /// <summary>cfg がホームタイムラインかどうか。</summary>
         private static bool IsHomeConfig(TimelineConfig cfg)
             => Uri.TryCreate(cfg.Url, UriKind.Absolute, out var u)
@@ -524,11 +557,12 @@ namespace XTimelineViewer.Views
                     }
                     EvaluateHardReloadPause(webView);
 
-                    // 画像表示中はペインを一時拡大する（試験機能 #287）
-                    if (_appSettings.MediaEnlargeEnabled &&
-                        _webViewToPane.TryGetValue(webView, out var pane))
+                    // 画像表示中はペインを一時拡大する（試験機能 #287）。トリガーは設定でゲートするが、
+                    // 復元はページ遷移で常に働かせる（動画視聴中に他ページへ移動した場合の保険。
+                    // 動画の主な復元は再生状態レポーター #289 の pause/ended 通知で行う）。
+                    if (_webViewToPane.TryGetValue(webView, out var pane))
                     {
-                        if (UrlHelper.IsMediaPhotoUrl(webView.CoreWebView2.Source))
+                        if (_appSettings.MediaEnlargeEnabled && UrlHelper.IsMediaPhotoUrl(webView.CoreWebView2.Source))
                             EnlargePane(pane);
                         else if (_enlargedPane == pane)
                             RestorePaneSize();
@@ -578,6 +612,8 @@ namespace XTimelineViewer.Views
             await webView.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(TimestampInterceptScript);
             // 編集状態レポーター（#258）：全ペインに注入し、編集中（リプライ/引用）を C# へ通知する。
             await webView.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(EditStateReporterScript);
+            // 動画再生状態レポーター（試験機能 #289）：全ペインに注入し、動画視聴中を C# へ通知する。
+            await webView.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(VideoStateReporterScript);
             // ホーム自動更新（#207）。ホームペインにのみ注入し、設定で ON/OFF・間隔を制御する。
             if (IsHomeConfig(cfg))
             {

--- a/Views/Settings/ExperimentalPage.xaml
+++ b/Views/Settings/ExperimentalPage.xaml
@@ -43,6 +43,15 @@
                 <ToggleSwitch x:Name="MediaEnlargeToggle"
                               IsOn="{x:Bind VM.MediaEnlargeEnabled, Mode=TwoWay}"/>
             </controls:SettingsCard>
+
+            <!-- 動画再生中のペインを一時拡大（#289）-->
+            <controls:SettingsCard x:Name="VideoEnlargeCard">
+                <controls:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE714;" FontFamily="Segoe Fluent Icons"/>
+                </controls:SettingsCard.HeaderIcon>
+                <ToggleSwitch x:Name="VideoEnlargeToggle"
+                              IsOn="{x:Bind VM.VideoEnlargeEnabled, Mode=TwoWay}"/>
+            </controls:SettingsCard>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/Views/Settings/ExperimentalPage.xaml.cs
+++ b/Views/Settings/ExperimentalPage.xaml.cs
@@ -63,6 +63,12 @@ namespace XTimelineViewer.Views.Settings
             MediaEnlargeToggle.OnContent  = R.Get("Toggle_On");
             MediaEnlargeToggle.OffContent = R.Get("Toggle_Off");
 
+            // 動画再生中のペインを一時拡大（#289）
+            VideoEnlargeCard.Header      = R.Get("Settings_VideoEnlarge");
+            VideoEnlargeCard.Description = R.Get("Settings_VideoEnlarge_Description");
+            VideoEnlargeToggle.OnContent  = R.Get("Toggle_On");
+            VideoEnlargeToggle.OffContent = R.Get("Toggle_Off");
+
             // ItemsSource 再設定で SelectedIndex が失われるため、バインディングを再評価する
             Bindings.Update();
         }


### PR DESCRIPTION
## 概要
動画再生中もペインを一時拡大する試験機能（既定 OFF）を追加します。#287 の段階2。Closes #289

## #288（画像）との違い：URL が変わらない
画像は「見る」操作がほぼ必ず別 URL（`/photo/N`）への遷移になり `SourceChanged` で検知できましたが、動画の多くは**タイムライン内でそのまま再生されるだけ**で URL が変わりません。そこで今回は**動画再生そのものを JS でフック**する方式にしました。

## 最大の課題：自動再生プレビューとの区別
X はスクロール中に動画をミュートで自動プレビュー再生します。素直に `play` イベントだけを見ると「スクロールしただけで拡大しまくる」誤検知になります。

**解決策**: ブラウザーの仕様上、**ミュートされていない動画はユーザー操作なしに自動再生できません**（autoplay policy）。したがって「一時停止しておらず、かつミュートされていない動画が1本でもある」ことを判定条件にすれば、ユーザーが明示的に再生（ミュート解除）した動画だけを検知でき、スクロール中のミュートプレビューを誤検知しません。

## 変更
- **`VideoStateReporterScript`**（新規、`MainWindow.WebView2.cs`）: `<video>` の `play`/`pause`/`volumechange`/`ended` を capture フェーズで監視し、`postMessage('videoPlaying:true'/'false')` で通知。全ペインに注入（`EditStateReporterScript` と同じパターン）。
- **`OnWebViewMessageReceived`**: `videoPlaying:` 分岐を追加し、**#288 の `EnlargePane`/`RestorePaneSize` をそのまま再利用**（reparent なし、新しい拡大機構は作らない）。
- **`SourceChanged`（#288）**: 「復元」を `MediaEnlargeEnabled`（画像トグル）に関わらず常に働くよう修正。画像トグル OFF・動画トグル ON で拡大中のペインからページ遷移した際に、正しく復元されるようにするため（「発火」の方は引き続き画像トグルでゲート）。
- **`SettingsChanged` の即時復元条件**（`MainWindow.Settings.cs`）: 画像・動画**両方**のトグルが OFF のときだけ復元するよう修正（片方だけ ON のまま他の設定を変更したときに、有効なはずの拡大表示を誤って消さないように）。
- **`AppSettings.VideoEnlargeEnabled`** ＋ `SettingsViewModel` バインディング。試験機能ページに画像用とは独立したトグルを追加（既定 OFF）。
- resw（ja/en）: `Settings_VideoEnlarge(_Description)`。

## 検証
- ビルド **0 エラー / 0 警告**
- テスト **130/130 合格**（JS/イベント駆動のため新規ユニットテストなし。既存の `EditStateReporterScript`/`HomeAutoLoadScript` と同様の位置づけ）
- resw 両言語キー数一致（各 155）
- クリーンビルド後の起動スモーク OK

## 手動確認のおすすめ
設定 →［試験機能］→「動画再生中はペインを拡大する」を ON にし、タイムライン内の動画をクリック（ミュート解除して再生）してみてください。ペインが拡大され、一時停止/終了すると元に戻るはずです。**スクロールで動画が自動再生プレビューされても拡大しない**ことも確認してください（誤検知対策の要）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
