### PR TITLE
feat(#301): GIF はフレーム保存を無効化し、GIF(MP4) をダウンロードする

### DIFF
--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -120,8 +120,10 @@
   <data name="MediaFrameSave_Tooltip" xml:space="preserve"><value>Save frame</value></data>
   <data name="MediaFrameSave_Saved" xml:space="preserve"><value>Frame saved</value></data>
   <data name="MediaFrameSave_Failed" xml:space="preserve"><value>Couldn't save frame</value></data>
+  <data name="MediaFrameSave_GifTooltip" xml:space="preserve"><value>Save GIF</value></data>
+  <data name="MediaFrameSave_GifSaved" xml:space="preserve"><value>Saved GIF as MP4</value></data>
   <data name="Settings_VideoFrameSave" xml:space="preserve"><value>Save a video frame as an image</value></data>
-  <data name="Settings_VideoFrameSave_Description" xml:space="preserve"><value>Shows a save button at the top-right when a video is full-screen. Press it to save the currently shown frame as a PNG to Pictures\XTimelineViewer.</value></data>
+  <data name="Settings_VideoFrameSave_Description" xml:space="preserve"><value>Shows a save button at the top-right when a video is full-screen. Press it to save the currently shown frame as a PNG to Pictures\XTimelineViewer. For GIFs, downloads the GIF (MP4) file instead.</value></data>
   <data name="Settings_VideoFrameSave_OpenFolder" xml:space="preserve"><value>Open the save folder</value></data>
   <data name="Nav_Extensions" xml:space="preserve"><value>Extensions</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>Profiles</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -120,8 +120,10 @@
   <data name="MediaFrameSave_Tooltip" xml:space="preserve"><value>フレームを保存</value></data>
   <data name="MediaFrameSave_Saved" xml:space="preserve"><value>フレームを保存しました</value></data>
   <data name="MediaFrameSave_Failed" xml:space="preserve"><value>フレームを保存できませんでした</value></data>
+  <data name="MediaFrameSave_GifTooltip" xml:space="preserve"><value>GIF を保存</value></data>
+  <data name="MediaFrameSave_GifSaved" xml:space="preserve"><value>GIF を MP4 として保存しました</value></data>
   <data name="Settings_VideoFrameSave" xml:space="preserve"><value>動画のフレームを画像として保存する</value></data>
-  <data name="Settings_VideoFrameSave_Description" xml:space="preserve"><value>動画を全画面表示したとき、右上に保存ボタンを表示します。押すと今表示しているフレームを PNG 画像として「ピクチャ\XTimelineViewer」に保存します。</value></data>
+  <data name="Settings_VideoFrameSave_Description" xml:space="preserve"><value>動画を全画面表示したとき、右上に保存ボタンを表示します。押すと今表示しているフレームを PNG 画像として「ピクチャ\XTimelineViewer」に保存します。GIF の場合は代わりに GIF（MP4）ファイルをダウンロードします。</value></data>
   <data name="Settings_VideoFrameSave_OpenFolder" xml:space="preserve"><value>保存先フォルダーを開く</value></data>
   <data name="Nav_Extensions" xml:space="preserve"><value>拡張機能</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>プロファイル</value></data>

--- a/Views/MainWindow.Post.cs
+++ b/Views/MainWindow.Post.cs
@@ -538,6 +538,15 @@ namespace XTimelineViewer.Views
                 return;
             }
 
+            if (message.StartsWith("saveGif:"))  // #301: GIF(MP4) をダウンロード保存
+            {
+                // 形式: saveGif:<handle>|<status>|<url>（url は残り全部）
+                var parts = message["saveGif:".Length..].Split('|', 3);
+                if (parts.Length == 3)
+                    _ = DownloadGifAsync(senderWebView, parts[0], parts[1], parts[2]);
+                return;
+            }
+
             switch (message)
             {
                 case "focusNext": FocusAdjacentTimeline(senderWebView, +1); break;
@@ -594,6 +603,51 @@ namespace XTimelineViewer.Views
                 {
                     senderWebView.CoreWebView2?.PostWebMessageAsString(
                         savedName is null ? "frameError" : "frameSaved:" + savedName);
+                }
+                catch { }
+            });
+        }
+
+        private static readonly System.Net.Http.HttpClient _frameHttp = new();
+
+        // GIF（X では tweet_video の無音ループ MP4）を直 URL からダウンロードして保存する（#301・試験機能）。
+        // 安全のため twimg.com ホストのみ許可。ファイル名は動画フレームと同じ <handle>_<statusId>_<時刻>。
+        private async Task DownloadGifAsync(WebView2 senderWebView, string handle, string status, string url)
+        {
+            string? savedName = null;
+            try
+            {
+                if (Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
+                    (uri.Scheme == Uri.UriSchemeHttps) &&
+                    (uri.Host == "video.twimg.com" || uri.Host.EndsWith(".twimg.com")))
+                {
+                    var req = new System.Net.Http.HttpRequestMessage(System.Net.Http.HttpMethod.Get, uri);
+                    req.Headers.TryAddWithoutValidation("User-Agent", "Mozilla/5.0");
+                    using var resp = await _frameHttp.SendAsync(req);
+                    resp.EnsureSuccessStatusCode();
+                    var bytes = await resp.Content.ReadAsByteArrayAsync();
+
+                    var dir = Path.Combine(
+                        Environment.GetFolderPath(Environment.SpecialFolder.MyPictures),
+                        "XTimelineViewer");
+                    Directory.CreateDirectory(dir);
+                    var name = $"{SanitizeNamePart(handle, "unknown")}_{SanitizeNamePart(status, "noid")}"
+                             + $"_{DateTime.Now:yyyyMMdd_HHmmss_fff}.mp4";
+                    await File.WriteAllBytesAsync(Path.Combine(dir, name), bytes);
+                    savedName = name;
+                }
+            }
+            catch (Exception ex)
+            {
+                LogError("DownloadGif", ex);
+            }
+
+            DispatcherQueue.TryEnqueue(() =>
+            {
+                try
+                {
+                    senderWebView.CoreWebView2?.PostWebMessageAsString(
+                        savedName is null ? "frameError" : "gifSaved:" + savedName);
                 }
                 catch { }
             });

--- a/Views/MainWindow.WebView2.cs
+++ b/Views/MainWindow.WebView2.cs
@@ -296,6 +296,19 @@ namespace XTimelineViewer.Views
                         return true;
                     } catch (e) { return false; }
                 }
+                // X の「GIF」は無音ループ MP4。<video> の src が blob でなく tweet_video 直リンクなら GIF（#301）。
+                // GIF は別オリジン直リンクのため canvas が汚染されフレーム保存は失敗する → 代わりに mp4 を落とす。
+                function isGif(video) {
+                    var s = (video && (video.currentSrc || video.src)) || '';
+                    return s.indexOf('blob:') !== 0 && /tweet_video/.test(s);
+                }
+                function downloadGif(video) {
+                    var url = (video && (video.currentSrc || video.src)) || '';
+                    if (!/^https?:/.test(url)) { showToast((window._xtvFrameSaveL || {}).failed || 'Failed'); return; }
+                    var r = getTweetRef(video);
+                    // 形式: saveGif:<handle>|<status>|<url>（url は最後まで丸ごと。C# 側は Split 上限 3 で温存）
+                    window.chrome.webview.postMessage('saveGif:' + r.handle + '|' + r.status + '|' + url);
+                }
                 // C# 側の保存結果を受けてトーストを出す。
                 try {
                     window.chrome.webview.addEventListener('message', function (e) {
@@ -303,6 +316,7 @@ namespace XTimelineViewer.Views
                         if (typeof d !== 'string') return;
                         var L = window._xtvFrameSaveL || {};
                         if (d.indexOf('frameSaved:') === 0) showToast(L.saved || 'Saved');
+                        else if (d.indexOf('gifSaved:') === 0) showToast(L.gifSaved || 'Saved');
                         else if (d === 'frameError') showToast(L.failed || 'Failed');
                     });
                 } catch (x) {}
@@ -323,18 +337,23 @@ namespace XTimelineViewer.Views
                             }, true);
                             fsEl.appendChild(c);
                         }
-                        // 動画かつ試験機能 ON なら「フレーム保存」ボタンを ✕ の左に置く（#299）。
+                        // 動画かつ試験機能 ON なら ✕ の左にボタンを置く（#299/#301）。
+                        // 通常動画: カメラ＝フレーム保存。GIF: 汚染で保存できないため代わりに mp4 ダウンロード。
                         if (window._xtvFrameSaveEnabled && fsEl.querySelector('video') && !fsEl.querySelector(':scope > .xtv-fs-save')) {
                             var L = window._xtvFrameSaveL || {};
+                            var gif = isGif(fsEl.querySelector('video'));
+                            var CAMERA = '<svg viewBox="0 0 24 24" width="22" height="22" fill="#fff"><path d="M20 5h-3.17L15 3H9L7.17 5H4a2 2 0 00-2 2v12a2 2 0 002 2h16a2 2 0 002-2V7a2 2 0 00-2-2zm-8 13a5 5 0 110-10 5 5 0 010 10zm0-8a3 3 0 100 6 3 3 0 000-6z"></path></svg>';
+                            var DOWNLOAD = '<svg viewBox="0 0 24 24" width="22" height="22" fill="#fff"><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"></path></svg>';
                             var sv = document.createElement('button');
                             sv.className = 'xtv-fs-save';
                             sv.type = 'button';
-                            sv.title = L.tip || 'Save frame';
-                            sv.innerHTML = '<svg viewBox="0 0 24 24" width="22" height="22" fill="#fff"><path d="M20 5h-3.17L15 3H9L7.17 5H4a2 2 0 00-2 2v12a2 2 0 002 2h16a2 2 0 002-2V7a2 2 0 00-2-2zm-8 13a5 5 0 110-10 5 5 0 010 10zm0-8a3 3 0 100 6 3 3 0 000-6z"></path></svg>';
+                            sv.title = gif ? (L.gifTip || 'Save GIF') : (L.tip || 'Save frame');
+                            sv.innerHTML = gif ? DOWNLOAD : CAMERA;
                             sv.addEventListener('click', function (e) {
                                 e.preventDefault(); e.stopPropagation();
                                 var video = fsEl.querySelector('video');
-                                if (!captureFrame(video)) showToast((window._xtvFrameSaveL || {}).failed || 'Failed');
+                                if (gif) downloadGif(video);
+                                else if (!captureFrame(video)) showToast((window._xtvFrameSaveL || {}).failed || 'Failed');
                             }, true);
                             fsEl.appendChild(sv);
                         }
@@ -364,9 +383,11 @@ namespace XTimelineViewer.Views
         {
             var labels = System.Text.Json.JsonSerializer.Serialize(new
             {
-                tip    = R.Get("MediaFrameSave_Tooltip"),
-                saved  = R.Get("MediaFrameSave_Saved"),
-                failed = R.Get("MediaFrameSave_Failed"),
+                tip      = R.Get("MediaFrameSave_Tooltip"),
+                saved    = R.Get("MediaFrameSave_Saved"),
+                failed   = R.Get("MediaFrameSave_Failed"),
+                gifTip   = R.Get("MediaFrameSave_GifTooltip"),
+                gifSaved = R.Get("MediaFrameSave_GifSaved"),
             });
             return $"window._xtvMediaOverlayEnabled = {(_appSettings.MediaOverlayButtonEnabled ? "true" : "false")};"
                  + $"window._xtvFrameSaveEnabled = {(_appSettings.VideoFrameSaveEnabled ? "true" : "false")};"


### PR DESCRIPTION
## 概要

GIF 投稿でフレーム保存（#299）が失敗する問題への対応。GIF ではフレーム保存を無効化し、代わりに **GIF（実体は MP4）ファイルをダウンロード**する（試験機能 #299 の一部）。

## 原因（実 DOM で確認）

- 通常動画は MSE 再生で `<video>` の src は同一オリジン blob → canvas 汚染なし。
- **GIF は `<video src="https://video.twimg.com/tweet_video/….mp4">` の直リンク別オリジン**。canvas に描くと汚染され `toDataURL` が **SecurityError**（＝フレーム保存が失敗）。
- 一方で mp4 直 URL が `video.currentSrc` にそのまま入っているため、ファイルとしての取得は容易。

## 変更

- **GIF 判定**: `<video>` の `currentSrc` が blob でなく `tweet_video` を含む。
- **GIF の場合**: カメラ（フレーム保存）ボタンを出さず、ダウンロードアイコンの「GIF を保存」ボタンを全画面右上（✕ の左）に表示。
- **ダウンロード**: `video.currentSrc`（mp4 直リンク）を C# に渡し、`HttpClient` で取得（CORS 無関係）。安全のため **twimg.com ホストのみ許可**、UA 付き。保存先 `Pictures\XTimelineViewer\<handle>_<statusId>_<yyyyMMdd_HHmmss_fff>.mp4`。
- **トースト**: 「GIF を MP4 として保存しました」— 実体が MP4 であることを明示。
- UI 文言は resw 化（日英）。設定カードの説明も「GIF はファイルをダウンロード」に追記。
- 通常動画は従来どおりカメラ＝フレーム保存のまま。

## 既知の制限

- 保存は mp4（X の GIF は無音ループ MP4。真の .gif 変換は ffmpeg が必要につき対象外）。

## 動作確認

- 例の GIF ポストで、全画面 → ダウンロードボタン → `Pictures\XTimelineViewer` に .mp4 生成・再生可を確認。
- 通常動画は GIF 判定に誤爆せずカメラ＝フレーム保存のまま。
- x64 Debug クリーンビルド 0 エラー / 0 警告、resw パリティ 165/165。

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)
