### PR TITLE
feat(#304): メディアDL（画像/動画/GIF）とオーバーレイのボタン配置整理

### DIFF
--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -122,8 +122,12 @@
   <data name="MediaFrameSave_Failed" xml:space="preserve"><value>Couldn't save frame</value></data>
   <data name="MediaFrameSave_GifTooltip" xml:space="preserve"><value>Save GIF</value></data>
   <data name="MediaFrameSave_GifSaved" xml:space="preserve"><value>Saved GIF as MP4</value></data>
+  <data name="MediaFrameSave_DownloadTooltip" xml:space="preserve"><value>Download</value></data>
+  <data name="MediaFrameSave_ImgSaved" xml:space="preserve"><value>Image saved</value></data>
+  <data name="MediaFrameSave_VideoSaved" xml:space="preserve"><value>Video saved</value></data>
+  <data name="MediaFrameSave_VideoUnavailable" xml:space="preserve"><value>Couldn't get the video URL</value></data>
   <data name="Settings_VideoFrameSave" xml:space="preserve"><value>Save a video frame as an image</value></data>
-  <data name="Settings_VideoFrameSave_Description" xml:space="preserve"><value>Shows a save button at the top-right when a video is full-screen. Press it to save the currently shown frame as a PNG to Pictures\XTimelineViewer. For GIFs, downloads the GIF (MP4) file instead.</value></data>
+  <data name="Settings_VideoFrameSave_Description" xml:space="preserve"><value>Shows Download and Frame-capture buttons at the top-left when a video, image, or GIF is full-screen (X's close button stays top-right). Download saves video as MP4, image as JPG, GIF as MP4 to Pictures\XTimelineViewer. Frame capture (video only) saves the current frame as a PNG.</value></data>
   <data name="Settings_VideoFrameSave_OpenFolder" xml:space="preserve"><value>Open the save folder</value></data>
   <data name="Nav_Extensions" xml:space="preserve"><value>Extensions</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>Profiles</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -122,8 +122,12 @@
   <data name="MediaFrameSave_Failed" xml:space="preserve"><value>フレームを保存できませんでした</value></data>
   <data name="MediaFrameSave_GifTooltip" xml:space="preserve"><value>GIF を保存</value></data>
   <data name="MediaFrameSave_GifSaved" xml:space="preserve"><value>GIF を MP4 として保存しました</value></data>
+  <data name="MediaFrameSave_DownloadTooltip" xml:space="preserve"><value>ダウンロード</value></data>
+  <data name="MediaFrameSave_ImgSaved" xml:space="preserve"><value>画像を保存しました</value></data>
+  <data name="MediaFrameSave_VideoSaved" xml:space="preserve"><value>動画を保存しました</value></data>
+  <data name="MediaFrameSave_VideoUnavailable" xml:space="preserve"><value>動画の URL を取得できませんでした</value></data>
   <data name="Settings_VideoFrameSave" xml:space="preserve"><value>動画のフレームを画像として保存する</value></data>
-  <data name="Settings_VideoFrameSave_Description" xml:space="preserve"><value>動画を全画面表示したとき、右上に保存ボタンを表示します。押すと今表示しているフレームを PNG 画像として「ピクチャ\XTimelineViewer」に保存します。GIF の場合は代わりに GIF（MP4）ファイルをダウンロードします。</value></data>
+  <data name="Settings_VideoFrameSave_Description" xml:space="preserve"><value>動画・画像・GIF を全画面表示したとき、左上に［ダウンロード］と［フレームキャプチャー］ボタンを表示します（右上は X の閉じるボタン）。ダウンロードは動画=MP4・画像=JPG・GIF=MP4 として「ピクチャ\XTimelineViewer」に保存。フレームキャプチャー（動画のみ）は現在のフレームを PNG 保存します。</value></data>
   <data name="Settings_VideoFrameSave_OpenFolder" xml:space="preserve"><value>保存先フォルダーを開く</value></data>
   <data name="Nav_Extensions" xml:space="preserve"><value>拡張機能</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>プロファイル</value></data>

--- a/Views/MainWindow.Post.cs
+++ b/Views/MainWindow.Post.cs
@@ -3,9 +3,11 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Web.WebView2.Core;
 using Windows.UI;
@@ -543,7 +545,31 @@ namespace XTimelineViewer.Views
                 // 形式: saveGif:<handle>|<status>|<url>（url は残り全部）
                 var parts = message["saveGif:".Length..].Split('|', 3);
                 if (parts.Length == 3)
-                    _ = DownloadGifAsync(senderWebView, parts[0], parts[1], parts[2]);
+                    _ = DownloadMediaAsync(senderWebView, parts[0], parts[1], parts[2], "mp4", "gifSaved");
+                return;
+            }
+
+            if (message.StartsWith("saveImg:"))  // #304: 画像（高解像度）をダウンロード保存
+            {
+                var parts = message["saveImg:".Length..].Split('|', 3);
+                if (parts.Length == 3)
+                    _ = DownloadMediaAsync(senderWebView, parts[0], parts[1], parts[2], "jpg", "imgSaved");
+                return;
+            }
+
+            if (message.StartsWith("saveVideo:"))  // #304: 動画を progressive MP4 でダウンロード保存
+            {
+                // 形式: saveVideo:<handle>|<status>（URL は GraphQL 傍受で保持した辞書から引く）
+                var parts = message["saveVideo:".Length..].Split('|', 2);
+                if (parts.Length == 2)
+                {
+                    var handle = parts[0];
+                    var status = parts[1];
+                    if (_videoMp4ByStatus.TryGetValue(status, out var mp4Url))
+                        _ = DownloadMediaAsync(senderWebView, handle, status, mp4Url, "mp4", "videoSaved");
+                    else
+                        try { senderWebView.CoreWebView2?.PostWebMessageAsString("videoUnavailable"); } catch { }
+                }
                 return;
             }
 
@@ -610,9 +636,102 @@ namespace XTimelineViewer.Views
 
         private static readonly System.Net.Http.HttpClient _frameHttp = new();
 
-        // GIF（X では tweet_video の無音ループ MP4）を直 URL からダウンロードして保存する（#301・試験機能）。
-        // 安全のため twimg.com ホストのみ許可。ファイル名は動画フレームと同じ <handle>_<statusId>_<時刻>。
-        private async Task DownloadGifAsync(WebView2 senderWebView, string handle, string status, string url)
+        // 動画ダウンロード用（#304）: statusId → progressive MP4（最高ビットレート）直 URL。
+        // X の GraphQL レスポンスを傍受して populate する。ffmpeg を使わず音声込み mp4 を得るための要。
+        private readonly ConcurrentDictionary<string, string> _videoMp4ByStatus = new();
+
+        // GraphQL レスポンスから tweet の video_info.variants を拾い、statusId→最高画質 MP4 を辞書化する（#304）。
+        // WebResourceResponseReceived から呼ぶ。失敗しても無視（動画DL 側で「取得できません」に degrade）。
+        internal async Task CaptureVideoVariantsAsync(CoreWebView2WebResourceResponseReceivedEventArgs args)
+        {
+            try
+            {
+                using var raStream = await args.Response.GetContentAsync();
+                if (raStream is null) return;
+                byte[] bytes;
+                using (var netStream = raStream.AsStreamForRead())
+                using (var ms = new MemoryStream())
+                {
+                    await netStream.CopyToAsync(ms);
+                    bytes = ms.ToArray();
+                }
+                if (bytes.Length == 0) return;
+                var pairs = await Task.Run(() =>
+                {
+                    var list = new List<(string id, string url)>();
+                    try
+                    {
+                        using var doc = JsonDocument.Parse(bytes);
+                        CollectVideoVariants(doc.RootElement, list);
+                    }
+                    catch { /* JSON でない/スキーマ違い等は無視 */ }
+                    return list;
+                });
+                foreach (var (id, url) in pairs) _videoMp4ByStatus[id] = url;
+            }
+            catch (Exception ex)
+            {
+                LogError("CaptureVideoVariants", ex);
+            }
+        }
+
+        // rest_id + legacy を持つ tweet オブジェクトを再帰探索し、最高ビットレートの video/mp4 を集める。
+        private static void CollectVideoVariants(JsonElement el, List<(string, string)> outp)
+        {
+            switch (el.ValueKind)
+            {
+                case JsonValueKind.Object:
+                    if (el.TryGetProperty("rest_id", out var idEl) && idEl.ValueKind == JsonValueKind.String &&
+                        el.TryGetProperty("legacy", out var legacy) && legacy.ValueKind == JsonValueKind.Object)
+                    {
+                        var url = BestMp4FromLegacy(legacy);
+                        if (url is not null) outp.Add((idEl.GetString()!, url));
+                    }
+                    foreach (var p in el.EnumerateObject()) CollectVideoVariants(p.Value, outp);
+                    break;
+                case JsonValueKind.Array:
+                    foreach (var it in el.EnumerateArray()) CollectVideoVariants(it, outp);
+                    break;
+            }
+        }
+
+        private static string? BestMp4FromLegacy(JsonElement legacy)
+        {
+            JsonElement media = default;
+            bool has =
+                (legacy.TryGetProperty("extended_entities", out var ee) &&
+                 ee.TryGetProperty("media", out media) && media.ValueKind == JsonValueKind.Array) ||
+                (legacy.TryGetProperty("entities", out var en) &&
+                 en.TryGetProperty("media", out media) && media.ValueKind == JsonValueKind.Array);
+            if (!has) return null;
+
+            string? best = null;
+            long bestBr = -1;
+            foreach (var m in media.EnumerateArray())
+            {
+                if (!m.TryGetProperty("video_info", out var vi)) continue;
+                if (!vi.TryGetProperty("variants", out var vars) || vars.ValueKind != JsonValueKind.Array) continue;
+                foreach (var v in vars.EnumerateArray())
+                {
+                    if (v.TryGetProperty("content_type", out var ct) && ct.ValueKind == JsonValueKind.String &&
+                        ct.GetString() == "video/mp4" &&
+                        v.TryGetProperty("url", out var u) && u.ValueKind == JsonValueKind.String)
+                    {
+                        long br = 0;
+                        if (v.TryGetProperty("bitrate", out var b) && b.ValueKind == JsonValueKind.Number &&
+                            b.TryGetInt64(out var bv)) br = bv;
+                        if (br > bestBr) { bestBr = br; best = u.GetString(); }
+                    }
+                }
+            }
+            return best;
+        }
+
+        // twimg.com の直 URL からメディア（GIF/画像/動画）をダウンロードして保存する（#301/#304・試験機能）。
+        // 安全のため twimg.com ホストのみ許可。ファイル名は <handle>_<statusId>_<時刻>.<ext>。
+        // 成功時は okPrefix + ":" + ファイル名、失敗時は frameError を WebView へ返す。
+        private async Task DownloadMediaAsync(
+            WebView2 senderWebView, string handle, string status, string url, string ext, string okPrefix)
         {
             string? savedName = null;
             try
@@ -632,14 +751,14 @@ namespace XTimelineViewer.Views
                         "XTimelineViewer");
                     Directory.CreateDirectory(dir);
                     var name = $"{SanitizeNamePart(handle, "unknown")}_{SanitizeNamePart(status, "noid")}"
-                             + $"_{DateTime.Now:yyyyMMdd_HHmmss_fff}.mp4";
+                             + $"_{DateTime.Now:yyyyMMdd_HHmmss_fff}.{ext}";
                     await File.WriteAllBytesAsync(Path.Combine(dir, name), bytes);
                     savedName = name;
                 }
             }
             catch (Exception ex)
             {
-                LogError("DownloadGif", ex);
+                LogError($"DownloadMedia({okPrefix})", ex);
             }
 
             DispatcherQueue.TryEnqueue(() =>
@@ -647,7 +766,7 @@ namespace XTimelineViewer.Views
                 try
                 {
                     senderWebView.CoreWebView2?.PostWebMessageAsString(
-                        savedName is null ? "frameError" : "gifSaved:" + savedName);
+                        savedName is null ? "frameError" : okPrefix + ":" + savedName);
                 }
                 catch { }
             });

--- a/Views/MainWindow.WebView2.cs
+++ b/Views/MainWindow.WebView2.cs
@@ -147,7 +147,9 @@ namespace XTimelineViewer.Views
                         // ボタンの opacity が上書きされて消える事象があったため、opacity は !important で
                         // 固定し、z-index もほぼ最大に上げて被りにも耐える。暗い画像でも縁が分かるよう
                         // 薄い白リング＋影を添える。
-                        '.xtv-enlarge-btn{position:absolute!important;top:8px;right:8px;z-index:2147483000;width:34px;height:34px;' +
+                        // 左上に置く（#297）。狭いペインで画像の右側が見切れると right:8px 固定のボタンも
+                        // 画面外に出て見えなくなるため。左端は常に見えるので left:8px にする。
+                        '.xtv-enlarge-btn{position:absolute!important;top:8px;left:8px;z-index:2147483000;width:34px;height:34px;' +
                         'border:none;border-radius:6px;background:rgba(0,0,0,0.55);color:#fff;font-size:16px;' +
                         'cursor:pointer;display:flex!important;align-items:center;justify-content:center;opacity:.55!important;' +
                         'box-shadow:0 0 0 1px rgba(255,255,255,0.35),0 1px 3px rgba(0,0,0,0.5);transition:opacity .15s,background .15s;}' +

--- a/Views/MainWindow.WebView2.cs
+++ b/Views/MainWindow.WebView2.cs
@@ -158,10 +158,14 @@ namespace XTimelineViewer.Views
                         ':fullscreen .xtv-enlarge-btn{display:none!important;}' +
                         '.xtv-fs-close{position:fixed;top:16px;right:16px;z-index:2147483647;width:46px;height:46px;' +
                         'border:none;border-radius:8px;background:rgba(0,0,0,0.7);color:#fff;font-size:22px;cursor:pointer;}' +
-                        // 動画フレーム保存ボタン（#299）：全画面中に ✕ の左へ置く。
-                        '.xtv-fs-save{position:fixed;top:16px;right:72px;z-index:2147483647;width:46px;height:46px;' +
-                        'border:none;border-radius:8px;background:rgba(0,0,0,0.7);color:#fff;cursor:pointer;' +
+                        // 自作機能ボタンは左上に置く（#304）: ダウンロード(left:16) / フレームキャプチャー(left:72)。
+                        // X 固有の ✕ は右上のまま、という住み分けで迷いにくくする。カメラは動画のみ活性。
+                        '.xtv-fs-btn{position:fixed;top:16px;z-index:2147483647;width:46px;height:46px;border:none;' +
+                        'border-radius:8px;background:rgba(0,0,0,0.7);color:#fff;cursor:pointer;' +
                         'display:flex;align-items:center;justify-content:center;}' +
+                        '.xtv-fs-dl{left:16px;}' +
+                        '.xtv-fs-cam{left:72px;}' +
+                        '.xtv-fs-btn:disabled{opacity:.35;cursor:default;}' +
                         '.xtv-toast{position:fixed;left:50%;bottom:44px;transform:translateX(-50%);z-index:2147483647;' +
                         'background:rgba(0,0,0,0.85);color:#fff;padding:10px 16px;border-radius:8px;font-size:14px;' +
                         'max-width:80vw;text-align:center;pointer-events:none;}' +
@@ -231,23 +235,17 @@ namespace XTimelineViewer.Views
                         try { if (container.requestFullscreen) container.requestFullscreen(); } catch (x) {}
                         return;
                     }
+                    var hi = hiResUrl(srcImg.currentSrc || srcImg.src);
                     var viewer = document.createElement('div');
                     viewer.className = 'xtv-img-viewer';
+                    viewer._xtvRef = getTweetRef(container);  // ダウンロード時のファイル名用（#304）
+                    viewer._xtvImgUrl = hi;
                     var big = document.createElement('img');
-                    big.src = hiResUrl(srcImg.currentSrc || srcImg.src);
+                    big.src = hi;
                     viewer.appendChild(big);
-                    var c = document.createElement('button');
-                    c.className = 'xtv-fs-close';
-                    c.type = 'button';
-                    c.textContent = '✕';
-                    c.addEventListener('click', function (e) {
-                        e.preventDefault(); e.stopPropagation();
-                        try { if (document.fullscreenElement) document.exitFullscreen(); } catch (x) {}
-                    }, true);
-                    viewer.appendChild(c);
                     document.body.appendChild(viewer);
-                    // requestFullscreen は非同期。失敗した場合だけビューアを片付ける
-                    // （成功時の後始末は fullscreenchange 側で行う）。
+                    // ✕・左上ボタンは fullscreenchange 側で付ける（動画/GIF と共通化）。
+                    // requestFullscreen は非同期。失敗した場合だけビューアを片付ける。
                     try {
                         var p = viewer.requestFullscreen && viewer.requestFullscreen();
                         if (p && p.catch) p.catch(function () { viewer.remove(); });
@@ -311,6 +309,59 @@ namespace XTimelineViewer.Views
                     // 形式: saveGif:<handle>|<status>|<url>（url は最後まで丸ごと。C# 側は Split 上限 3 で温存）
                     window.chrome.webview.postMessage('saveGif:' + r.handle + '|' + r.status + '|' + url);
                 }
+                // 画像ダウンロード（#304）。DL は全て C# 側で実行（JS fetch は CORS 不可）。
+                function sendSaveImg(ref, url) {
+                    if (!url) { showToast((window._xtvFrameSaveL || {}).failed || 'Failed'); return; }
+                    window.chrome.webview.postMessage('saveImg:' + (ref.handle || '') + '|' + (ref.status || '') + '|' + url);
+                }
+                // 動画ダウンロード（#304）。progressive MP4 の直 URL は C# が GraphQL 傍受で保持。statusId で引く。
+                function sendVideoDownload(video) {
+                    var r = getTweetRef(video);
+                    window.chrome.webview.postMessage('saveVideo:' + r.handle + '|' + r.status);
+                }
+
+                // ── オーバーレイのボタン生成（#304）──
+                var XTV_CAMERA = '<svg viewBox="0 0 24 24" width="22" height="22" fill="#fff"><path d="M20 5h-3.17L15 3H9L7.17 5H4a2 2 0 00-2 2v12a2 2 0 002 2h16a2 2 0 002-2V7a2 2 0 00-2-2zm-8 13a5 5 0 110-10 5 5 0 010 10zm0-8a3 3 0 100 6 3 3 0 000-6z"></path></svg>';
+                var XTV_DOWNLOAD = '<svg viewBox="0 0 24 24" width="22" height="22" fill="#fff"><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"></path></svg>';
+                function mkBtn(cls, svg, title) {
+                    var b = document.createElement('button');
+                    b.className = cls; b.type = 'button'; b.title = title || ''; b.innerHTML = svg;
+                    return b;
+                }
+                function addCloseButton(host) {  // X 固有の閉じる（✕）は右上
+                    if (host.querySelector(':scope > .xtv-fs-close')) return;
+                    var c = document.createElement('button');
+                    c.className = 'xtv-fs-close'; c.type = 'button'; c.textContent = '✕';
+                    c.addEventListener('click', function (e) {
+                        e.preventDefault(); e.stopPropagation();
+                        try { if (document.exitFullscreen) document.exitFullscreen(); } catch (x) {}
+                    }, true);
+                    host.appendChild(c);
+                }
+                // 左上に［ダウンロード］［フレームキャプチャー］を付ける（#304）。
+                // ダウンロードは全 kind で活性。カメラは kind==='video' のみ活性（画像/GIF は不活性）。
+                function addLeftControls(host, kind, opts) {
+                    if (host.querySelector(':scope > .xtv-fs-dl')) return;
+                    var L = window._xtvFrameSaveL || {};
+                    var dl = mkBtn('xtv-fs-btn xtv-fs-dl', XTV_DOWNLOAD, L.dlTip || 'Download');
+                    dl.addEventListener('click', function (e) {
+                        e.preventDefault(); e.stopPropagation();
+                        if (kind === 'image') sendSaveImg(opts.ref || {}, opts.imgUrl);
+                        else if (kind === 'gif') downloadGif(opts.video);
+                        else sendVideoDownload(opts.video);
+                    }, true);
+                    host.appendChild(dl);
+                    var cam = mkBtn('xtv-fs-btn xtv-fs-cam', XTV_CAMERA, L.tip || 'Save frame');
+                    if (kind !== 'video') {
+                        cam.disabled = true;
+                    } else {
+                        cam.addEventListener('click', function (e) {
+                            e.preventDefault(); e.stopPropagation();
+                            if (!captureFrame(opts.video)) showToast(L.failed || 'Failed');
+                        }, true);
+                    }
+                    host.appendChild(cam);
+                }
                 // C# 側の保存結果を受けてトーストを出す。
                 try {
                     window.chrome.webview.addEventListener('message', function (e) {
@@ -319,51 +370,32 @@ namespace XTimelineViewer.Views
                         var L = window._xtvFrameSaveL || {};
                         if (d.indexOf('frameSaved:') === 0) showToast(L.saved || 'Saved');
                         else if (d.indexOf('gifSaved:') === 0) showToast(L.gifSaved || 'Saved');
+                        else if (d.indexOf('imgSaved:') === 0) showToast(L.imgSaved || 'Saved');
+                        else if (d.indexOf('videoSaved:') === 0) showToast(L.videoSaved || 'Saved');
+                        else if (d === 'videoUnavailable') showToast(L.videoUnavailable || 'Failed');
                         else if (d === 'frameError') showToast(L.failed || 'Failed');
                     });
                 } catch (x) {}
 
-                // 全画面中は「✕」ボタンを全画面要素に重ねる（Esc でも解除できる）。
-                // 画像ビューア（.xtv-img-viewer）は自前で ✕ を内包するのでここでは付けない。
+                // 全画面時にオーバーレイ操作を付ける（画像ビューア・動画・GIF 共通）。
+                //   ✕（右上・常時） / 試験機能 ON のとき 左上に［DL］［カメラ］（#304）。
                 function onFsChange() {
                     var fsEl = document.fullscreenElement;
-                    if (fsEl && !fsEl.classList.contains('xtv-img-viewer')) {
-                        if (!fsEl.querySelector(':scope > .xtv-fs-close')) {
-                            var c = document.createElement('button');
-                            c.className = 'xtv-fs-close';
-                            c.type = 'button';
-                            c.textContent = '✕';
-                            c.addEventListener('click', function (e) {
-                                e.preventDefault(); e.stopPropagation();
-                                try { if (document.exitFullscreen) document.exitFullscreen(); } catch (x) {}
-                            }, true);
-                            fsEl.appendChild(c);
-                        }
-                        // 動画かつ試験機能 ON なら ✕ の左にボタンを置く（#299/#301）。
-                        // 通常動画: カメラ＝フレーム保存。GIF: 汚染で保存できないため代わりに mp4 ダウンロード。
-                        if (window._xtvFrameSaveEnabled && fsEl.querySelector('video') && !fsEl.querySelector(':scope > .xtv-fs-save')) {
-                            var L = window._xtvFrameSaveL || {};
-                            var gif = isGif(fsEl.querySelector('video'));
-                            var CAMERA = '<svg viewBox="0 0 24 24" width="22" height="22" fill="#fff"><path d="M20 5h-3.17L15 3H9L7.17 5H4a2 2 0 00-2 2v12a2 2 0 002 2h16a2 2 0 002-2V7a2 2 0 00-2-2zm-8 13a5 5 0 110-10 5 5 0 010 10zm0-8a3 3 0 100 6 3 3 0 000-6z"></path></svg>';
-                            var DOWNLOAD = '<svg viewBox="0 0 24 24" width="22" height="22" fill="#fff"><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"></path></svg>';
-                            var sv = document.createElement('button');
-                            sv.className = 'xtv-fs-save';
-                            sv.type = 'button';
-                            sv.title = gif ? (L.gifTip || 'Save GIF') : (L.tip || 'Save frame');
-                            sv.innerHTML = gif ? DOWNLOAD : CAMERA;
-                            sv.addEventListener('click', function (e) {
-                                e.preventDefault(); e.stopPropagation();
+                    if (fsEl) {
+                        addCloseButton(fsEl);  // X 固有の閉じるは右上・常時
+                        if (window._xtvFrameSaveEnabled) {
+                            if (fsEl.classList.contains('xtv-img-viewer')) {
+                                addLeftControls(fsEl, 'image', { ref: fsEl._xtvRef, imgUrl: fsEl._xtvImgUrl });
+                            } else {
                                 var video = fsEl.querySelector('video');
-                                if (gif) downloadGif(video);
-                                else if (!captureFrame(video)) showToast((window._xtvFrameSaveL || {}).failed || 'Failed');
-                            }, true);
-                            fsEl.appendChild(sv);
+                                if (video) addLeftControls(fsEl, isGif(video) ? 'gif' : 'video', { video: video });
+                            }
                         }
-                    } else if (!fsEl) {
-                        // 全画面終了: 画像ビューアと、動画コンテナに付けた ✕・保存ボタン・トーストを後始末する。
+                    } else {
+                        // 全画面終了: 画像ビューアと、付けた ✕・左上ボタン・トーストを後始末する。
                         var v = document.querySelector('.xtv-img-viewer');
                         if (v) v.remove();
-                        document.querySelectorAll('.xtv-fs-close, .xtv-fs-save, .xtv-toast')
+                        document.querySelectorAll('.xtv-fs-close, .xtv-fs-btn, .xtv-toast')
                                .forEach(function (x) { x.remove(); });
                     }
                 }
@@ -385,11 +417,15 @@ namespace XTimelineViewer.Views
         {
             var labels = System.Text.Json.JsonSerializer.Serialize(new
             {
-                tip      = R.Get("MediaFrameSave_Tooltip"),
-                saved    = R.Get("MediaFrameSave_Saved"),
-                failed   = R.Get("MediaFrameSave_Failed"),
-                gifTip   = R.Get("MediaFrameSave_GifTooltip"),
-                gifSaved = R.Get("MediaFrameSave_GifSaved"),
+                tip              = R.Get("MediaFrameSave_Tooltip"),
+                saved            = R.Get("MediaFrameSave_Saved"),
+                failed           = R.Get("MediaFrameSave_Failed"),
+                gifTip           = R.Get("MediaFrameSave_GifTooltip"),
+                gifSaved         = R.Get("MediaFrameSave_GifSaved"),
+                dlTip            = R.Get("MediaFrameSave_DownloadTooltip"),
+                imgSaved         = R.Get("MediaFrameSave_ImgSaved"),
+                videoSaved       = R.Get("MediaFrameSave_VideoSaved"),
+                videoUnavailable = R.Get("MediaFrameSave_VideoUnavailable"),
             });
             return $"window._xtvMediaOverlayEnabled = {(_appSettings.MediaOverlayButtonEnabled ? "true" : "false")};"
                  + $"window._xtvFrameSaveEnabled = {(_appSettings.VideoFrameSaveEnabled ? "true" : "false")};"
@@ -835,6 +871,16 @@ namespace XTimelineViewer.Views
                     else if (_enlargedPane == pane)
                         RestorePaneSize();
                 };
+
+                // 動画DL 用（#304・試験機能）：GraphQL レスポンスを傍受し、progressive MP4 の直 URL を
+                // statusId 毎に保持する。JS からの直 fetch は CORS 不可のため、ここで拾って DL 時に使う。
+                webView.CoreWebView2.WebResourceResponseReceived += (s, args) =>
+                {
+                    if (!_appSettings.VideoFrameSaveEnabled) return;
+                    if (args.Request.Uri.IndexOf("/graphql/", StringComparison.OrdinalIgnoreCase) < 0) return;
+                    _ = CaptureVideoVariantsAsync(args);
+                };
+
                 await LoadExtensionsAsync(webView);
                 ApplyThemeToWebViews();
             }


### PR DESCRIPTION
## 概要

全画面オーバーレイのボタンを住み分け整理し、メディアのダウンロードを画像・動画・GIF で揃えた（試験機能）。

## ボタン配置（迷いにくさ重視）

- **X 固有の閉じる（✕）＝右上**（従来どおり）
- **自作機能＝左上**：［ダウンロード］（`left:16`）＋［フレームキャプチャー／カメラ］（`left:72`）
- **カメラは動画のみ活性**。GIF・画像では不活性（グレー）表示。
- 画像ビューア・動画・GIF いずれも `fullscreenchange` 側でボタンを付ける形に共通化。

## ダウンロード

すべて **C# の HttpClient**（JS の直 fetch は CORS 不可を実測）、**twimg.com ホストのみ許可**、保存先 `Pictures\XTimelineViewer\<handle>_<statusId>_<yyyyMMdd_HHmmss_fff>.<ext>`。

- **画像** → `.jpg`（`name=orig` の高解像度）
- **GIF** → `.mp4`（`tweet_video` 直リンク、#301 の仕組みを流用）
- **動画** → `.mp4`（progressive・音声込み・最高ビットレート）

### 動画DL の方式

X の通常動画は HLS で**音声/映像が demux**（`pl/avc1/…` と `pl/mp4a/…` が別）。連結だけでは音声付き mp4 にならず mux（ffmpeg）が必要になる。→ **ffmpeg を避け、X の GraphQL レスポンスを傍受**（`WebResourceResponseReceived`、`/graphql/` のみ）して `video_info.variants` の **progressive MP4 直 URL（最高ビットレート）** を `rest_id`(=statusId) 毎に辞書化。DL 時に statusId で引いてそのままダウンロードする。取得できない場合はトーストで通知（graceful degrade）。

- 傍受・パースは試験機能 ON 時のみ。パースは別スレッド（`Task.Run` + `JsonDocument`）で UI を止めない。
- `DownloadGifAsync` を汎用 `DownloadMediaAsync(handle, status, url, ext, okPrefix)` に整理。

## 既知の制限・リスク

- 動画DL は X の GraphQL スキーマ依存でスキーマ変更に弱い（`rest_id`+`legacy.extended_entities.media[].video_info.variants` を辿る）。
- 引用ツイート内の動画は statusId が外側ツイートを指すため取得できないことがある（degrade）。
- 画質は variants の最上位（progressive）。

## 動作確認

- 画像/GIF/動画の全画面で、左上 DL＋（動画のみ活性）カメラ／右上 ✕ を確認。
- 画像=JPG、GIF=MP4、動画=MP4（音声込み）で `Pictures\XTimelineViewer` に保存を確認。
- x64 Debug クリーンビルド 0 エラー / 0 警告、resw パリティ 169/169。

Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)
