### PR TITLE
feat(#310): 動画DL 失敗トーストに回避策リンクを追加

### DIFF
--- a/Strings/en-US/Resources.resw
+++ b/Strings/en-US/Resources.resw
@@ -128,6 +128,7 @@
   <data name="MediaFrameSave_VideoUnavailable" xml:space="preserve"><value>Couldn't get the video URL</value></data>
   <data name="MediaFrameSave_OpenFolder" xml:space="preserve"><value>Open folder</value></data>
   <data name="MediaFrameSave_Downloading" xml:space="preserve"><value>Downloading…</value></data>
+  <data name="MediaFrameSave_HelpLink" xml:space="preserve"><value>How to fix this</value></data>
   <data name="Settings_VideoFrameSave" xml:space="preserve"><value>Save images, GIFs, and videos as files</value></data>
   <data name="Settings_VideoFrameSave_Desc1" xml:space="preserve"><value>A Download button appears at the top-left when media is full-screen. Images are saved to: </value></data>
   <data name="Settings_VideoFrameSave_Desc2" xml:space="preserve"><value>GIFs and videos are saved to: </value></data>

--- a/Strings/ja-JP/Resources.resw
+++ b/Strings/ja-JP/Resources.resw
@@ -128,6 +128,7 @@
   <data name="MediaFrameSave_VideoUnavailable" xml:space="preserve"><value>動画の URL を取得できませんでした</value></data>
   <data name="MediaFrameSave_OpenFolder" xml:space="preserve"><value>フォルダーを開く</value></data>
   <data name="MediaFrameSave_Downloading" xml:space="preserve"><value>ダウンロード中…</value></data>
+  <data name="MediaFrameSave_HelpLink" xml:space="preserve"><value>対処法を見る</value></data>
   <data name="Settings_VideoFrameSave" xml:space="preserve"><value>画像・GIF・動画をファイル保存する</value></data>
   <data name="Settings_VideoFrameSave_Desc1" xml:space="preserve"><value>メディアを全画面表示すると左上に［ダウンロード］が出ます。画像の保存先: </value></data>
   <data name="Settings_VideoFrameSave_Desc2" xml:space="preserve"><value>GIF・動画の保存先: </value></data>

--- a/Views/MainWindow.Post.cs
+++ b/Views/MainWindow.Post.cs
@@ -587,6 +587,12 @@ namespace XTimelineViewer.Views
                 return;
             }
 
+            if (message == "openHelp")  // #310: 動画DL 失敗トーストの「対処法を見る」リンク
+            {
+                _ = LaunchUriByEdgeProfileAsync(new Uri("https://daruyanagi.jp/posts/2026/07/16/"));
+                return;
+            }
+
             switch (message)
             {
                 case "focusNext": FocusAdjacentTimeline(senderWebView, +1); break;

--- a/Views/MainWindow.WebView2.cs
+++ b/Views/MainWindow.WebView2.cs
@@ -257,25 +257,30 @@ namespace XTimelineViewer.Views
                 // 全画面中の <video> の現在フレームを canvas に焼き、base64 PNG を C# に送って保存する。
                 // 全画面中は全画面要素の子孫しか描画されないため、トーストは全画面要素側へ挿入する。
                 // folder（'pictures'|'videos'）を渡すと「フォルダーを開く」リンクを付ける（#308）。
-                function showToast(msg, folder) {
+                // link={label, message} を渡すとリンクを付ける（クリックで postMessage(message)）。
+                function showToast(msg, link) {
                     var host = document.fullscreenElement || document.body;
                     if (!host) return;
                     var t = document.createElement('div');
                     t.className = 'xtv-toast';
                     t.textContent = msg;
-                    if (folder) {
+                    if (link && link.label && link.message) {
                         var a = document.createElement('a');
                         a.className = 'xtv-toast-link';
                         a.href = '#';
-                        a.textContent = (window._xtvFrameSaveL || {}).openFolder || 'Open folder';
+                        a.textContent = link.label;
                         a.addEventListener('click', function (e) {
                             e.preventDefault(); e.stopPropagation();
-                            try { window.chrome.webview.postMessage('openFolder:' + folder); } catch (x) {}
+                            try { window.chrome.webview.postMessage(link.message); } catch (x) {}
                         }, true);
                         t.appendChild(a);
                     }
                     host.appendChild(t);
-                    setTimeout(function () { t.remove(); }, folder ? 5000 : 2200);  // リンク付きは長めに
+                    setTimeout(function () { t.remove(); }, link ? 5000 : 2200);  // リンク付きは長めに
+                }
+                // 「フォルダーを開く」リンク付きトースト（#308）
+                function toastFolder(msg, folder) {
+                    showToast(msg, { label: (window._xtvFrameSaveL || {}).openFolder || 'Open folder', message: 'openFolder:' + folder });
                 }
                 // ダウンロード進捗トースト（#308）。自動では消さず、結果受信時に hideProgress で消す。
                 function showProgress(text) {
@@ -391,11 +396,12 @@ namespace XTimelineViewer.Views
                         var L = window._xtvFrameSaveL || {};
                         if (d.indexOf('dlProgress:') === 0) { showProgress((L.downloading || 'Downloading…') + ' ' + d.slice(11) + '%'); return; }
                         hideProgress();
-                        if (d.indexOf('frameSaved:') === 0) showToast(L.saved || 'Saved', 'pictures');
-                        else if (d.indexOf('gifSaved:') === 0) showToast(L.gifSaved || 'Saved', 'videos');
-                        else if (d.indexOf('imgSaved:') === 0) showToast(L.imgSaved || 'Saved', 'pictures');
-                        else if (d.indexOf('videoSaved:') === 0) showToast(L.videoSaved || 'Saved', 'videos');
-                        else if (d === 'videoUnavailable') showToast(L.videoUnavailable || 'Failed');
+                        if (d.indexOf('frameSaved:') === 0) toastFolder(L.saved || 'Saved', 'pictures');
+                        else if (d.indexOf('gifSaved:') === 0) toastFolder(L.gifSaved || 'Saved', 'videos');
+                        else if (d.indexOf('imgSaved:') === 0) toastFolder(L.imgSaved || 'Saved', 'pictures');
+                        else if (d.indexOf('videoSaved:') === 0) toastFolder(L.videoSaved || 'Saved', 'videos');
+                        // 動画DL 失敗時は回避策（ブログ）へのリンクを付ける（#310 のワークアラウンド）
+                        else if (d === 'videoUnavailable') showToast(L.videoUnavailable || 'Failed', { label: L.help || 'How to fix', message: 'openHelp' });
                         else if (d === 'frameError') showToast(L.failed || 'Failed');
                     });
                 } catch (x) {}
@@ -451,6 +457,7 @@ namespace XTimelineViewer.Views
                 videoUnavailable = R.Get("MediaFrameSave_VideoUnavailable"),
                 openFolder       = R.Get("MediaFrameSave_OpenFolder"),
                 downloading      = R.Get("MediaFrameSave_Downloading"),
+                help             = R.Get("MediaFrameSave_HelpLink"),
             });
             return $"window._xtvMediaOverlayEnabled = {(_appSettings.MediaOverlayButtonEnabled ? "true" : "false")};"
                  + $"window._xtvFrameSaveEnabled = {(_appSettings.VideoFrameSaveEnabled ? "true" : "false")};"


### PR DESCRIPTION
## 概要

動画DL が「動画の URL を取得できませんでした」（`videoUnavailable`）で失敗するケースへの**運用回避**。#310 の方針どおり、複雑なホットフィックス（オンデマンド TweetDetail 取得等）は避け、失敗トーストから**回避策を案内するブログ記事**へ誘導する。

失敗要因（#310 で判明）: 一部の動画はタイムライン応答に mp4 変種が無く TweetDetail のみに来る／`GetContentAsync` の取りこぼし等。詳細を一度開けば捕捉されるため、その案内をリンクで提供する。

## 変更

- **`videoUnavailable` トーストに「対処法を見る」リンク**を付与。クリックで `openHelp` を postMessage し、C# が `LaunchUriByEdgeProfileAsync` でブログ記事（https://daruyanagi.jp/posts/2026/07/16/ ）を外部ブラウザーで開く。
- `showToast` を汎用リンク対応（`{label, message}`）にリファクタ。既存の「フォルダーを開く」は `toastFolder` ヘルパーに整理（挙動は不変・デグレなし）。
- 文言は resw 化（`MediaFrameSave_HelpLink` = 「対処法を見る」/「How to fix this」、日英）。

## 補足

- **#310 は close しない**: 診断ログ（LogDebug）の削除は試験機能卒業時に別途行うため、本 PR はワークアラウンド部分のみ。

## 動作確認

- 辞書未登録の動画をそのまま DL → 「動画の URL を取得できませんでした｜対処法を見る」トースト → リンクでブログが外部ブラウザーで開く。
- 保存成功時の「フォルダーを開く」リンクは従来どおり（デグレなし）。
- x64 Debug ビルド 0 エラー / 0 警告、resw パリティ 175/175。

Refs #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)