### PR TITLE
fix(#297): タイムラインの拡大ボタンを左上へ移動（右端見切れ対策）

### DIFF
--- a/Views/MainWindow.WebView2.cs
+++ b/Views/MainWindow.WebView2.cs
@@ -147,7 +147,9 @@ namespace XTimelineViewer.Views
                         // ボタンの opacity が上書きされて消える事象があったため、opacity は !important で
                         // 固定し、z-index もほぼ最大に上げて被りにも耐える。暗い画像でも縁が分かるよう
                         // 薄い白リング＋影を添える。
-                        '.xtv-enlarge-btn{position:absolute!important;top:8px;right:8px;z-index:2147483000;width:34px;height:34px;' +
+                        // 左上に置く（#297）。狭いペインで画像の右側が見切れると right:8px 固定のボタンも
+                        // 画面外に出て見えなくなるため。左端は常に見えるので left:8px にする。
+                        '.xtv-enlarge-btn{position:absolute!important;top:8px;left:8px;z-index:2147483000;width:34px;height:34px;' +
                         'border:none;border-radius:6px;background:rgba(0,0,0,0.55);color:#fff;font-size:16px;' +
                         'cursor:pointer;display:flex!important;align-items:center;justify-content:center;opacity:.55!important;' +
                         'box-shadow:0 0 0 1px rgba(255,255,255,0.35),0 1px 3px rgba(0,0,0,0.5);transition:opacity .15s,background .15s;}' +


### PR DESCRIPTION
## 概要

タイムライン上のメディア拡大ボタン `.xtv-enlarge-btn` を **`right:8px` → `left:8px`（左上）** へ移動する（#297）。

## 背景

狭いペインで画像の右側が見切れると、右端固定（`right:8px`）のボタンも一緒に画面外へ出て見えなくなることがあった（実機で再現）。左端は常に見えるため、`left:8px` にすることで確実に表示される。バックスペースで戻ると表示されたのは、再描画のタイミングで一瞬右端が収まっていたためと考えられる。

## 方針

- X のメディア要素（DOM/CSS）には**一切手を入れず**、自前オーバーレイの位置のみ変更。X が時々メディアをペイン幅より広く描画する挙動は X 側の問題であり、こちらで無理にレイアウトを矯正する脆いホットフィックスは避ける。
- 全画面の ✕・保存/DL ボタン（ビューポート固定）には影響なし。

## 確認

- 右側が見切れる画像でも左上にボタンが出ることを確認。通常画像・複数画像でも左上表示。
- しばらくドッグフーディングして左上でも隠れるケースが無いことを確認済み。

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)