### PR TITLE
feat(#312): 試験機能カードの名称更新＋保存先の inline リンク化

### DIFF
--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -128,9 +128,12 @@
   <data name="MediaFrameSave_VideoUnavailable" xml:space="preserve"><value>Couldn't get the video URL</value></data>
   <data name="MediaFrameSave_OpenFolder" xml:space="preserve"><value>Open folder</value></data>
   <data name="MediaFrameSave_Downloading" xml:space="preserve"><value>Downloading…</value></data>
-  <data name="Settings_VideoFrameSave" xml:space="preserve"><value>Save a video frame as an image</value></data>
-  <data name="Settings_VideoFrameSave_Description" xml:space="preserve"><value>Shows Download and Frame-capture buttons at the top-left when a video, image, or GIF is full-screen (X's close button stays top-right). Download saves video and GIF as MP4 to Videos\XTimelineViewer, and images as JPG to Pictures\XTimelineViewer (the post-save toast has a link to open the folder). Frame capture (video only) saves the current frame as a PNG to Pictures\XTimelineViewer.</value></data>
-  <data name="Settings_VideoFrameSave_OpenFolder" xml:space="preserve"><value>Open the save folder</value></data>
+  <data name="Settings_VideoFrameSave" xml:space="preserve"><value>Save images, GIFs, and videos as files</value></data>
+  <data name="Settings_VideoFrameSave_Desc1" xml:space="preserve"><value>A Download button appears at the top-left when media is full-screen. Images are saved to: </value></data>
+  <data name="Settings_VideoFrameSave_Desc2" xml:space="preserve"><value>GIFs and videos are saved to: </value></data>
+  <data name="Settings_VideoFrameSave_Desc3" xml:space="preserve"><value>For videos, Frame capture also saves the current frame (PNG / Pictures).</value></data>
+  <data name="Settings_VideoFrameSave_PicturesFolder" xml:space="preserve"><value>Pictures\XTimelineViewer</value></data>
+  <data name="Settings_VideoFrameSave_VideosFolder" xml:space="preserve"><value>Videos\XTimelineViewer</value></data>
   <data name="Nav_Extensions" xml:space="preserve"><value>Extensions</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>Profiles</value></data>
   <data name="Nav_Data" xml:space="preserve"><value>User Data</value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -128,9 +128,12 @@
   <data name="MediaFrameSave_VideoUnavailable" xml:space="preserve"><value>動画の URL を取得できませんでした</value></data>
   <data name="MediaFrameSave_OpenFolder" xml:space="preserve"><value>フォルダーを開く</value></data>
   <data name="MediaFrameSave_Downloading" xml:space="preserve"><value>ダウンロード中…</value></data>
-  <data name="Settings_VideoFrameSave" xml:space="preserve"><value>動画のフレームを画像として保存する</value></data>
-  <data name="Settings_VideoFrameSave_Description" xml:space="preserve"><value>動画・画像・GIF を全画面表示したとき、左上に［ダウンロード］と［フレームキャプチャー］ボタンを表示します（右上は X の閉じるボタン）。ダウンロードは動画・GIF を「ビデオ\XTimelineViewer」に MP4、画像を「ピクチャ\XTimelineViewer」に JPG として保存します（保存後のトーストからフォルダーを開けます）。フレームキャプチャー（動画のみ）は現在のフレームを PNG で「ピクチャ\XTimelineViewer」に保存します。</value></data>
-  <data name="Settings_VideoFrameSave_OpenFolder" xml:space="preserve"><value>保存先フォルダーを開く</value></data>
+  <data name="Settings_VideoFrameSave" xml:space="preserve"><value>画像・GIF・動画をファイル保存する</value></data>
+  <data name="Settings_VideoFrameSave_Desc1" xml:space="preserve"><value>メディアを全画面表示すると左上に［ダウンロード］が出ます。画像の保存先: </value></data>
+  <data name="Settings_VideoFrameSave_Desc2" xml:space="preserve"><value>GIF・動画の保存先: </value></data>
+  <data name="Settings_VideoFrameSave_Desc3" xml:space="preserve"><value>動画は［フレームキャプチャー］で現在のフレームも保存できます（PNG／ピクチャ）。</value></data>
+  <data name="Settings_VideoFrameSave_PicturesFolder" xml:space="preserve"><value>ピクチャ\XTimelineViewer</value></data>
+  <data name="Settings_VideoFrameSave_VideosFolder" xml:space="preserve"><value>ビデオ\XTimelineViewer</value></data>
   <data name="Nav_Extensions" xml:space="preserve"><value>拡張機能</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>プロファイル</value></data>
   <data name="Nav_Data" xml:space="preserve"><value>ユーザーデータ管理</value></data>

--- a/Views/Settings/ExperimentalPage.xaml
+++ b/Views/Settings/ExperimentalPage.xaml
@@ -62,17 +62,13 @@
                               IsOn="{x:Bind VM.MediaOverlayButtonEnabled, Mode=TwoWay}"/>
             </controls:SettingsCard>
 
-            <!-- 動画の現在フレームを画像保存（#299）-->
+            <!-- 画像・GIF・動画をファイル保存（#299/#304/#308）。説明文に保存先フォルダーの inline リンク（#312）-->
             <controls:SettingsCard x:Name="VideoFrameSaveCard">
                 <controls:SettingsCard.HeaderIcon>
                     <FontIcon Glyph="&#xE722;" FontFamily="Segoe Fluent Icons"/>
                 </controls:SettingsCard.HeaderIcon>
-                <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                    <HyperlinkButton x:Name="VideoFrameSaveOpenFolder"
-                                     Click="VideoFrameSaveOpenFolder_Click"/>
-                    <ToggleSwitch x:Name="VideoFrameSaveToggle"
-                                  IsOn="{x:Bind VM.VideoFrameSaveEnabled, Mode=TwoWay}"/>
-                </StackPanel>
+                <ToggleSwitch x:Name="VideoFrameSaveToggle"
+                              IsOn="{x:Bind VM.VideoFrameSaveEnabled, Mode=TwoWay}"/>
             </controls:SettingsCard>
         </StackPanel>
     </ScrollViewer>

--- a/Views/Settings/ExperimentalPage.xaml.cs
+++ b/Views/Settings/ExperimentalPage.xaml.cs
@@ -1,5 +1,7 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Documents;
+using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 using System;
 using System.ComponentModel;
@@ -77,10 +79,9 @@ namespace XTimelineViewer.Views.Settings
             MediaOverlayButtonToggle.OnContent  = R.Get("Toggle_On");
             MediaOverlayButtonToggle.OffContent = R.Get("Toggle_Off");
 
-            // 動画の現在フレームを画像保存（#299）
+            // 画像・GIF・動画をファイル保存（#299/#304/#308）。説明文は保存先フォルダーへの inline リンク付き（#312）
             VideoFrameSaveCard.Header      = R.Get("Settings_VideoFrameSave");
-            VideoFrameSaveCard.Description = R.Get("Settings_VideoFrameSave_Description");
-            VideoFrameSaveOpenFolder.Content = R.Get("Settings_VideoFrameSave_OpenFolder");
+            VideoFrameSaveCard.Description = BuildVideoFrameSaveDescription();
             VideoFrameSaveToggle.OnContent  = R.Get("Toggle_On");
             VideoFrameSaveToggle.OffContent = R.Get("Toggle_Off");
 
@@ -88,14 +89,44 @@ namespace XTimelineViewer.Views.Settings
             Bindings.Update();
         }
 
-        // 動画フレームの保存先フォルダー（ピクチャ\XTimelineViewer）を開く（#299）。
-        private void VideoFrameSaveOpenFolder_Click(object sender, RoutedEventArgs e)
+        // 保存先フォルダーへの inline リンクを含む説明文を組み立てる（#312）。
+        // 3 行構成で、リンク（フォルダー名）は各行末に置き i18n の語順問題を軽減する。
+        //   1) 画像の保存先 → ピクチャ\XTimelineViewer（リンク）
+        //   2) GIF・動画の保存先 → ビデオ\XTimelineViewer（リンク）
+        //   3) 動画はフレームキャプチャーで現在フレームも保存可
+        private TextBlock BuildVideoFrameSaveDescription()
+        {
+            var tb = new TextBlock
+            {
+                TextWrapping = TextWrapping.Wrap,
+                Style        = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+                Foreground   = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+            };
+            tb.Inlines.Add(new Run { Text = R.Get("Settings_VideoFrameSave_Desc1") });
+            tb.Inlines.Add(MakeFolderLink(R.Get("Settings_VideoFrameSave_PicturesFolder"), isVideo: false));
+            tb.Inlines.Add(new LineBreak());
+            tb.Inlines.Add(new Run { Text = R.Get("Settings_VideoFrameSave_Desc2") });
+            tb.Inlines.Add(MakeFolderLink(R.Get("Settings_VideoFrameSave_VideosFolder"), isVideo: true));
+            tb.Inlines.Add(new LineBreak());
+            tb.Inlines.Add(new Run { Text = R.Get("Settings_VideoFrameSave_Desc3") });
+            return tb;
+        }
+
+        private static Hyperlink MakeFolderLink(string text, bool isVideo)
+        {
+            var link = new Hyperlink();
+            link.Inlines.Add(new Run { Text = text });
+            link.Click += (_, _) => OpenMediaFolder(isVideo);
+            return link;
+        }
+
+        // 保存先フォルダー（動画/GIF=ビデオ、画像/フレーム=ピクチャ）を Explorer で開く（#312）。
+        private static void OpenMediaFolder(bool isVideo)
         {
             try
             {
-                var dir = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.MyPictures),
-                    "XTimelineViewer");
+                var special = isVideo ? Environment.SpecialFolder.MyVideos : Environment.SpecialFolder.MyPictures;
+                var dir = Path.Combine(Environment.GetFolderPath(special), "XTimelineViewer");
                 Directory.CreateDirectory(dir);
                 Process.Start(new ProcessStartInfo { FileName = dir, UseShellExecute = true });
             }


### PR DESCRIPTION
## 概要

#304 / #308 で機能が「フレーム保存」から「画像・GIF・動画のダウンロード＋フレームキャプチャー」へ広がったのに、試験機能カードの名称・説明が古く・長かった。イシューのコメント案に沿って整理した。

## 変更

- **名称変更**: 「動画のフレームを画像として保存する」→ **「画像・GIF・動画をファイル保存する」**（表示名のみ。トグルの設定キー `VideoFrameSaveEnabled` は互換のため据え置き）。
- **「保存先フォルダーを開く」ボタンを削除**。
- **説明文を 3 行に簡潔化し、保存先フォルダーを inline リンク化**:
  1. 画像の保存先 → **`ピクチャ\XTimelineViewer`**（クリックで開く）
  2. GIF・動画の保存先 → **`ビデオ\XTimelineViewer`**（クリックで開く）
  3. 動画は［フレームキャプチャー］で現在のフレームも保存できる旨
- リンク（フォルダー名）は**各行末**に配置し、i18n の語順問題を軽減（イシューのコメント案どおり）。
- 実装: `SettingsCard.Description` に `TextBlock` + `Hyperlink` を設定（`CaptionTextBlockStyle` / `TextFillColorSecondaryBrush` で説明文らしく描画）。クリックで `MyPictures` / `MyVideos` 配下の `XTimelineViewer` を Explorer で開く。
- 文言は resw 化（日英）。旧 `Settings_VideoFrameSave_Description` / `_OpenFolder` を削除、`_Desc1`..`_Desc3` / `_PicturesFolder` / `_VideosFolder` を追加。

## 動作確認

- 設定→試験機能で新名称・3 行説明・フォルダー名リンクを確認。リンクで各フォルダーが開く。
- 単独ボタンが消えていること、日英とも崩れないことを確認。
- x64 Debug ビルド 0 エラー / 0 警告、resw パリティ 174/174。

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)
