### PR TITLE
feat(#289): 動画の全画面ボタンでペインを一時拡大する試験機能

### DIFF
--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -21,5 +21,6 @@ namespace XTimelineViewer.Models
         public bool    ComposePreloadEnabled { get; set; } = false;     // 投稿ウィンドウのプリロード（試験機能 #244 案B）
         public bool    ComposeResetToPrimaryEnabled { get; set; } = false; // 投稿後にプライマリへ戻す（試験機能 #285）
         public bool    MediaEnlargeEnabled   { get; set; } = false;     // 画像表示中のペインを一時拡大（試験機能 #287）
+        public bool    VideoEnlargeEnabled   { get; set; } = false;     // 動画の全画面ボタンでペインを一時拡大（試験機能 #289）
     }
 }

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -113,6 +113,8 @@
   <data name="Settings_ComposeResetToPrimary_Description" xml:space="preserve"><value>After you switch accounts and post, the compose window returns to your primary profile next time. Helps avoid posting from the wrong account. Set the primary profile on the Profiles page.</value></data>
   <data name="Settings_MediaEnlarge" xml:space="preserve"><value>Enlarge pane when viewing a photo</value></data>
   <data name="Settings_MediaEnlarge_Description" xml:space="preserve"><value>When a timeline navigates to a photo (e.g. .../status/&lt;id&gt;/photo/1), temporarily enlarges that pane to fill the window. Returns to normal when you leave the photo.</value></data>
+  <data name="Settings_VideoEnlarge" xml:space="preserve"><value>Enlarge pane when a video goes fullscreen</value></data>
+  <data name="Settings_VideoEnlarge_Description" xml:space="preserve"><value>When you press the fullscreen button on a video in a timeline, temporarily enlarges that pane to fill the window. Exit fullscreen to return to normal.</value></data>
   <data name="Nav_Extensions" xml:space="preserve"><value>Extensions</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>Profiles</value></data>
   <data name="Nav_Data" xml:space="preserve"><value>User Data</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -113,6 +113,8 @@
   <data name="Settings_ComposeResetToPrimary_Description" xml:space="preserve"><value>アカウントを切り替えて投稿したあと、次回の投稿ウィンドウをプライマリプロフィールに戻します。誤ったアカウントでの投稿を防ぎます。プライマリは［プロファイル］ページで指定します。</value></data>
   <data name="Settings_MediaEnlarge" xml:space="preserve"><value>画像表示中はペインを拡大する</value></data>
   <data name="Settings_MediaEnlarge_Description" xml:space="preserve"><value>タイムラインが画像（.../status/&lt;id&gt;/photo/1 など）へ遷移したとき、そのペインを一時的にウィンドウいっぱいに拡大します。画像から離れると元に戻ります。</value></data>
+  <data name="Settings_VideoEnlarge" xml:space="preserve"><value>動画の全画面ボタンでペインを拡大する</value></data>
+  <data name="Settings_VideoEnlarge_Description" xml:space="preserve"><value>タイムライン内の動画の全画面ボタンを押すと、そのペインを一時的にウィンドウいっぱいに拡大します。全画面を解除すると元に戻ります。</value></data>
   <data name="Nav_Extensions" xml:space="preserve"><value>拡張機能</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>プロファイル</value></data>
   <data name="Nav_Data" xml:space="preserve"><value>ユーザーデータ管理</value></data>

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -189,6 +189,18 @@ namespace XTimelineViewer.ViewModels
             }
         }
 
+        /// <summary>動画の全画面ボタンでペインを一時拡大する（試験機能 #289）。</summary>
+        public bool VideoEnlargeEnabled
+        {
+            get => _settings.VideoEnlargeEnabled;
+            set
+            {
+                if (_settings.VideoEnlargeEnabled == value) return;
+                _settings.VideoEnlargeEnabled = value;
+                Notify(nameof(VideoEnlargeEnabled));
+            }
+        }
+
         public int BrowserIndex
         {
             get => Math.Max(0, Array.IndexOf(BrowserValues, _settings.ExternalBrowser));

--- a/Views/MainWindow.Settings.cs
+++ b/Views/MainWindow.Settings.cs
@@ -127,7 +127,9 @@ namespace XTimelineViewer.Views
                 ApplySavedTheme();
                 UpdateThemeRadioState();
                 _ = WarmUpComposeAsync();  // 投稿プリロードの ON/OFF を即時反映（#244 案B）
-                if (!_appSettings.MediaEnlargeEnabled) RestorePaneSize();  // トグル OFF を即時反映（#287）
+                // 画像(#287)・動画(#289)拡大トグルが両方 OFF になったら即座に復元する
+                if (!_appSettings.MediaEnlargeEnabled && !_appSettings.VideoEnlargeEnabled)
+                    RestorePaneSize();
 
                 // WebView のタイムスタンプ設定を即時反映
                 var tsFlag = _appSettings.OpenTimestampInBrowser ? "true" : "false";

--- a/Views/MainWindow.WebView2.cs
+++ b/Views/MainWindow.WebView2.cs
@@ -534,6 +534,20 @@ namespace XTimelineViewer.Views
                             RestorePaneSize();
                     }
                 };
+
+                // 動画の全画面ボタン（試験機能 #289）。ページが HTML 全画面 API を要求すると発火する。
+                // 既定では WebView2 は自コントロール内で全画面表示するため、細いペイン内に収まって
+                // 戻る導線が失われる。要求を検知してペインごと拡大し、全画面解除で元に戻す。
+                // ユーザーが全画面ボタンを押したときだけ発火するので、動画の自動再生を誤検知しない。
+                webView.CoreWebView2.ContainsFullScreenElementChanged += (s, e) =>
+                {
+                    if (!_appSettings.VideoEnlargeEnabled) return;
+                    if (!_webViewToPane.TryGetValue(webView, out var pane)) return;
+                    if (webView.CoreWebView2.ContainsFullScreenElement)
+                        EnlargePane(pane);
+                    else if (_enlargedPane == pane)
+                        RestorePaneSize();
+                };
                 await LoadExtensionsAsync(webView);
                 ApplyThemeToWebViews();
             }

--- a/Views/Settings/ExperimentalPage.xaml
+++ b/Views/Settings/ExperimentalPage.xaml
@@ -43,6 +43,15 @@
                 <ToggleSwitch x:Name="MediaEnlargeToggle"
                               IsOn="{x:Bind VM.MediaEnlargeEnabled, Mode=TwoWay}"/>
             </controls:SettingsCard>
+
+            <!-- 動画の全画面ボタンでペインを一時拡大（#289）-->
+            <controls:SettingsCard x:Name="VideoEnlargeCard">
+                <controls:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE740;" FontFamily="Segoe Fluent Icons"/>
+                </controls:SettingsCard.HeaderIcon>
+                <ToggleSwitch x:Name="VideoEnlargeToggle"
+                              IsOn="{x:Bind VM.VideoEnlargeEnabled, Mode=TwoWay}"/>
+            </controls:SettingsCard>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/Views/Settings/ExperimentalPage.xaml.cs
+++ b/Views/Settings/ExperimentalPage.xaml.cs
@@ -63,6 +63,11 @@ namespace XTimelineViewer.Views.Settings
             MediaEnlargeToggle.OnContent  = R.Get("Toggle_On");
             MediaEnlargeToggle.OffContent = R.Get("Toggle_Off");
 
+            VideoEnlargeCard.Header      = R.Get("Settings_VideoEnlarge");
+            VideoEnlargeCard.Description = R.Get("Settings_VideoEnlarge_Description");
+            VideoEnlargeToggle.OnContent  = R.Get("Toggle_On");
+            VideoEnlargeToggle.OffContent = R.Get("Toggle_Off");
+
             // ItemsSource 再設定で SelectedIndex が失われるため、バインディングを再評価する
             Bindings.Update();
         }


### PR DESCRIPTION
## 概要
動画の**全画面ボタン**を押したときに、そのペインをウィンドウいっぱいへ一時拡大する試験機能（既定 OFF）を追加します。Closes #289

## 発想の転換
当初は動画の再生（play / volumechange）を検知して拡大しようとしたが、X はスクロール中に動画をミュートで自動再生するため誤検知が多発し、レイアウト崩れ・戻れない等の問題が続いた。

**ユーザーが明確な意図を持って押す「全画面ボタン」= HTML 全画面 API の要求**をトリガーにすることで、これらを一挙に解決した:
- 全画面ボタンを押したときだけ発火 → **自動再生の誤検知が原理的にゼロ**
- 既定では WebView2 は自コントロール内で全画面表示するため細いペイン内に収まり戻る導線が消えるが、**ペインごと拡大**すれば X 自身の全画面解除 UI が使える → 既存の「戻れない」不便も解消
- 実装は `CoreWebView2.ContainsFullScreenElementChanged` の購読のみ（**JS 注入不要**）

## 変更
- **`MainWindow.WebView2.cs`**: `ContainsFullScreenElementChanged` を購読し、`ContainsFullScreenElement` の true/false で #287/#288 の `EnlargePane`/`RestorePaneSize` を呼ぶ（再利用）。
- **`AppSettings.VideoEnlargeEnabled`** ＋ `SettingsViewModel` バインディング、試験機能ページにトグル追加（既定 OFF）。両拡大トグルが OFF になったら即復元。
- resw（ja/en）: `Settings_VideoEnlarge(_Description)`。

## 検証
- ビルド 0 エラー/0 警告・テスト **130/130**・resw 両言語一致（各155）
- クリーンビルド後、実機で **全画面ボタン→拡大／解除→復帰／自動再生で誤検知なし**を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)