### PR TITLE
feat(#293): メディアに自前の拡大ボタンを重ね、メディアだけを全画面表示する

### DIFF
--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -22,5 +22,6 @@ namespace XTimelineViewer.Models
         public bool    ComposeResetToPrimaryEnabled { get; set; } = false; // 投稿後にプライマリへ戻す（試験機能 #285）
         public bool    MediaEnlargeEnabled   { get; set; } = false;     // 画像表示中のペインを一時拡大（試験機能 #287）
         public bool    VideoEnlargeEnabled   { get; set; } = false;     // 動画の全画面ボタンでペインを一時拡大（試験機能 #289）
+        public bool    MediaOverlayButtonEnabled { get; set; } = false; // メディアに自前の拡大ボタンを重ねる（試験機能 #293）
     }
 }

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -115,6 +115,8 @@
   <data name="Settings_MediaEnlarge_Description" xml:space="preserve"><value>When a timeline navigates to a photo (e.g. .../status/&lt;id&gt;/photo/1), temporarily enlarges that pane to fill the window. Returns to normal when you leave the photo.</value></data>
   <data name="Settings_VideoEnlarge" xml:space="preserve"><value>Enlarge pane when a video goes fullscreen</value></data>
   <data name="Settings_VideoEnlarge_Description" xml:space="preserve"><value>When you press the fullscreen button on a video in a timeline, temporarily enlarges that pane to fill the window. Exit fullscreen to return to normal.</value></data>
+  <data name="Settings_MediaOverlayButton" xml:space="preserve"><value>Show an enlarge button on media</value></data>
+  <data name="Settings_MediaOverlayButton_Description" xml:space="preserve"><value>Overlays an enlarge button on photos and videos in timelines. Press it to show just that media full-screen (press Esc or the ✕ button to return).</value></data>
   <data name="Nav_Extensions" xml:space="preserve"><value>Extensions</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>Profiles</value></data>
   <data name="Nav_Data" xml:space="preserve"><value>User Data</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -115,6 +115,8 @@
   <data name="Settings_MediaEnlarge_Description" xml:space="preserve"><value>タイムラインが画像（.../status/&lt;id&gt;/photo/1 など）へ遷移したとき、そのペインを一時的にウィンドウいっぱいに拡大します。画像から離れると元に戻ります。</value></data>
   <data name="Settings_VideoEnlarge" xml:space="preserve"><value>動画の全画面ボタンでペインを拡大する</value></data>
   <data name="Settings_VideoEnlarge_Description" xml:space="preserve"><value>タイムライン内の動画の全画面ボタンを押すと、そのペインを一時的にウィンドウいっぱいに拡大します。全画面を解除すると元に戻ります。</value></data>
+  <data name="Settings_MediaOverlayButton" xml:space="preserve"><value>メディアに拡大ボタンを表示する</value></data>
+  <data name="Settings_MediaOverlayButton_Description" xml:space="preserve"><value>タイムラインの画像・動画に拡大ボタンを重ねます。押すとそのメディアだけを画面いっぱいに表示します（Esc または ✕ ボタンで戻る）。</value></data>
   <data name="Nav_Extensions" xml:space="preserve"><value>拡張機能</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>プロファイル</value></data>
   <data name="Nav_Data" xml:space="preserve"><value>ユーザーデータ管理</value></data>

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -201,6 +201,18 @@ namespace XTimelineViewer.ViewModels
             }
         }
 
+        /// <summary>メディアに自前の拡大ボタンを重ねる（試験機能 #293）。</summary>
+        public bool MediaOverlayButtonEnabled
+        {
+            get => _settings.MediaOverlayButtonEnabled;
+            set
+            {
+                if (_settings.MediaOverlayButtonEnabled == value) return;
+                _settings.MediaOverlayButtonEnabled = value;
+                Notify(nameof(MediaOverlayButtonEnabled));
+            }
+        }
+
         public int BrowserIndex
         {
             get => Math.Max(0, Array.IndexOf(BrowserValues, _settings.ExternalBrowser));

--- a/Views/MainWindow.Settings.cs
+++ b/Views/MainWindow.Settings.cs
@@ -138,6 +138,11 @@ namespace XTimelineViewer.Views
                         _ = wv.CoreWebView2.ExecuteScriptAsync(
                             $"window._xtvOpenTimestampInBrowser = {tsFlag};");
 
+                // メディア拡大ボタン（#293）の ON/OFF を各ペインへ即時反映
+                foreach (var wv in _webViews)
+                    if (wv.CoreWebView2 is not null)
+                        _ = ApplyMediaOverlayButtonAsync(wv);
+
                 // ホーム自動更新（#207）の ON/OFF・間隔を各ホームペインへ即時反映し、インジケーターも更新
                 foreach (var (homePane, _) in _autoLoadIndicators)
                 {

--- a/Views/MainWindow.WebView2.cs
+++ b/Views/MainWindow.WebView2.cs
@@ -122,6 +122,103 @@ namespace XTimelineViewer.Views
             })();
             """;
 
+        // メディア拡大ボタンのオーバーレイ（試験機能 #293）。全ペインに注入し、タイムライン上の
+        // 画像・動画コンテナに「⛶」ボタンを重ねる。押すとそのメディアコンテナを requestFullscreen()
+        // で全画面表示し（＝メディアだけにフォーカス）、WebView2 の ContainsFullScreenElement が立って
+        // 既存の全画面フック（#291）でペインが画面いっぱいに拡大される。全画面中は「✕」ボタンを重ね、
+        // Esc とあわせて戻れる。window._xtvMediaOverlayEnabled で ON/OFF を制御する。
+        private static readonly string MediaOverlayButtonScript = """
+            (function () {
+                if (window._xtvMediaBtn) return;
+                window._xtvMediaBtn = true;
+
+                var SEL = '[data-testid="tweetPhoto"], [data-testid="videoPlayer"], [data-testid="videoComponent"]';
+
+                function addStyle() {
+                    if (document.getElementById('xtv-media-btn-style')) return;
+                    var s = document.createElement('style');
+                    s.id = 'xtv-media-btn-style';
+                    s.textContent =
+                        '.xtv-enlarge-btn{position:absolute;top:8px;right:8px;z-index:9999;width:34px;height:34px;' +
+                        'border:none;border-radius:6px;background:rgba(0,0,0,0.6);color:#fff;font-size:16px;' +
+                        'cursor:pointer;display:flex;align-items:center;justify-content:center;opacity:0;transition:opacity .15s;}' +
+                        '.xtv-enlarge-host:hover .xtv-enlarge-btn{opacity:1;}' +
+                        '.xtv-fs-close{position:fixed;top:16px;right:16px;z-index:2147483647;width:46px;height:46px;' +
+                        'border:none;border-radius:8px;background:rgba(0,0,0,0.7);color:#fff;font-size:22px;cursor:pointer;}';
+                    (document.head || document.documentElement).appendChild(s);
+                }
+
+                function attach(container) {
+                    if (!window._xtvMediaOverlayEnabled) return;
+                    if (container.__xtvBtn) return;
+                    container.__xtvBtn = true;
+                    container.classList.add('xtv-enlarge-host');
+                    if (getComputedStyle(container).position === 'static') container.style.position = 'relative';
+                    var btn = document.createElement('button');
+                    btn.className = 'xtv-enlarge-btn';
+                    btn.type = 'button';
+                    btn.textContent = '⛶';
+                    btn.addEventListener('click', function (e) {
+                        e.preventDefault(); e.stopPropagation();
+                        try { if (container.requestFullscreen) container.requestFullscreen(); } catch (x) {}
+                    }, true);
+                    container.appendChild(btn);
+                }
+
+                function scan() {
+                    if (!window._xtvMediaOverlayEnabled) return;
+                    var list = document.querySelectorAll(SEL);
+                    for (var i = 0; i < list.length; i++) attach(list[i]);
+                }
+                window._xtvMediaBtnRescan = scan;  // C# から ON 切り替え時に既存メディアへ付与するため
+
+                // 全画面中は「✕」ボタンを全画面要素に重ねる（Esc でも解除できる）。
+                function onFsChange() {
+                    var fsEl = document.fullscreenElement;
+                    var existing = document.querySelector('.xtv-fs-close');
+                    if (fsEl) {
+                        if (!existing) {
+                            var c = document.createElement('button');
+                            c.className = 'xtv-fs-close';
+                            c.type = 'button';
+                            c.textContent = '✕';
+                            c.addEventListener('click', function (e) {
+                                e.preventDefault(); e.stopPropagation();
+                                try { if (document.exitFullscreen) document.exitFullscreen(); } catch (x) {}
+                            }, true);
+                            fsEl.appendChild(c);
+                        }
+                    } else if (existing) {
+                        existing.remove();
+                    }
+                }
+                document.addEventListener('fullscreenchange', onFsChange, true);
+
+                var obs = new MutationObserver(function () { scan(); });
+                function start() {
+                    addStyle();
+                    obs.observe(document.body || document.documentElement, { childList: true, subtree: true });
+                    scan();
+                }
+                document.readyState === 'loading' ? document.addEventListener('DOMContentLoaded', start) : start();
+            })();
+            """;
+
+        /// <summary>現在の設定を、メディア拡大ボタンの JS 制御変数へ反映するスニペット（#293）。</summary>
+        private string BuildMediaOverlayButtonConfigJs()
+            => $"window._xtvMediaOverlayEnabled = {(_appSettings.MediaOverlayButtonEnabled ? "true" : "false")};";
+
+        /// <summary>メディア拡大ボタンの ON/OFF を各ペインへ即時反映する（#293）。</summary>
+        private async Task ApplyMediaOverlayButtonAsync(WebView2 webView)
+        {
+            try
+            {
+                await webView.CoreWebView2.ExecuteScriptAsync(BuildMediaOverlayButtonConfigJs());
+                await webView.CoreWebView2.ExecuteScriptAsync("window._xtvMediaBtnRescan && window._xtvMediaBtnRescan();");
+            }
+            catch { }
+        }
+
         /// <summary>cfg がホームタイムラインかどうか。</summary>
         private static bool IsHomeConfig(TimelineConfig cfg)
             => Uri.TryCreate(cfg.Url, UriKind.Absolute, out var u)
@@ -539,9 +636,11 @@ namespace XTimelineViewer.Views
                 // 既定では WebView2 は自コントロール内で全画面表示するため、細いペイン内に収まって
                 // 戻る導線が失われる。要求を検知してペインごと拡大し、全画面解除で元に戻す。
                 // ユーザーが全画面ボタンを押したときだけ発火するので、動画の自動再生を誤検知しない。
+                // 動画の全画面ボタン（#289）に加え、メディア拡大ボタン（#293）から requestFullscreen した
+                // ときもここに合流する。どちらのトグルも OFF なら何もしない。
                 webView.CoreWebView2.ContainsFullScreenElementChanged += (s, e) =>
                 {
-                    if (!_appSettings.VideoEnlargeEnabled) return;
+                    if (!_appSettings.VideoEnlargeEnabled && !_appSettings.MediaOverlayButtonEnabled) return;
                     if (!_webViewToPane.TryGetValue(webView, out var pane)) return;
                     if (webView.CoreWebView2.ContainsFullScreenElement)
                         EnlargePane(pane);
@@ -592,6 +691,9 @@ namespace XTimelineViewer.Views
             await webView.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(TimestampInterceptScript);
             // 編集状態レポーター（#258）：全ペインに注入し、編集中（リプライ/引用）を C# へ通知する。
             await webView.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(EditStateReporterScript);
+            // メディア拡大ボタン（#293）：全ペインに注入。config を先に入れてから本体を注入する。
+            await webView.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(BuildMediaOverlayButtonConfigJs());
+            await webView.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(MediaOverlayButtonScript);
             // ホーム自動更新（#207）。ホームペインにのみ注入し、設定で ON/OFF・間隔を制御する。
             if (IsHomeConfig(cfg))
             {

--- a/Views/Settings/ExperimentalPage.xaml
+++ b/Views/Settings/ExperimentalPage.xaml
@@ -52,6 +52,15 @@
                 <ToggleSwitch x:Name="VideoEnlargeToggle"
                               IsOn="{x:Bind VM.VideoEnlargeEnabled, Mode=TwoWay}"/>
             </controls:SettingsCard>
+
+            <!-- メディアに自前の拡大ボタンを重ねる（#293）-->
+            <controls:SettingsCard x:Name="MediaOverlayButtonCard">
+                <controls:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE740;" FontFamily="Segoe Fluent Icons"/>
+                </controls:SettingsCard.HeaderIcon>
+                <ToggleSwitch x:Name="MediaOverlayButtonToggle"
+                              IsOn="{x:Bind VM.MediaOverlayButtonEnabled, Mode=TwoWay}"/>
+            </controls:SettingsCard>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/Views/Settings/ExperimentalPage.xaml.cs
+++ b/Views/Settings/ExperimentalPage.xaml.cs
@@ -68,6 +68,11 @@ namespace XTimelineViewer.Views.Settings
             VideoEnlargeToggle.OnContent  = R.Get("Toggle_On");
             VideoEnlargeToggle.OffContent = R.Get("Toggle_Off");
 
+            MediaOverlayButtonCard.Header      = R.Get("Settings_MediaOverlayButton");
+            MediaOverlayButtonCard.Description = R.Get("Settings_MediaOverlayButton_Description");
+            MediaOverlayButtonToggle.OnContent  = R.Get("Toggle_On");
+            MediaOverlayButtonToggle.OffContent = R.Get("Toggle_Off");
+
             // ItemsSource 再設定で SelectedIndex が失われるため、バインディングを再評価する
             Bindings.Update();
         }


### PR DESCRIPTION
## 概要
画像・動画を区別せず、タイムラインのメディアに**自前の「⛶」拡大ボタン**を重ね、押すと**そのメディアだけ**を画面いっぱいに表示する試験機能（既定 OFF）です。Closes #293

## 仕組み（画像・動画で1経路に統一）
- 全ペインに JS を注入し、`MutationObserver` で画像 `tweetPhoto` / 動画 `videoPlayer` コンテナに「⛶」ボタンを重ねる（ホバーで表示）。
- ボタンのクリック（ユーザー操作）で、そのコンテナを **`requestFullscreen()`** → メディアだけが全画面表示（周囲のコメント等が消える）。
- `requestFullscreen` で WebView2 の `ContainsFullScreenElement` が立つので、**#291 の既存フックにそのまま合流**してペインを画面いっぱいに拡大。画像・動画とも同一経路。
- **戻り**: 全画面中に「✕」ボタンを重ね、**Esc**（Fullscreen API 標準）でも解除。

## 効果
- **明示クリック起点なので自動再生の誤検知ゼロ**。
- 標準 Fullscreen API に依存しないケース（#292 の複数動画ポスト等）も、このボタンで拾える。
- 既存の画像自動拡大（#288）・動画全画面フック（#291）はそのまま残す（案2: 二段構え）。

## 変更
- `MainWindow.WebView2.cs`: `MediaOverlayButtonScript`（注入）、フックのゲートを `VideoEnlargeEnabled || MediaOverlayButtonEnabled` に拡張、`ApplyMediaOverlayButtonAsync`。
- `AppSettings.MediaOverlayButtonEnabled` ＋ `SettingsViewModel`、試験機能ページにトグル（既定 OFF）、`SettingsChanged` で即時反映。
- resw(ja/en): `Settings_MediaOverlayButton(_Description)`。

## 検証
- ビルド 0 エラー/0 警告・テスト **130/130**・resw 両言語一致（各157）
- クリーンビルド後、実機で画像・動画の拡大／戻り（ESC・✕）／誤検知なしを確認

## 備考
- ボタン付与は X の DOM セレクタ（`data-testid`）依存。構造変更で「ボタンが出ないだけ」になるが実害小。

🤖 Generated with [Claude Code](https://claude.com/claude-code)