### PR TITLE
feat(#308): 動画は Videos へ保存、DL 進捗トースト＋フォルダーを開くリンク

### DIFF
--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -126,8 +126,10 @@
   <data name="MediaFrameSave_ImgSaved" xml:space="preserve"><value>Image saved</value></data>
   <data name="MediaFrameSave_VideoSaved" xml:space="preserve"><value>Video saved</value></data>
   <data name="MediaFrameSave_VideoUnavailable" xml:space="preserve"><value>Couldn't get the video URL</value></data>
+  <data name="MediaFrameSave_OpenFolder" xml:space="preserve"><value>Open folder</value></data>
+  <data name="MediaFrameSave_Downloading" xml:space="preserve"><value>Downloading…</value></data>
   <data name="Settings_VideoFrameSave" xml:space="preserve"><value>Save a video frame as an image</value></data>
-  <data name="Settings_VideoFrameSave_Description" xml:space="preserve"><value>Shows Download and Frame-capture buttons at the top-left when a video, image, or GIF is full-screen (X's close button stays top-right). Download saves video as MP4, image as JPG, GIF as MP4 to Pictures\XTimelineViewer. Frame capture (video only) saves the current frame as a PNG.</value></data>
+  <data name="Settings_VideoFrameSave_Description" xml:space="preserve"><value>Shows Download and Frame-capture buttons at the top-left when a video, image, or GIF is full-screen (X's close button stays top-right). Download saves video and GIF as MP4 to Videos\XTimelineViewer, and images as JPG to Pictures\XTimelineViewer (the post-save toast has a link to open the folder). Frame capture (video only) saves the current frame as a PNG to Pictures\XTimelineViewer.</value></data>
   <data name="Settings_VideoFrameSave_OpenFolder" xml:space="preserve"><value>Open the save folder</value></data>
   <data name="Nav_Extensions" xml:space="preserve"><value>Extensions</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>Profiles</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -126,8 +126,10 @@
   <data name="MediaFrameSave_ImgSaved" xml:space="preserve"><value>画像を保存しました</value></data>
   <data name="MediaFrameSave_VideoSaved" xml:space="preserve"><value>動画を保存しました</value></data>
   <data name="MediaFrameSave_VideoUnavailable" xml:space="preserve"><value>動画の URL を取得できませんでした</value></data>
+  <data name="MediaFrameSave_OpenFolder" xml:space="preserve"><value>フォルダーを開く</value></data>
+  <data name="MediaFrameSave_Downloading" xml:space="preserve"><value>ダウンロード中…</value></data>
   <data name="Settings_VideoFrameSave" xml:space="preserve"><value>動画のフレームを画像として保存する</value></data>
-  <data name="Settings_VideoFrameSave_Description" xml:space="preserve"><value>動画・画像・GIF を全画面表示したとき、左上に［ダウンロード］と［フレームキャプチャー］ボタンを表示します（右上は X の閉じるボタン）。ダウンロードは動画=MP4・画像=JPG・GIF=MP4 として「ピクチャ\XTimelineViewer」に保存。フレームキャプチャー（動画のみ）は現在のフレームを PNG 保存します。</value></data>
+  <data name="Settings_VideoFrameSave_Description" xml:space="preserve"><value>動画・画像・GIF を全画面表示したとき、左上に［ダウンロード］と［フレームキャプチャー］ボタンを表示します（右上は X の閉じるボタン）。ダウンロードは動画・GIF を「ビデオ\XTimelineViewer」に MP4、画像を「ピクチャ\XTimelineViewer」に JPG として保存します（保存後のトーストからフォルダーを開けます）。フレームキャプチャー（動画のみ）は現在のフレームを PNG で「ピクチャ\XTimelineViewer」に保存します。</value></data>
   <data name="Settings_VideoFrameSave_OpenFolder" xml:space="preserve"><value>保存先フォルダーを開く</value></data>
   <data name="Nav_Extensions" xml:space="preserve"><value>拡張機能</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>プロファイル</value></data>

--- a/Views/MainWindow.Post.cs
+++ b/Views/MainWindow.Post.cs
@@ -573,6 +573,18 @@ namespace XTimelineViewer.Views
                 return;
             }
 
+            if (message.StartsWith("openFolder:"))  // #308: トーストの「フォルダーを開く」リンク
+            {
+                var dir = MediaDir(isVideo: message["openFolder:".Length..] == "videos");
+                try
+                {
+                    Directory.CreateDirectory(dir);
+                    Process.Start(new ProcessStartInfo { FileName = dir, UseShellExecute = true });
+                }
+                catch (Exception ex) { LogError("openFolder", ex); }
+                return;
+            }
+
             switch (message)
             {
                 case "focusNext": FocusAdjacentTimeline(senderWebView, +1); break;
@@ -606,9 +618,7 @@ namespace XTimelineViewer.Views
             try
             {
                 var bytes = Convert.FromBase64String(base64Png);
-                var dir = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.MyPictures),
-                    "XTimelineViewer");
+                var dir = MediaDir(isVideo: false);  // フレームは PNG 画像 → Pictures
                 Directory.CreateDirectory(dir);
                 // 保存時刻はミリ秒まで付けて同一秒内の連続保存でも衝突しないようにする。
                 var name = $"{SanitizeNamePart(handle, "unknown")}_{SanitizeNamePart(status, "noid")}"
@@ -727,9 +737,16 @@ namespace XTimelineViewer.Views
             return best;
         }
 
+        // WebView へメッセージを返す（UI スレッドで PostWebMessageAsString）。トースト/進捗の通知用。
+        private void PostToWebView(WebView2 webView, string message)
+            => DispatcherQueue.TryEnqueue(() =>
+            {
+                try { webView.CoreWebView2?.PostWebMessageAsString(message); } catch { }
+            });
+
         // twimg.com の直 URL からメディア（GIF/画像/動画）をダウンロードして保存する（#301/#304・試験機能）。
         // 安全のため twimg.com ホストのみ許可。ファイル名は <handle>_<statusId>_<時刻>.<ext>。
-        // 成功時は okPrefix + ":" + ファイル名、失敗時は frameError を WebView へ返す。
+        // ストリーム読みしながら進捗（dlProgress:<pct>）を返し、完了時に okPrefix、失敗時に frameError を返す（#308）。
         private async Task DownloadMediaAsync(
             WebView2 senderWebView, string handle, string status, string url, string ext, string okPrefix)
         {
@@ -742,17 +759,41 @@ namespace XTimelineViewer.Views
                 {
                     var req = new System.Net.Http.HttpRequestMessage(System.Net.Http.HttpMethod.Get, uri);
                     req.Headers.TryAddWithoutValidation("User-Agent", "Mozilla/5.0");
-                    using var resp = await _frameHttp.SendAsync(req);
+                    using var resp = await _frameHttp
+                        .SendAsync(req, System.Net.Http.HttpCompletionOption.ResponseHeadersRead)
+                        .ConfigureAwait(false);
                     resp.EnsureSuccessStatusCode();
-                    var bytes = await resp.Content.ReadAsByteArrayAsync();
 
-                    var dir = Path.Combine(
-                        Environment.GetFolderPath(Environment.SpecialFolder.MyPictures),
-                        "XTimelineViewer");
+                    var total = resp.Content.Headers.ContentLength;
+                    byte[] bytes;
+                    using (var src = await resp.Content.ReadAsStreamAsync().ConfigureAwait(false))
+                    using (var buf = new MemoryStream())
+                    {
+                        var chunk = new byte[81920];
+                        long readTotal = 0;
+                        int lastPct = -1, n;
+                        while ((n = await src.ReadAsync(chunk).ConfigureAwait(false)) > 0)
+                        {
+                            buf.Write(chunk, 0, n);
+                            readTotal += n;
+                            if (total is long tot && tot > 0)
+                            {
+                                int pct = (int)(readTotal * 100 / tot);
+                                if (pct >= lastPct + 2 || pct == 100)  // 2% 刻みでスロットル
+                                {
+                                    lastPct = pct;
+                                    PostToWebView(senderWebView, "dlProgress:" + pct);
+                                }
+                            }
+                        }
+                        bytes = buf.ToArray();
+                    }
+
+                    var dir = MediaDir(isVideo: ext == "mp4");  // 動画/GIF(mp4)→Videos, 画像(jpg)→Pictures
                     Directory.CreateDirectory(dir);
                     var name = $"{SanitizeNamePart(handle, "unknown")}_{SanitizeNamePart(status, "noid")}"
                              + $"_{DateTime.Now:yyyyMMdd_HHmmss_fff}.{ext}";
-                    await File.WriteAllBytesAsync(Path.Combine(dir, name), bytes);
+                    await File.WriteAllBytesAsync(Path.Combine(dir, name), bytes).ConfigureAwait(false);
                     savedName = name;
                 }
             }
@@ -761,15 +802,14 @@ namespace XTimelineViewer.Views
                 LogError($"DownloadMedia({okPrefix})", ex);
             }
 
-            DispatcherQueue.TryEnqueue(() =>
-            {
-                try
-                {
-                    senderWebView.CoreWebView2?.PostWebMessageAsString(
-                        savedName is null ? "frameError" : okPrefix + ":" + savedName);
-                }
-                catch { }
-            });
+            PostToWebView(senderWebView, savedName is null ? "frameError" : okPrefix + ":" + savedName);
+        }
+
+        // メディア保存先（#308）: 動画/GIF(mp4)は Videos\XTimelineViewer、画像/フレームは Pictures\XTimelineViewer。
+        private static string MediaDir(bool isVideo)
+        {
+            var special = isVideo ? Environment.SpecialFolder.MyVideos : Environment.SpecialFolder.MyPictures;
+            return Path.Combine(Environment.GetFolderPath(special), "XTimelineViewer");
         }
 
         // ファイル名の一部（handle / statusId）を安全化する。空ならフォールバックを返す。

--- a/Views/MainWindow.WebView2.cs
+++ b/Views/MainWindow.WebView2.cs
@@ -169,6 +169,7 @@ namespace XTimelineViewer.Views
                         '.xtv-toast{position:fixed;left:50%;bottom:44px;transform:translateX(-50%);z-index:2147483647;' +
                         'background:rgba(0,0,0,0.85);color:#fff;padding:10px 16px;border-radius:8px;font-size:14px;' +
                         'max-width:80vw;text-align:center;pointer-events:none;}' +
+                        '.xtv-toast a{color:#8ec7ff;margin-left:12px;text-decoration:underline;cursor:pointer;pointer-events:auto;}' +
                         '.xtv-img-viewer{position:fixed;inset:0;width:100%;height:100%;background:#000;' +
                         'display:flex;align-items:center;justify-content:center;overflow:hidden;}' +
                         '.xtv-img-viewer img{max-width:100%;max-height:100%;width:auto;height:auto;object-fit:contain;}';
@@ -255,14 +256,38 @@ namespace XTimelineViewer.Views
                 // ── 動画フレーム保存（#299）──
                 // 全画面中の <video> の現在フレームを canvas に焼き、base64 PNG を C# に送って保存する。
                 // 全画面中は全画面要素の子孫しか描画されないため、トーストは全画面要素側へ挿入する。
-                function showToast(msg) {
+                // folder（'pictures'|'videos'）を渡すと「フォルダーを開く」リンクを付ける（#308）。
+                function showToast(msg, folder) {
                     var host = document.fullscreenElement || document.body;
                     if (!host) return;
                     var t = document.createElement('div');
                     t.className = 'xtv-toast';
                     t.textContent = msg;
+                    if (folder) {
+                        var a = document.createElement('a');
+                        a.className = 'xtv-toast-link';
+                        a.href = '#';
+                        a.textContent = (window._xtvFrameSaveL || {}).openFolder || 'Open folder';
+                        a.addEventListener('click', function (e) {
+                            e.preventDefault(); e.stopPropagation();
+                            try { window.chrome.webview.postMessage('openFolder:' + folder); } catch (x) {}
+                        }, true);
+                        t.appendChild(a);
+                    }
                     host.appendChild(t);
-                    setTimeout(function () { t.remove(); }, 2200);
+                    setTimeout(function () { t.remove(); }, folder ? 5000 : 2200);  // リンク付きは長めに
+                }
+                // ダウンロード進捗トースト（#308）。自動では消さず、結果受信時に hideProgress で消す。
+                function showProgress(text) {
+                    var host = document.fullscreenElement || document.body;
+                    if (!host) return;
+                    var t = document.querySelector('.xtv-progress');
+                    if (!t) { t = document.createElement('div'); t.className = 'xtv-toast xtv-progress'; host.appendChild(t); }
+                    else if (t.parentNode !== host) { host.appendChild(t); }  // 全画面切替に追従
+                    t.textContent = text;
+                }
+                function hideProgress() {
+                    document.querySelectorAll('.xtv-progress').forEach(function (x) { x.remove(); });
                 }
                 // 動画が属するツイートの handle / status ID を求める（ファイル名でソースを辿れるように）。
                 // 全画面中でも article は DOM に残るので closest で辿れる。取得失敗時は空を返す。
@@ -299,17 +324,20 @@ namespace XTimelineViewer.Views
                     var url = (video && (video.currentSrc || video.src)) || '';
                     if (!/^https?:/.test(url)) { showToast((window._xtvFrameSaveL || {}).failed || 'Failed'); return; }
                     var r = getTweetRef(video);
+                    showProgress((window._xtvFrameSaveL || {}).downloading || 'Downloading…');
                     // 形式: saveGif:<handle>|<status>|<url>（url は最後まで丸ごと。C# 側は Split 上限 3 で温存）
                     window.chrome.webview.postMessage('saveGif:' + r.handle + '|' + r.status + '|' + url);
                 }
                 // 画像ダウンロード（#304）。DL は全て C# 側で実行（JS fetch は CORS 不可）。
                 function sendSaveImg(ref, url) {
                     if (!url) { showToast((window._xtvFrameSaveL || {}).failed || 'Failed'); return; }
+                    showProgress((window._xtvFrameSaveL || {}).downloading || 'Downloading…');
                     window.chrome.webview.postMessage('saveImg:' + (ref.handle || '') + '|' + (ref.status || '') + '|' + url);
                 }
                 // 動画ダウンロード（#304）。progressive MP4 の直 URL は C# が GraphQL 傍受で保持。statusId で引く。
                 function sendVideoDownload(video) {
                     var r = getTweetRef(video);
+                    showProgress((window._xtvFrameSaveL || {}).downloading || 'Downloading…');
                     window.chrome.webview.postMessage('saveVideo:' + r.handle + '|' + r.status);
                 }
 
@@ -361,10 +389,12 @@ namespace XTimelineViewer.Views
                         var d = e.data;
                         if (typeof d !== 'string') return;
                         var L = window._xtvFrameSaveL || {};
-                        if (d.indexOf('frameSaved:') === 0) showToast(L.saved || 'Saved');
-                        else if (d.indexOf('gifSaved:') === 0) showToast(L.gifSaved || 'Saved');
-                        else if (d.indexOf('imgSaved:') === 0) showToast(L.imgSaved || 'Saved');
-                        else if (d.indexOf('videoSaved:') === 0) showToast(L.videoSaved || 'Saved');
+                        if (d.indexOf('dlProgress:') === 0) { showProgress((L.downloading || 'Downloading…') + ' ' + d.slice(11) + '%'); return; }
+                        hideProgress();
+                        if (d.indexOf('frameSaved:') === 0) showToast(L.saved || 'Saved', 'pictures');
+                        else if (d.indexOf('gifSaved:') === 0) showToast(L.gifSaved || 'Saved', 'videos');
+                        else if (d.indexOf('imgSaved:') === 0) showToast(L.imgSaved || 'Saved', 'pictures');
+                        else if (d.indexOf('videoSaved:') === 0) showToast(L.videoSaved || 'Saved', 'videos');
                         else if (d === 'videoUnavailable') showToast(L.videoUnavailable || 'Failed');
                         else if (d === 'frameError') showToast(L.failed || 'Failed');
                     });
@@ -419,6 +449,8 @@ namespace XTimelineViewer.Views
                 imgSaved         = R.Get("MediaFrameSave_ImgSaved"),
                 videoSaved       = R.Get("MediaFrameSave_VideoSaved"),
                 videoUnavailable = R.Get("MediaFrameSave_VideoUnavailable"),
+                openFolder       = R.Get("MediaFrameSave_OpenFolder"),
+                downloading      = R.Get("MediaFrameSave_Downloading"),
             });
             return $"window._xtvMediaOverlayEnabled = {(_appSettings.MediaOverlayButtonEnabled ? "true" : "false")};"
                  + $"window._xtvFrameSaveEnabled = {(_appSettings.VideoFrameSaveEnabled ? "true" : "false")};"


### PR DESCRIPTION
## 概要

ダウンロード（保存）の使い勝手を改善する（試験機能）。

1. **保存先を種類で振り分け**：動画・GIF（`.mp4`）→ `Videos\XTimelineViewer`、画像（`.jpg`）・フレームキャプチャー（`.png`）→ `Pictures\XTimelineViewer`（従来どおり）。
2. **保存完了トーストに「フォルダーを開く」リンク**：クリックで種類に応じたフォルダー（pictures/videos）を Explorer で開く。全画面中でもリンクだけ `pointer-events:auto` で押せる。
3. **ダウンロード中の通知＋進捗**：押下時に「ダウンロード中…」トーストを表示し、無反応感を解消。進捗％も表示。

## 変更点

- `MediaDir(bool isVideo)` で保存先を切替（`MyVideos` / `MyPictures`）。`DownloadMediaAsync` は `ext == "mp4"` で Videos、フレーム保存(PNG)は Pictures。
- トースト: `showToast(msg, folder)` に「フォルダーを開く」リンクを追加。リンククリックで `openFolder:<pictures|videos>` を C# へ送り、対応フォルダーを開く。
- 進捗: DL ボタン押下で `showProgress("ダウンロード中…")`。`DownloadMediaAsync` は `HttpCompletionOption.ResponseHeadersRead` + ストリーム読みで `Content-Length` があれば 2% 刻みに `dlProgress:<pct>` を返し、JS が「ダウンロード中… NN%」と更新。完了/失敗で `hideProgress()` → 結果トースト。読み取りは `ConfigureAwait(false)` でワーカースレッド実行し UI を止めない。
- 文言は resw 化（`MediaFrameSave_OpenFolder` / `MediaFrameSave_Downloading`、日英）。設定説明も保存先の振り分けを反映。

## 補足

- 設定カードの「保存先フォルダーを開く」ボタンは従来どおり Pictures（画像/フレーム）を開く。動画は各トーストのリンクから開く住み分け。
- `Content-Length` が無い応答では％なしの「ダウンロード中…」のまま完了（無反応にはならない）。

## 動作確認

- 動画DL：押下で「ダウンロード中… NN%」→「動画を保存しました｜フォルダーを開く」→ リンクで `Videos\XTimelineViewer`（.mp4）。
- 画像DL：`Pictures\XTimelineViewer`（.jpg）、GIF：`Videos`（.mp4）、フレーム：`Pictures`（.png）。
- x64 Debug ビルド 0 エラー / 0 警告、resw パリティ 171/171。

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)
