### PR TITLE
feat(#299): 動画の現在フレームを画像として保存（試験機能）

### DIFF
--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -23,5 +23,6 @@ namespace XTimelineViewer.Models
         public bool    MediaEnlargeEnabled   { get; set; } = false;     // 画像表示中のペインを一時拡大（試験機能 #287）
         public bool    VideoEnlargeEnabled   { get; set; } = false;     // 動画の全画面ボタンでペインを一時拡大（試験機能 #289）
         public bool    MediaOverlayButtonEnabled { get; set; } = false; // メディアに自前の拡大ボタンを重ねる（試験機能 #293）
+        public bool    VideoFrameSaveEnabled { get; set; } = false;     // 動画の現在フレームを画像保存（試験機能 #299）
     }
 }

--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -117,6 +117,12 @@
   <data name="Settings_VideoEnlarge_Description" xml:space="preserve"><value>When you press the fullscreen button on a video in a timeline, temporarily enlarges that pane to fill the window. Exit fullscreen to return to normal.</value></data>
   <data name="Settings_MediaOverlayButton" xml:space="preserve"><value>Show an enlarge button on media</value></data>
   <data name="Settings_MediaOverlayButton_Description" xml:space="preserve"><value>Overlays an enlarge button on photos and videos in timelines. Press it to show just that media full-screen (press Esc or the ✕ button to return).</value></data>
+  <data name="MediaFrameSave_Tooltip" xml:space="preserve"><value>Save frame</value></data>
+  <data name="MediaFrameSave_Saved" xml:space="preserve"><value>Frame saved</value></data>
+  <data name="MediaFrameSave_Failed" xml:space="preserve"><value>Couldn't save frame</value></data>
+  <data name="Settings_VideoFrameSave" xml:space="preserve"><value>Save a video frame as an image</value></data>
+  <data name="Settings_VideoFrameSave_Description" xml:space="preserve"><value>Shows a save button at the top-right when a video is full-screen. Press it to save the currently shown frame as a PNG to Pictures\XTimelineViewer.</value></data>
+  <data name="Settings_VideoFrameSave_OpenFolder" xml:space="preserve"><value>Open the save folder</value></data>
   <data name="Nav_Extensions" xml:space="preserve"><value>Extensions</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>Profiles</value></data>
   <data name="Nav_Data" xml:space="preserve"><value>User Data</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -117,6 +117,12 @@
   <data name="Settings_VideoEnlarge_Description" xml:space="preserve"><value>タイムライン内の動画の全画面ボタンを押すと、そのペインを一時的にウィンドウいっぱいに拡大します。全画面を解除すると元に戻ります。</value></data>
   <data name="Settings_MediaOverlayButton" xml:space="preserve"><value>メディアに拡大ボタンを表示する</value></data>
   <data name="Settings_MediaOverlayButton_Description" xml:space="preserve"><value>タイムラインの画像・動画に拡大ボタンを重ねます。押すとそのメディアだけを画面いっぱいに表示します（Esc または ✕ ボタンで戻る）。</value></data>
+  <data name="MediaFrameSave_Tooltip" xml:space="preserve"><value>フレームを保存</value></data>
+  <data name="MediaFrameSave_Saved" xml:space="preserve"><value>フレームを保存しました</value></data>
+  <data name="MediaFrameSave_Failed" xml:space="preserve"><value>フレームを保存できませんでした</value></data>
+  <data name="Settings_VideoFrameSave" xml:space="preserve"><value>動画のフレームを画像として保存する</value></data>
+  <data name="Settings_VideoFrameSave_Description" xml:space="preserve"><value>動画を全画面表示したとき、右上に保存ボタンを表示します。押すと今表示しているフレームを PNG 画像として「ピクチャ\XTimelineViewer」に保存します。</value></data>
+  <data name="Settings_VideoFrameSave_OpenFolder" xml:space="preserve"><value>保存先フォルダーを開く</value></data>
   <data name="Nav_Extensions" xml:space="preserve"><value>拡張機能</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>プロファイル</value></data>
   <data name="Nav_Data" xml:space="preserve"><value>ユーザーデータ管理</value></data>

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -213,6 +213,18 @@ namespace XTimelineViewer.ViewModels
             }
         }
 
+        /// <summary>動画の現在フレームを画像保存（試験機能 #299）。</summary>
+        public bool VideoFrameSaveEnabled
+        {
+            get => _settings.VideoFrameSaveEnabled;
+            set
+            {
+                if (_settings.VideoFrameSaveEnabled == value) return;
+                _settings.VideoFrameSaveEnabled = value;
+                Notify(nameof(VideoFrameSaveEnabled));
+            }
+        }
+
         public int BrowserIndex
         {
             get => Math.Max(0, Array.IndexOf(BrowserValues, _settings.ExternalBrowser));

--- a/Views/MainWindow.Post.cs
+++ b/Views/MainWindow.Post.cs
@@ -4,6 +4,7 @@ using Microsoft.UI.Xaml.Media;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Web.WebView2.Core;
@@ -528,6 +529,15 @@ namespace XTimelineViewer.Views
                 return;
             }
 
+            if (message.StartsWith("saveFrame:"))  // #299: 動画の現在フレームを PNG 保存
+            {
+                // 形式: saveFrame:<handle>|<status>|<base64>
+                var parts = message["saveFrame:".Length..].Split('|', 3);
+                if (parts.Length == 3)
+                    _ = SaveVideoFrameAsync(senderWebView, parts[0], parts[1], parts[2]);
+                return;
+            }
+
             switch (message)
             {
                 case "focusNext": FocusAdjacentTimeline(senderWebView, +1); break;
@@ -551,6 +561,51 @@ namespace XTimelineViewer.Views
                     EnsureWebViewKeyboardFocus(senderWebView);
                     break;
             }
+        }
+
+        // 動画の現在フレーム（base64 PNG）を Pictures\XTimelineViewer に保存する（#299・試験機能）。
+        // ファイル名は <handle>_<statusId>_<保存時刻> で元ポスト（x.com/handle/status/statusId）を辿れる。
+        private async Task SaveVideoFrameAsync(WebView2 senderWebView, string handle, string status, string base64Png)
+        {
+            string? savedName = null;
+            try
+            {
+                var bytes = Convert.FromBase64String(base64Png);
+                var dir = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.MyPictures),
+                    "XTimelineViewer");
+                Directory.CreateDirectory(dir);
+                // 保存時刻はミリ秒まで付けて同一秒内の連続保存でも衝突しないようにする。
+                var name = $"{SanitizeNamePart(handle, "unknown")}_{SanitizeNamePart(status, "noid")}"
+                         + $"_{DateTime.Now:yyyyMMdd_HHmmss_fff}.png";
+                await File.WriteAllBytesAsync(Path.Combine(dir, name), bytes);
+                savedName = name;
+            }
+            catch (Exception ex)
+            {
+                LogError("SaveVideoFrame", ex);
+            }
+
+            // 保存結果を WebView へ返してトースト表示させる（全画面中は XAML ダイアログが
+            // WebView2 の裏に隠れるため、フィードバックはページ内で出す）。
+            DispatcherQueue.TryEnqueue(() =>
+            {
+                try
+                {
+                    senderWebView.CoreWebView2?.PostWebMessageAsString(
+                        savedName is null ? "frameError" : "frameSaved:" + savedName);
+                }
+                catch { }
+            });
+        }
+
+        // ファイル名の一部（handle / statusId）を安全化する。空ならフォールバックを返す。
+        private static string SanitizeNamePart(string value, string fallback)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return fallback;
+            foreach (var c in Path.GetInvalidFileNameChars())
+                value = value.Replace(c, '_');
+            return value;
         }
 
         // WebView2 コンテンツに実際のキーボードフォーカスを確実に当てる（#251）。

--- a/Views/MainWindow.WebView2.cs
+++ b/Views/MainWindow.WebView2.cs
@@ -156,6 +156,13 @@ namespace XTimelineViewer.Views
                         ':fullscreen .xtv-enlarge-btn{display:none!important;}' +
                         '.xtv-fs-close{position:fixed;top:16px;right:16px;z-index:2147483647;width:46px;height:46px;' +
                         'border:none;border-radius:8px;background:rgba(0,0,0,0.7);color:#fff;font-size:22px;cursor:pointer;}' +
+                        // 動画フレーム保存ボタン（#299）：全画面中に ✕ の左へ置く。
+                        '.xtv-fs-save{position:fixed;top:16px;right:72px;z-index:2147483647;width:46px;height:46px;' +
+                        'border:none;border-radius:8px;background:rgba(0,0,0,0.7);color:#fff;cursor:pointer;' +
+                        'display:flex;align-items:center;justify-content:center;}' +
+                        '.xtv-toast{position:fixed;left:50%;bottom:44px;transform:translateX(-50%);z-index:2147483647;' +
+                        'background:rgba(0,0,0,0.85);color:#fff;padding:10px 16px;border-radius:8px;font-size:14px;' +
+                        'max-width:80vw;text-align:center;pointer-events:none;}' +
                         '.xtv-img-viewer{position:fixed;inset:0;width:100%;height:100%;background:#000;' +
                         'display:flex;align-items:center;justify-content:center;overflow:hidden;}' +
                         '.xtv-img-viewer img{max-width:100%;max-height:100%;width:auto;height:auto;object-fit:contain;}';
@@ -252,6 +259,54 @@ namespace XTimelineViewer.Views
                 }
                 window._xtvMediaBtnRescan = scan;  // C# から ON 切り替え時に既存メディアへ付与するため
 
+                // ── 動画フレーム保存（#299）──
+                // 全画面中の <video> の現在フレームを canvas に焼き、base64 PNG を C# に送って保存する。
+                // 全画面中は全画面要素の子孫しか描画されないため、トーストは全画面要素側へ挿入する。
+                function showToast(msg) {
+                    var host = document.fullscreenElement || document.body;
+                    if (!host) return;
+                    var t = document.createElement('div');
+                    t.className = 'xtv-toast';
+                    t.textContent = msg;
+                    host.appendChild(t);
+                    setTimeout(function () { t.remove(); }, 2200);
+                }
+                // 動画が属するツイートの handle / status ID を求める（ファイル名でソースを辿れるように）。
+                // 全画面中でも article は DOM に残るので closest で辿れる。取得失敗時は空を返す。
+                function getTweetRef(el) {
+                    try {
+                        var tw = el.closest('[data-testid="tweet"]');
+                        if (!tw) return { handle: '', status: '' };
+                        var timeA = tw.querySelector('a[href*="/status/"] time');
+                        var a = timeA ? timeA.closest('a') : tw.querySelector('a[href*="/status/"]');
+                        var m = a && (a.getAttribute('href') || '').match(/^\/([^\/]+)\/status\/(\d+)/);
+                        return m ? { handle: m[1], status: m[2] } : { handle: '', status: '' };
+                    } catch (e) { return { handle: '', status: '' }; }
+                }
+                function captureFrame(video) {
+                    if (!video || !video.videoWidth || !video.videoHeight) return false;
+                    try {
+                        var c = document.createElement('canvas');
+                        c.width = video.videoWidth; c.height = video.videoHeight;
+                        c.getContext('2d').drawImage(video, 0, 0, c.width, c.height);
+                        var url = c.toDataURL('image/png');
+                        var r = getTweetRef(video);
+                        // 形式: saveFrame:<handle>|<status>|<base64>（handle/status は英数と _ のみで | を含まない）
+                        window.chrome.webview.postMessage('saveFrame:' + r.handle + '|' + r.status + '|' + url.slice(url.indexOf(',') + 1));
+                        return true;
+                    } catch (e) { return false; }
+                }
+                // C# 側の保存結果を受けてトーストを出す。
+                try {
+                    window.chrome.webview.addEventListener('message', function (e) {
+                        var d = e.data;
+                        if (typeof d !== 'string') return;
+                        var L = window._xtvFrameSaveL || {};
+                        if (d.indexOf('frameSaved:') === 0) showToast(L.saved || 'Saved');
+                        else if (d === 'frameError') showToast(L.failed || 'Failed');
+                    });
+                } catch (x) {}
+
                 // 全画面中は「✕」ボタンを全画面要素に重ねる（Esc でも解除できる）。
                 // 画像ビューア（.xtv-img-viewer）は自前で ✕ を内包するのでここでは付けない。
                 function onFsChange() {
@@ -268,12 +323,27 @@ namespace XTimelineViewer.Views
                             }, true);
                             fsEl.appendChild(c);
                         }
+                        // 動画かつ試験機能 ON なら「フレーム保存」ボタンを ✕ の左に置く（#299）。
+                        if (window._xtvFrameSaveEnabled && fsEl.querySelector('video') && !fsEl.querySelector(':scope > .xtv-fs-save')) {
+                            var L = window._xtvFrameSaveL || {};
+                            var sv = document.createElement('button');
+                            sv.className = 'xtv-fs-save';
+                            sv.type = 'button';
+                            sv.title = L.tip || 'Save frame';
+                            sv.innerHTML = '<svg viewBox="0 0 24 24" width="22" height="22" fill="#fff"><path d="M20 5h-3.17L15 3H9L7.17 5H4a2 2 0 00-2 2v12a2 2 0 002 2h16a2 2 0 002-2V7a2 2 0 00-2-2zm-8 13a5 5 0 110-10 5 5 0 010 10zm0-8a3 3 0 100 6 3 3 0 000-6z"></path></svg>';
+                            sv.addEventListener('click', function (e) {
+                                e.preventDefault(); e.stopPropagation();
+                                var video = fsEl.querySelector('video');
+                                if (!captureFrame(video)) showToast((window._xtvFrameSaveL || {}).failed || 'Failed');
+                            }, true);
+                            fsEl.appendChild(sv);
+                        }
                     } else if (!fsEl) {
-                        // 全画面終了: 画像ビューアと、動画コンテナに付けた ✕ を後始末する。
+                        // 全画面終了: 画像ビューアと、動画コンテナに付けた ✕・保存ボタン・トーストを後始末する。
                         var v = document.querySelector('.xtv-img-viewer');
                         if (v) v.remove();
-                        var leftover = document.querySelector('.xtv-fs-close');
-                        if (leftover) leftover.remove();
+                        document.querySelectorAll('.xtv-fs-close, .xtv-fs-save, .xtv-toast')
+                               .forEach(function (x) { x.remove(); });
                     }
                 }
                 document.addEventListener('fullscreenchange', onFsChange, true);
@@ -288,9 +358,20 @@ namespace XTimelineViewer.Views
             })();
             """;
 
-        /// <summary>現在の設定を、メディア拡大ボタンの JS 制御変数へ反映するスニペット（#293）。</summary>
+        /// <summary>現在の設定を、メディア拡大ボタンの JS 制御変数へ反映するスニペット（#293）。
+        /// フレーム保存（#299）のローカライズ文言もここで JS へ渡す。</summary>
         private string BuildMediaOverlayButtonConfigJs()
-            => $"window._xtvMediaOverlayEnabled = {(_appSettings.MediaOverlayButtonEnabled ? "true" : "false")};";
+        {
+            var labels = System.Text.Json.JsonSerializer.Serialize(new
+            {
+                tip    = R.Get("MediaFrameSave_Tooltip"),
+                saved  = R.Get("MediaFrameSave_Saved"),
+                failed = R.Get("MediaFrameSave_Failed"),
+            });
+            return $"window._xtvMediaOverlayEnabled = {(_appSettings.MediaOverlayButtonEnabled ? "true" : "false")};"
+                 + $"window._xtvFrameSaveEnabled = {(_appSettings.VideoFrameSaveEnabled ? "true" : "false")};"
+                 + $"window._xtvFrameSaveL = {labels};";
+        }
 
         /// <summary>メディア拡大ボタンの ON/OFF を各ペインへ即時反映する（#293）。</summary>
         private async Task ApplyMediaOverlayButtonAsync(WebView2 webView)

--- a/Views/Settings/ExperimentalPage.xaml
+++ b/Views/Settings/ExperimentalPage.xaml
@@ -61,6 +61,19 @@
                 <ToggleSwitch x:Name="MediaOverlayButtonToggle"
                               IsOn="{x:Bind VM.MediaOverlayButtonEnabled, Mode=TwoWay}"/>
             </controls:SettingsCard>
+
+            <!-- 動画の現在フレームを画像保存（#299）-->
+            <controls:SettingsCard x:Name="VideoFrameSaveCard">
+                <controls:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE722;" FontFamily="Segoe Fluent Icons"/>
+                </controls:SettingsCard.HeaderIcon>
+                <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                    <HyperlinkButton x:Name="VideoFrameSaveOpenFolder"
+                                     Click="VideoFrameSaveOpenFolder_Click"/>
+                    <ToggleSwitch x:Name="VideoFrameSaveToggle"
+                                  IsOn="{x:Bind VM.VideoFrameSaveEnabled, Mode=TwoWay}"/>
+                </StackPanel>
+            </controls:SettingsCard>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/Views/Settings/ExperimentalPage.xaml.cs
+++ b/Views/Settings/ExperimentalPage.xaml.cs
@@ -1,6 +1,10 @@
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
+using System;
 using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
 using XTimelineViewer.ViewModels;
 
 namespace XTimelineViewer.Views.Settings
@@ -73,8 +77,29 @@ namespace XTimelineViewer.Views.Settings
             MediaOverlayButtonToggle.OnContent  = R.Get("Toggle_On");
             MediaOverlayButtonToggle.OffContent = R.Get("Toggle_Off");
 
+            // 動画の現在フレームを画像保存（#299）
+            VideoFrameSaveCard.Header      = R.Get("Settings_VideoFrameSave");
+            VideoFrameSaveCard.Description = R.Get("Settings_VideoFrameSave_Description");
+            VideoFrameSaveOpenFolder.Content = R.Get("Settings_VideoFrameSave_OpenFolder");
+            VideoFrameSaveToggle.OnContent  = R.Get("Toggle_On");
+            VideoFrameSaveToggle.OffContent = R.Get("Toggle_Off");
+
             // ItemsSource 再設定で SelectedIndex が失われるため、バインディングを再評価する
             Bindings.Update();
+        }
+
+        // 動画フレームの保存先フォルダー（ピクチャ\XTimelineViewer）を開く（#299）。
+        private void VideoFrameSaveOpenFolder_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                var dir = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.MyPictures),
+                    "XTimelineViewer");
+                Directory.CreateDirectory(dir);
+                Process.Start(new ProcessStartInfo { FileName = dir, UseShellExecute = true });
+            }
+            catch { /* フォルダーを開けなくても致命的ではない */ }
         }
     }
 }


### PR DESCRIPTION
## 概要

動画を全画面表示したとき、右上の ✕ の左に**カメラアイコンの保存ボタン**を置き、**今表示しているフレームを PNG として保存**する試験機能（#299）。

## 実現方式

- 全画面中の `<video>` を `canvas.drawImage` → `toDataURL('image/png')`。X は HLS/MSE 再生だが、**MSE 同一オリジン blob 由来のため canvas は汚染されず書き出せる**ことを実測で確認（ログイン済み Chrome、1280x720、実画素取得可）。
- base64 を `postMessage` で C# に渡して保存。保存結果は **ページ内トースト**で表示（全画面中は XAML ダイアログが WebView2 の裏に隠れる airspace 問題を回避）。

## 保存先・ファイル名

- `Pictures\XTimelineViewer\<handle>_<statusId>_<yyyyMMdd_HHmmss_fff>.png`
- 例: `daruyanagi_2076132613665034697_20260712_135533_412.png` → `x.com/daruyanagi/status/2076132613665034697` で**元ポストを辿れる**。
- handle/statusId は動画が属するツイート（`video.closest('[data-testid="tweet"]')` の permalink）から抽出。取得失敗時は `unknown`/`noid` にフォールバック。ミリ秒付きで同一秒の連続保存でも衝突しない。

## UI / 設定

- **試験機能トグル（既定 OFF）** を「設定 → 試験機能」に追加（`VideoFrameSaveEnabled`）。ON のときだけ全画面に保存ボタンを表示。
- 同カード内に **「保存先フォルダーを開く」** リンクを併設（`Pictures\XTimelineViewer` を Explorer で開く）。
- 全画面保存ボタンのアイコンはカメラに統一（設定カードの `` カメラと対応）。
- UI 文言は resw 化（日英、`MediaFrameSave_*` / `Settings_VideoFrameSave*`）。

## 既知の制限

- 焼けるのは「今再生中の画質」のフレーム。最高解像度は HLS 最上位レンディションの取得が必要（別途）。
- 引用/リポスト内動画などで、動画に紐づく status の取り違えが起こり得る（フォールバックあり）。実測では主要ケースで正しく取得。

## 動作確認

- 実機で全画面→保存→トースト→`Pictures\XTimelineViewer` に PNG 生成を確認（複数枚）。
- x64 Debug クリーンビルド 0 エラー / 0 警告、resw パリティ 163/163。

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)
