### PR TITLE
chore(#310): 動画DL に一時診断ログを追加（試験機能の観測用）

### DIFF
--- a/Views/MainWindow.Post.cs
+++ b/Views/MainWindow.Post.cs
@@ -565,8 +565,10 @@ namespace XTimelineViewer.Views
                 {
                     var handle = parts[0];
                     var status = parts[1];
-                    if (_videoMp4ByStatus.TryGetValue(status, out var mp4Url))
-                        _ = DownloadMediaAsync(senderWebView, handle, status, mp4Url, "mp4", "videoSaved");
+                    var hit = _videoMp4ByStatus.TryGetValue(status, out var mp4Url);
+                    LogDebug($"saveVideo status={status} handle={handle} hit={hit} mapTotal={_videoMp4ByStatus.Count}");
+                    if (hit)
+                        _ = DownloadMediaAsync(senderWebView, handle, status, mp4Url!, "mp4", "videoSaved");
                     else
                         try { senderWebView.CoreWebView2?.PostWebMessageAsString("videoUnavailable"); } catch { }
                 }
@@ -654,10 +656,15 @@ namespace XTimelineViewer.Views
         // WebResourceResponseReceived から呼ぶ。失敗しても無視（動画DL 側で「取得できません」に degrade）。
         internal async Task CaptureVideoVariantsAsync(CoreWebView2WebResourceResponseReceivedEventArgs args)
         {
+            // 一時診断（動画DL 調査）: 操作名を URL 末尾から抜く。
+            var uri = args.Request.Uri;
+            var op = uri;
+            var q = op.IndexOf('?'); if (q >= 0) op = op[..q];
+            var slash = op.LastIndexOf('/'); if (slash >= 0) op = op[(slash + 1)..];
             try
             {
                 using var raStream = await args.Response.GetContentAsync();
-                if (raStream is null) return;
+                if (raStream is null) { LogDebug($"gql {op} status={args.Response.StatusCode} content=NULL"); return; }
                 byte[] bytes;
                 using (var netStream = raStream.AsStreamForRead())
                 using (var ms = new MemoryStream())
@@ -665,7 +672,7 @@ namespace XTimelineViewer.Views
                     await netStream.CopyToAsync(ms);
                     bytes = ms.ToArray();
                 }
-                if (bytes.Length == 0) return;
+                if (bytes.Length == 0) { LogDebug($"gql {op} status={args.Response.StatusCode} content=EMPTY"); return; }
                 var pairs = await Task.Run(() =>
                 {
                     var list = new List<(string id, string url)>();
@@ -678,9 +685,28 @@ namespace XTimelineViewer.Views
                     return list;
                 });
                 foreach (var (id, url) in pairs) _videoMp4ByStatus[id] = url;
+                // 診断: 応答に video_info / mp4変種 が含まれるか（パーサ漏れか、そもそも含まれないかの判別）。
+                bool hasVI = false, hasMp4 = false; string snip = "";
+                try
+                {
+                    var text = System.Text.Encoding.UTF8.GetString(bytes);
+                    hasVI = text.Contains("video_info");
+                    hasMp4 = text.Contains("video/mp4");
+                    if (hasVI && pairs.Count == 0)
+                    {
+                        var idx = text.IndexOf("video_info", StringComparison.Ordinal);
+                        var from = Math.Max(0, idx - 40);
+                        snip = text.Substring(from, Math.Min(320, text.Length - from)).Replace("\n", " ").Replace("\r", "");
+                    }
+                }
+                catch { }
+                LogDebug($"gql {op} bytes={bytes.Length} hasVI={hasVI} hasMp4={hasMp4} videos={pairs.Count} mapTotal={_videoMp4ByStatus.Count}"
+                       + (pairs.Count > 0 ? " ids=" + string.Join(",", pairs.Select(p => p.id).Take(5)) : "")
+                       + (snip != "" ? " SNIP=" + snip : ""));
             }
             catch (Exception ex)
             {
+                LogDebug($"gql {op} EXCEPTION {ex.GetType().Name}: {ex.Message}");
                 LogError("CaptureVideoVariants", ex);
             }
         }

--- a/Views/MainWindow.WebView2.cs
+++ b/Views/MainWindow.WebView2.cs
@@ -783,6 +783,17 @@ namespace XTimelineViewer.Views
             catch { /* ログ書き込み失敗は無視 */ }
         }
 
+        // 一時診断用（動画DL の GraphQL 傍受調査）。1 行だけ error.log に追記する。
+        private static void LogDebug(string msg)
+        {
+            try
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(LogFilePath)!);
+                File.AppendAllText(LogFilePath, $"[{DateTime.Now:HH:mm:ss}] DBG {msg}\n");
+            }
+            catch { }
+        }
+
         /// <summary>
         /// 現在アクティブなアカウントの X スクリーンネームをセッションからライブ取得する。
         /// 左ナビの「プロフィール」リンク（AppTabBar_Profile_Link）は委任アカウント切り替え後も


### PR DESCRIPTION
動画DL の「URL を取得できませんでした」調査用に、error.log へ診断ログを出す（#310）。試験機能の間の観測用に残す。

## 追加ログ
- `LogDebug(msg)`: error.log へ 1 行追記。
- `CaptureVideoVariantsAsync`: GraphQL 応答ごとに 操作名 / bytes / hasVI(video_info有無) / hasMp4(video/mp4有無) / videos(拾えた数) / mapTotal を記録。`content=NULL` / `EMPTY` / `COMException` も記録。`hasVI かつ videos=0` の場合は video_info 周辺のスニペットも出す。
- `saveVideo`: 要求 statusId が辞書に有るか（hit）と mapTotal を記録。

## 調査結果（このログで判明）
- パーサ・アプローチは正しい（大きいタイムライン応答は mp4 変種を含み拾えている: videos=8/15 等、`hasVI=True かつ videos=0` は皆無）。
- 失敗は**タイミング/取りこぼし**が主因: 早期 DL（辞書が育つ前）・`GetContentAsync` の COMException/空。
- 対策候補（GetContentAsync リトライ / JS フック傍受 / 詳細を開くワークアラウンド）は #310 に記録。

試験機能を卒業したら削除する（#310 でトラッキング、本 PR では close しない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)